### PR TITLE
Use print-like handler if logging is unconfigured

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -225,15 +225,16 @@ if _ip is not None:
     _ip.set_hook('complete_command', _sensor_completer, re_key=r"(?:.*\=)?(.+?)\[")
 
 
-# Setup library logger, and suppress spurious logger messages via a null handler
-class _NullHandler(_logging.Handler):
-    def emit(self, record):
-        pass
+# Setup library logger and add a print-like handler used when no logging is configured
+class _NoConfigFilter(_logging.Filter):
+    """Filter which only allows event if top-level logging is not configured."""
+    def filter(self, record):
+        return 1 if not _logging.root.handlers else 0
+_no_config_handler = _logging.StreamHandler()
+_no_config_handler.setFormatter(_logging.Formatter(_logging.BASIC_FORMAT))
+_no_config_handler.addFilter(_NoConfigFilter())
 logger = _logging.getLogger(__name__)
-logger.addHandler(_NullHandler())
-if not _logging.root.handlers:
-    print "Python logging has not been configured yet! All warnings and errors will be"
-    print "silently ignored. A simple fix is to do 'import logging; logging.basicConfig()'"
+logger.addHandler(_no_config_handler)
 
 # Attempt to determine installed package version
 try:


### PR DESCRIPTION
Instead of printing a warning and getting the user to configure
logging, do a very basicConfig-like configuration at the module
level. This logs warnings and above to sys.stderr using the basic
format (not unlike a plain old print statement), thereby ensuring
that the user receives these warnings and errors.

While this behaviour is strongly discouraged by the logging
documentation, the saving grace is that the configured handler
also has a filter that disables the handler once the user properly
configures logging at the application or script level.

Reviewer: @spassmoor 
