### PR TITLE
Add preload targets and antennas

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -344,7 +344,8 @@ def get_targets(filename):
 
     Returns
     -------
-    targets : list of :class:'katpoint.Target' objects
+    targets : :class:'katpoint.Catalogue' object
+        All targets in file
 
     """
     return _file_action('_get_targets', filename)

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -258,16 +258,15 @@ class H5DataV1(DataSet):
 
         Returns
         -------
-        targets : list of :class:'katpoint.Target' objects
+        targets : :class:'katpoint.Catalogue' object
+            All targets in file
 
         """
         f, version = H5DataV1._open(filename)
         compound_scans = f['Scans']
         all_target_strings = [compound_scans[group].attrs['target']
                               for group in compound_scans]
-        targets = [katpoint.Target(target_string)
-                   for target_string in np.unique(all_target_strings)]
-        return targets
+        return katpoint.Catalogue(np.unique(all_target_strings))
 
     @property
     def timestamps(self):

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -380,7 +380,8 @@ class H5DataV2(DataSet):
 
         Returns
         -------
-        targets : list of :class:'katpoint.Target' objects
+        targets : :class:'katpoint.Catalogue' object
+            All targets in file
 
         """
         f, version = H5DataV2._open(filename)
@@ -392,9 +393,7 @@ class H5DataV2(DataSet):
             # Since h5py errors have varied over the years, we need Exception
             target_list = f['MetaData/Sensors/Beams/Beam0/target']
         all_target_strings = [target_data[1] for target_data in target_list]
-        targets = [katpoint.Target(target_string)
-                   for target_string in np.unique(all_target_strings)]
-        return targets
+        return katpoint.Catalogue(np.unique(all_target_strings))
 
     def __str__(self):
         """Verbose human-friendly string representation of data set."""

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -333,15 +333,14 @@ class H5DataV3(DataSet):
 
         Returns
         -------
-        targets : list of :class:'katpoint.Target' objects
+        targets : :class:'katpoint.Catalogue' object
+            All targets in file
 
         """
         f, version = H5DataV3._open(filename)
         target_list = f['TelescopeModel/cbf/target']
         all_target_strings = [target_data[1] for target_data in target_list]
-        targets = [katpoint.Target(target_string)
-                   for target_string in np.unique(all_target_strings)]
-        return targets
+        return katpoint.Catalogue(np.unique(all_target_strings))
 
     def __str__(self):
         """Verbose human-friendly string representation of data set."""


### PR DESCRIPTION
Added two functions 'get_ants' and 'get_targs' to katdal. These are intended to be quick-look functions which return a list of antennas or targets in an input file. They are intended to be run when the user does not require a full katdal object to be instantiated in order to get some quick information from the file (eg. In order to find a potential reference antenna - which is required when a katdal object is created).

Each function is implemented as a @staticmethod in the h5datav1,v2,v3 classes and is not visible in a katdal object, to encourage the user to use the 'targets' and 'ants' attributes if the object has been created.  

@ludwigschwardt 
