### PR TITLE
Fix flag ordering for AR1+ files

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -672,8 +672,8 @@ class H5DataV3(DataSet):
             Only then will data be loaded into memory.
 
         """
-
-        known_flags = [row[0] for row in self._flags_description]
+        # Reverse flag indices as np.packbits has bit 0 as the MSB (we want LSB)
+        known_flags = [row[0] for row in reversed(self._flags_description)]
 
         names = names.split(',') if isinstance(names, basestring) else known_flags if names is None else names
 


### PR DESCRIPTION
The use of np.packbits has confused the flag ordering. Contrary to popular
belief it takes bit 0 to be the MSB, while we always assumed it would be the
LSB of the flag byte. The situation is complicated by the existence of two
flaggers that handled this differently.

Mauch's ingest flagger on KAT-7 also uses the packbits convention, which has
'detected_rfi' as value 8. We therefore leave H5DataV2 as is (living with
the incongruity of the flag descriptions in terms of bits).

Merry's AR1 ingest flagger assumed that bit 0 == LSB and has 'ingest_rfi'
as value 16. Therefore reverse the flag descriptions to match them up in
H5DataV3. RTS had no ingest flagger, FWIW, so those v3 files should be OK.
