### PR TITLE
h5toms creation of MODEL_DATA and CORRECTED_DATA

### DIFF
--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -257,9 +257,9 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     scan_number : int or array of int, shape (num_vis_samples,), optional
         The scan index (compound scan index in the case of KAT-7)
     model_data : array of complex, shape (num_vis_samples, num_channels, num_pols)
-        Array containing complex visibility data in Janskys, initialised to unity
+        Array containing complex visibility data in Janskys
     corrected_data : array of complex, shape (num_vis_samples, num_channels, num_pols)
-        Array containing complex visibility data in Janskys, initialised to unity
+        Array containing complex visibility data in Janskys
 
     Returns
     -------

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -37,7 +37,7 @@ parser.add_option("-u", "--uvfits", action="store_true", default=False, help="Pr
 parser.add_option("-a", "--no-auto", action="store_true", default=False, help="MeasurementSet will exclude autocorrelation data")
 parser.add_option("-C", "--channel-range", help="Range of frequency channels to keep (zero-based inclusive 'first_chan,last_chan', default is all channels)")
 parser.add_option("-e", "--elevation-range", help="Flag elevations outside the range 'lowest_elevation,highest_elevation'")
-parser.add_option("-m", "--model-data", action="store_true", default=False, help="Add MODEL_DATA and CORRECTED_DATA columns to the MS. Initialised to unity amplitude zero phase.")
+parser.add_option("-m", "--model-data", action="store_true", default=False, help="Add MODEL_DATA and CORRECTED_DATA columns to the MS. MODEL_DATA initialised to unity amplitude zero phase, CORRECTED_DATA initialised to DATA.")
 parser.add_option("--flags", help="List of online flags to apply (from 'static,cam,detected_rfi,predicted_rfi', default is all flags, '' will apply no flags)")
 parser.add_option("--dumptime", type=float, default=0.0, help="Output time averaging interval in seconds, default is no averaging.")
 parser.add_option("--chanbin", type=int, default=0, help="Bin width for channel averaging in channels, default is no averaging.")


### PR DESCRIPTION
(laura) Edited h5toms.py and ms_extra.py to allow for optional creation of MODEL_DATA and CORRECTED_DATA columns when MS is created.

This behavior is controlled with a -m switch in h5toms. The default is not to create these data columns, as it increases the size of the file (there is effectively 3x more data). However, creation of these data columns with h5toms can be considerably faster than using clearcal in casa (especially for large files), so the option is made available.
