### PR TITLE
Use latest incarnation of wind speed sensor

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -709,42 +709,29 @@ class H5DataV3(DataSet):
     @property
     def temperature(self):
         """Air temperature in degrees Celsius."""
-        try:
-            return self.sensor['Enviro/air_temperature']
-        except KeyError:
-            return self.sensor['TelescopeState/anc_weather_temperature']
+        names = ['Enviro/air_temperature', 'TelescopeState/anc_weather_temperature']
+        return self.sensor.get_with_fallback('temperature', names)
 
     @property
     def pressure(self):
         """Barometric pressure in millibars."""
-        try:
-            return self.sensor['Enviro/air_pressure']
-        except KeyError:
-            return self.sensor['TelescopeState/anc_weather_pressure']
+        names = ['Enviro/air_pressure', 'TelescopeState/anc_weather_pressure']
+        return self.sensor.get_with_fallback('pressure', names)
 
     @property
     def humidity(self):
         """Relative humidity as a percentage."""
-        try:
-            return self.sensor['Enviro/air_relative_humidity']
-        except KeyError:
-            return self.sensor['TelescopeState/anc_weather_humidity']
+        names = ['Enviro/air_relative_humidity', 'TelescopeState/anc_weather_humidity']
+        return self.sensor.get_with_fallback('humidity', names)
 
     @property
     def wind_speed(self):
         """Wind speed in metres per second."""
-        try:
-            return self.sensor['Enviro/mean_wind_speed']
-        except KeyError:
-            try:
-                return self.sensor['Enviro/wind_speed']
-            except KeyError:
-                return self.sensor['TelescopeState/anc_weather_wind_speed']
+        names = ['Enviro/mean_wind_speed', 'Enviro/wind_speed', 'TelescopeState/anc_weather_wind_speed']
+        return self.sensor.get_with_fallback('wind_speed', names)
 
     @property
     def wind_direction(self):
         """Wind direction as an azimuth angle in degrees."""
-        try:
-            return self.sensor['Enviro/wind_direction']
-        except KeyError:
-            return self.sensor['TelescopeState/anc_weather_wind_direction']
+        names = ['Enviro/wind_direction', 'TelescopeState/anc_weather_wind_direction']
+        return self.sensor.get_with_fallback('wind_direction', names)

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -532,6 +532,38 @@ class SensorCache(dict):
             self[name] = sensor_data
         return sensor_data[self.keep] if select else sensor_data
 
+    def get_with_fallback(self, sensor_type, names):
+        """Sensor values interpolated to correlator data timestamps.
+
+        Get data for a type of sensor that may have one of several names.
+        Try each name in turn until something works, or crash sensibly.
+
+        Parameters
+        ----------
+        sensor_type : string
+            Name of sensor class / type, used for informational purposes only
+        names : sequence of strings
+            Sensor names to try until one of them provides data
+
+        Returns
+        -------
+        sensor_data : array
+           Interpolated sensor data as 1-D array, one value per selected timestamp
+
+        Raises
+        ------
+        KeyError
+            If none of the sensor names were found in the cache
+
+        """
+        for name in names:
+            try:
+                return self.get(name, select=True)
+            except KeyError:
+                logger.debug('Could not find %s sensor with name %r, trying next option' % (sensor_type, name))
+        raise KeyError('Could not find any %s sensor, tried %s' % (sensor_type, names))
+
+
 # -------------------------------------------------------------------------------------------------
 # -- FUNCTION :  _sensor_completer
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The ANC proxy now has "generic" weather sensors which should be used.
It distinguishes between mean and gust wind speeds, so we pick the former.

Also add a helper function to SensorCache to make it simple to look up
sensors by alternative names with decent error reporting if it fails.
