### PR TITLE
Fix kwarg in d.select

### DIFF
--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -105,7 +105,7 @@ if len(args) == 0:
 else:
     d = katdal.open(args)
     ant = opts.ant if opts.ant is not None else d.ref_ant
-    d.select(ant=ant, pol=opts.pol)
+    d.select(ants=ant, pol=opts.pol)
 
     plt.figure(1)
     plt.clf()


### PR DESCRIPTION
Expected "ants", got "ant". Not sure if functionality is affected, I found this error while trying to use the example script to learn the library a bit...
