### PR TITLE
Work around a CBF bandwidth bug

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -23,7 +23,9 @@ SENSOR_PROPS.update({
                   'transform': lambda act: SIMPLIFY_STATE.get(act, 'stop')},
     '*target': {'initial_value': '', 'transform': _robust_target},
     '*ap_indexer_position': {'initial_value': ''},
-    '*_serial_number': {'initial_value': 0}
+    '*_serial_number': {'initial_value': 0},
+    '*dig_noise_diode': {'categorical': True, 'greedy_values': (True,),
+                         'initial_value': 0.0, 'transform': lambda x: x > 0.0},
 })
 
 SENSOR_ALIASES = {


### PR DESCRIPTION
Work around a CBF bug in the bc856M4k instrument where the V pol had an
incorrect bandwidth in the SPEAD metadata. This was active from 2016-04-28
to 2016-06-01.
