### PR TITLE
Fix exception due to unknown select() kwarg

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -562,11 +562,11 @@ class DataSet(object):
         time_selectors = ['dumps', 'timerange', 'scans', 'compscans', 'targets']
         freq_selectors = ['channels', 'freqrange']
         corrprod_selectors = ['corrprods', 'ants', 'inputs', 'pol']
-        # Check if keywords are valid
+        # Check if keywords are valid but don't raise exception if invalid as kwargs may arrive from strange places
         valid_kwargs = time_selectors + freq_selectors + corrprod_selectors + ['spw', 'subarray', 'reset']
         if set(kwargs.keys()) - set(valid_kwargs):
-            raise TypeError("select() got unexpected keyword argument(s) %s, valid ones are %s" %
-                            (list(set(kwargs.keys()) - set(valid_kwargs)), valid_kwargs))
+            logger.warning("select() got unexpected keyword argument(s) %s, valid ones are %s" %
+                           (list(set(kwargs.keys()) - set(valid_kwargs)), valid_kwargs))
         # If select() is called without arguments, reset all selections
         reset = 'TFB' if not kwargs else kwargs.pop('reset', 'auto')
         kwargs['spw'] = spw = kwargs.get('spw', self.spw)


### PR DESCRIPTION
If an unknown / invalid keyword argument is passed to select(), warn
the user instead of raising an exception, as these kwargs may originate
from places like scape and the pipeline where they are mixed with other
unrelated kwargs. The old behaviour currently causes scape to crash.
It is still useful to warn the new user unfamiliar with select().

Review: @mauch
