### PR TITLE
Remove initial blank target

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -311,6 +311,10 @@ class H5DataV3(DataSet):
         self.sensor['Observation/compscan_index'] = CategoricalData(range(len(label)), label.events)
         # Use the target sensor of reference antenna to set the target for each scan
         target = self.sensor.get('Antennas/%s/target' % (self.ref_ant,))
+        # RTS workaround: Remove an initial blank target (typically because the antenna is stopped at the start)
+        if len(target) > 1 and target[0] == 'Nothing, special':
+            target.events, target.indices = target.events[1:], target.indices[1:]
+            target.events[0] = 0
         # Move target events onto the nearest scan start
         # ASSUMPTION: Number of targets <= number of scans (i.e. only a single target allowed per scan)
         target.align(scan.events)


### PR DESCRIPTION
In RTS, the antenna sometimes remains in stop mode when capture starts,
which implies having no target (aka 'Nothing, special'). This typically
messes up the first compound scan. As a workaround, remove this spurious
blank target and replace it with the next (hopefully meaningful) target.
The 'stop' scan thereby gets grouped with the next proper set of scans.

Reviewer: @SharmilaGoedhart 
