### PR TITLE
Fix package import with missing pkg_resources

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -250,6 +250,7 @@ else:
         # a .index method.
         ver = list(dist.parsed_version)
         __version__ = "r%d" % int(ver[ver.index("*r") + 1])
+        del dist, ver
     except (_pkg_resources.DistributionNotFound, ValueError, IndexError, TypeError):
         __version__ = "unknown"
 


### PR DESCRIPTION
If there is no pkg_resources, handle the ImportError but don't then
also look for a pkg_resources exception...
