### PR TITLE
Replace virtual noise diode sensor with real one

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -25,6 +25,7 @@ SENSOR_PROPS.update({
 })
 
 SENSOR_ALIASES = {
+    'nd_coupler': 'dig.noise-diode',
 }
 
 


### PR DESCRIPTION
Instead of calling cam2spead to set the virtual nd sensor (via the data
proxy), rather use the newly provided digitiser sensor (dig.noise-diode).
The new sensor is not much better than the virtual one, but requires
less work from SP + CAM.

@mauch, and another one...
