### PR TITLE
Use flag names from HDF5 file rather than hard-coded ones

### DIFF
--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -521,11 +521,12 @@ class H5DataV2(DataSet):
             Only then will data be loaded into memory.
 
         """
-        names = names.split(',') if isinstance(names, basestring) else FLAG_NAMES if names is None else names
+        known_flags = [row[0] for row in self._flags_description]
+
+        names = names.split(',') if isinstance(names, basestring) else known_flags if names is None else names
 
         # Create index list for desired flags
         flagmask = np.zeros(8, dtype=np.int)
-        known_flags = [row[0] for row in self._flags_description]
         for name in names:
             try:
                 flagmask[known_flags.index(name)] = 1

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -38,10 +38,10 @@ def _calc_azel(cache, name, ant):
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel, 'Antennas/{ant}/el': _calc_azel})
 
-FLAG_NAMES = ('reserved0', 'static', 'cam', 'reserved3', 'detected_rfi', 'predicted_rfi', 'reserved6', 'reserved7')
+FLAG_NAMES = ('reserved0', 'static', 'cam', 'reserved3', 'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'reserved7')
 FLAG_DESCRIPTIONS = ('reserved - bit 0', 'predefined static flag list', 'flag based on live CAM information',
-                     'reserved - bit 3', 'RFI detected in the online system', 'RFI predicted from space based pollutants',
-                     'reserved - bit 6', 'reserved - bit 7')
+                     'reserved - bit 3', 'RFI detected in ingest', 'RFI predicted from space based pollutants',
+                     'RFI detected in calibration', 'reserved - bit 7')
 WEIGHT_NAMES = ('precision',)
 WEIGHT_DESCRIPTIONS = ('visibility precision (inverse variance, i.e. 1 / sigma^2)',)
 
@@ -563,11 +563,13 @@ class H5DataV3(DataSet):
             Only then will data be loaded into memory.
 
         """
-        names = names.split(',') if isinstance(names, basestring) else FLAG_NAMES if names is None else names
+
+        known_flags = [row[0] for row in self._flags_description]
+
+        names = names.split(',') if isinstance(names, basestring) else known_flags if names is None else names
 
         # Create index list for desired flags
         flagmask = np.zeros(8, dtype=np.int)
-        known_flags = [row[0] for row in self._flags_description]
         for name in names:
             try:
                 flagmask[known_flags.index(name)] = 1


### PR DESCRIPTION
When calling the 'flags' method without specifying a list of desired flag names, the default behaviour is to return all flag bits OR'ed together. Previously the flag bits were determined from a hard-coded list of flag names. This change rather uses the list of flags found in the input h5 file, which are conveniently previously saved in '_flags_description'. 
I've also updated the list of hard-coded flag names and descriptions in h5datav3 to reflect the added bit for flags determined in katsdpcal (described in ska-sa/katsdpingest#65)

@ludwigschwardt 
