### PR TITLE
Obtain centre frequency from obs_params

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -305,8 +305,8 @@ class H5DataV3(DataSet):
 
         # ------ Extract spectral windows / frequencies ------
 
-        # The centre frequency is now in the domain of the CBF
-        centre_freq = cbf_group.attrs['center_freq']
+        # The centre frequency will always be set by the script (and available in data proxy)
+        centre_freq = self.obs_params.get('centre_freq', np.nan) * 1e6
         num_chans = cbf_group.attrs['n_chans']
         if num_chans != self._vis.shape[1]:
             raise BrokenFile('Number of channels received from correlator '


### PR DESCRIPTION
Contrary to popular belief, the RTS system supports different centre
frequencies, thanks to its inclusion of a Ku-band receiver. The CBF actually
does not know the sky centre frequency anymore (and doesn't need to).
The data proxy needs it for delay correction and therefore knows it, so one
option is to include its delay-center-frequency sensor. On the other hand, the
soon-to-be-updated RTS CaptureSession sets and gets the frequency from this
sensor already and then passes it to obs_params. Reading it from obs_params
is therefore the easiest solution.

The only restriction (and a justifiable one) is that there can only be a single
centre frequency per file. Since changing the centre frequency amounts to a new
receiver and/or a new correlator product, this is fair.

Reviewer: @LauraRichter 
