### PR TITLE
Add preload targets and antennas

### DIFF
--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -363,10 +363,10 @@ class H5DataV2(DataSet):
         """
         f, version = H5DataV2._open(filename)
         config_group = f['MetaData/Configuration']
-        script_ants = config_group['Observation'].attrs['script_ants'].split(',')
-        antennas = [katpoint.Antenna(config_group['Antennas'][name].attrs['description'])
-                    for name in script_ants]
-        return antennas
+        all_ants = [ant for ant in config_group['Antennas']]
+        script_ants = config_group['Observation'].attrs.get('script_ants')
+        script_ants = script_ants.split(',') if script_ants else all_ants
+        return [katpoint.Antenna(config_group['Antennas'][ant].attrs['description']) for ant in script_ants if ant in all_ants]
 
     @staticmethod
     def _get_targets(filename):


### PR DESCRIPTION
The branch was reopened to correct a problem with the 'get_ants' function returning a different list of antennas to the 'ants' method in a katdal object. The get_ants function now first checks the list of antennas defined in the observation script (from 'script_params' in a V2 file, and from 'obs/params' in the TelsecopeModel group in a V3 file). It then retrieves the antenna objects from the names present in this list that are also present in the list of configured antennas. If no script antennas are defined the list of configured antennas is returned instead.

@ludwigschwardt 
