### PR TITLE
Make observation script log a top-level attribute

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -285,6 +285,8 @@ class DataSet(object):
         experiment together with blog entries, etc.
     obs_params : dict mapping string to string or list of strings
         Observation parameters, typically set in observation script
+    obs_script_log : list of strings
+        Observation script output log (useful for debugging)
 
     subarrays : list of :class:`SubArray` objects
         List of all subarrays in data set
@@ -348,6 +350,7 @@ class DataSet(object):
         self.description = ''
         self.experiment_id = ''
         self.obs_params = {}
+        self.obs_script_log = []
 
         self.subarrays = []
         self.subarray = -1

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -161,6 +161,8 @@ class H5DataV2(DataSet):
         self.observer = self.obs_params.get('observer', '')
         self.description = self.obs_params.get('description', '')
         self.experiment_id = self.obs_params.get('experiment_id', '')
+        # Get script log from History group
+        self.obs_script_log = f['History/script_log'].value['log'].tolist()
 
         # ------ Extract timestamps ------
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -274,7 +274,7 @@ class H5DataV3(DataSet):
                         dummy_dataset('dummy_weights', shape=self._vis.shape[:-1] + (1,), dtype=np.float32, value=1.0)
         self._weights_description = np.array(zip(WEIGHT_NAMES, WEIGHT_DESCRIPTIONS))
 
-        # ------ Extract observation parameters ------
+        # ------ Extract observation parameters and script log ------
 
         self.obs_params = {}
         # Replay obs_params sensor if available and update obs_params dict accordingly
@@ -290,6 +290,11 @@ class H5DataV3(DataSet):
         self.observer = self.obs_params.get('observer', '')
         self.description = self.obs_params.get('description', '')
         self.experiment_id = self.obs_params.get('experiment_id', '')
+        # Extract script log data verbatim (it is not a standard sensor anyway)
+        try:
+            self.obs_script_log = self.sensor.get('Observation/script_log', extract=False)['value'].tolist()
+        except KeyError:
+            self.obs_script_log = []
 
         # ------ Extract subarrays ------
 


### PR DESCRIPTION
The obs script_log is not a standard sensor in that you do not want to
interpolate its values onto the data timestamps. Instead, extract its
values verbatim, turn them into a list of strings (one per log line) and
make it a top-level attribute in the DataSet. This also provides a unified
way to access the log between KAT-7 and MeerKAT.
