### PR TITLE
Improve receiver serial numbers

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -285,22 +285,18 @@ class H5DataV3(DataSet):
         self.ref_ant = obs_ants[0] if not ref_ant else ref_ant
         # Populate antenna -> receiver mapping
         for ant in all_ants:
-            try:
-                band = self.sensor['Antennas/%s/ap_indexer_position' % (ant,)][0]
-            except KeyError:
-                band = ''
-            try:
-                rx_serial = self.sensor['Antennas/%s/rsc_rx%s_serial_number' % (ant, band)][0]
-            except KeyError:
-                rx_serial = 0
-            if band and rx_serial:
+            band_sensor = 'Antennas/%s/ap_indexer_position' % (ant,)
+            band = self.sensor[band_sensor][0] if band_sensor in self.sensor else ''
+            rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
+            rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
+            if band:
                 self.receivers[ant] = '%s.%d' % (band, rx_serial)
         # Original list of correlation products as pairs of input labels
         corrprods = cbf_group.attrs['bls_ordering']
         # Work around early RTS correlator bug by re-ordering labels
         if rotate_bls:
             corrprods = corrprods[range(1, len(corrprods)) + [0]]
-        
+
         if len(corrprods) != self._vis.shape[2]:
             # Apply k7_capture baseline mask after the fact, in the hope that it fixes correlation product mislabelling
             corrprods = np.array([cp for cp in corrprods if cp[0][:-1] in obs_ants and cp[1][:-1] in obs_ants])


### PR DESCRIPTION
This safeguards the band and serial numbers by providing
default values of the correct type (in case their sensors are
missing). The default values indicate 'unknown' in both cases.

Also streamline the code and now report serial numbers of 0
(useless for noise diode models but useful to spot Ku-band
receivers).
