### PR TITLE
Make attenuation sensors categorical

### DIFF
--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -22,8 +22,12 @@ SENSOR_PROPS.update({
     '*activity': {'greedy_values': ('slew', 'stop'), 'initial_value': 'slew',
                    'transform': lambda act: SIMPLIFY_STATE.get(act, 'stop')},
     '*target': {'initial_value': '', 'transform': _robust_target},
+    # These float sensors are actually categorical by nature as they represent user settings
     'RFE/center-frequency-hz': {'categorical': True},
     'RFE/rfe7.lo1.frequency': {'categorical': True},
+    '*attenuation' : {'categorical': True},
+    '*attenuator.horizontal' : {'categorical': True},
+    '*attenuator.vertical' : {'categorical': True},
 })
 
 SENSOR_ALIASES = {


### PR DESCRIPTION
The various attenuation sensors have floating-point values but are
actually categorical as they represent user settings that stay put.
