### PR TITLE
Support weights in file and improve vis / weights / flags API

### DIFF
--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -535,44 +535,36 @@ class ConcatenatedDataSet(DataSet):
         """
         return ConcatenatedLazyIndexer([d.vis for d in self.datasets])
 
-    def weights(self, names=None):
+    @property
+    def weights(self):
         """Visibility weights as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            List of names of weights to be multiplied together, as a sequence
-            or string of comma-separated names (combine all weights by default)
-
-        Returns
-        -------
-        weights : :class:`LazyIndexer` object of float32, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The weights data are returned as an array indexer of float32, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        return ConcatenatedLazyIndexer([d.weights(names) for d in self.datasets])
+        return ConcatenatedLazyIndexer([d.weights for d in self.datasets])
 
-    def flags(self, names=None):
-        """Visibility flags as a function of time, frequency and baseline.
+    @property
+    def flags(self):
+        """Flags as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            List of names of flags that will be OR'ed together, as a sequence or
-            a string of comma-separated names (use all flags by default)
-
-        Returns
-        -------
-        flags : :class:`LazyIndexer` object of bool, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The flags data are returned as an array indexer of bool, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        return ConcatenatedLazyIndexer([d.flags(names) for d in self.datasets])
+        return ConcatenatedLazyIndexer([d.flags for d in self.datasets])

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -568,3 +568,28 @@ class ConcatenatedDataSet(DataSet):
 
         """
         return ConcatenatedLazyIndexer([d.flags for d in self.datasets])
+
+    @property
+    def temperature(self):
+        """Air temperature in degrees Celsius."""
+        return np.concatenate([d.temperature for d in self.datasets])
+
+    @property
+    def pressure(self):
+        """Barometric pressure in millibars."""
+        return np.concatenate([d.pressure for d in self.datasets])
+
+    @property
+    def humidity(self):
+        """Relative humidity as a percentage."""
+        return np.concatenate([d.humidity for d in self.datasets])
+
+    @property
+    def wind_speed(self):
+        """Wind speed in metres per second."""
+        return np.concatenate([d.wind_speed for d in self.datasets])
+
+    @property
+    def wind_direction(self):
+        """Wind direction as an azimuth angle in degrees."""
+        return np.concatenate([d.wind_direction for d in self.datasets])

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -472,13 +472,15 @@ class ConcatenatedDataSet(DataSet):
         # Apply default selection and initialise all members that depend on selection in the process
         self.select(spw=0, subarray=0)
 
-    def _set_keep(self, time_keep=None, freq_keep=None, corrprod_keep=None):
+    def _set_keep(self, time_keep=None, freq_keep=None, corrprod_keep=None,
+                  weights_keep=None, flags_keep=None):
         """Set time, frequency and/or correlation product selection masks.
 
         Set the selection masks for those parameters that are present. The time
         mask is split into chunks and applied to the underlying datasets and
         sensor caches, while the frequency and corrprod masks are directly
-        applied to the underlying datasets as well.
+        applied to the underlying datasets as well. Also allow for weights
+        and flags selections.
 
         Parameters
         ----------
@@ -488,6 +490,10 @@ class ConcatenatedDataSet(DataSet):
             Boolean selection mask with one entry per frequency channel
         corrprod_keep : array of bool, shape (*B*,), optional
             Boolean selection mask with one entry per correlation product
+        weights_keep : 'all' or string or sequence of strings, optional
+            Names of selected weight types (or 'all' for the lot)
+        flags_keep : 'all' or string or sequence of strings, optional
+            Names of selected flag types (or 'all' for the lot)
 
         """
         if time_keep is not None:
@@ -505,6 +511,14 @@ class ConcatenatedDataSet(DataSet):
             self._corrprod_keep = corrprod_keep
             for n, d in enumerate(self.datasets):
                 d._set_keep(corrprod_keep=self._corrprod_keep)
+        if weights_keep is not None:
+            self._weights_keep = weights_keep
+            for n, d in enumerate(self.datasets):
+                d._set_keep(weights_keep=self._weights_keep)
+        if flags_keep is not None:
+            self._flags_keep = flags_keep
+            for n, d in enumerate(self.datasets):
+                d._set_keep(flags_keep=self._flags_keep)
 
     @property
     def timestamps(self):

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -404,6 +404,7 @@ class DataSet(object):
         self._time_keep = []
         self._freq_keep = []
         self._corrprod_keep = []
+        self._weights_keep = 'all'
 
     def __repr__(self):
         """Short human-friendly string representation of data set object."""
@@ -616,6 +617,10 @@ class DataSet(object):
         pol : {'H', 'V', 'HH', 'VV', 'HV', 'VH'}, optional
             Select polarisation term
 
+        weights : 'all' or string or sequence of strings, optional
+            List of names of weights to be multiplied together, as a sequence
+            or string of comma-separated names (combine all weights by default)
+
         reset : {'auto', '', 'T', 'F', 'B', 'TF', 'TB', 'FB', 'TFB'}, optional
             Remove existing selections on specified dimensions before applying
             the new selections. The default 'auto' option clears those dimensions
@@ -636,7 +641,8 @@ class DataSet(object):
         freq_selectors = ['channels', 'freqrange']
         corrprod_selectors = ['corrprods', 'ants', 'inputs', 'pol']
         # Check if keywords are valid and raise exception only if this is explicitly enabled
-        valid_kwargs = time_selectors + freq_selectors + corrprod_selectors + ['spw', 'subarray', 'reset', 'strict']
+        valid_kwargs = time_selectors + freq_selectors + corrprod_selectors + \
+            ['spw', 'subarray', 'weights', 'reset', 'strict']
         # Check for definition of strict
         strict = kwargs.get('strict', True)
         if strict and set(kwargs.keys()) - set(valid_kwargs):
@@ -774,6 +780,9 @@ class DataSet(object):
                 polAB = polAB * 2 if polAB in ('h', 'v') else polAB
                 self._corrprod_keep &= [(inpA[-1] == polAB[0] and inpB[-1] == polAB[1])
                                         for inpA, inpB in self.subarrays[self.subarray].corr_products]
+            # Selections that affect weights
+            elif k == 'weights':
+                self._weights_keep = v
 
         # Ensure that updated selections make their way to sensor cache and potentially underlying datasets
         self._set_keep(self._time_keep, self._freq_keep, self._corrprod_keep)

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -518,10 +518,12 @@ class DataSet(object):
                 model.min_freq_MHz = new_min_freq
                 model.max_freq_MHz = new_max_freq
 
-    def _set_keep(self, time_keep=None, freq_keep=None, corrprod_keep=None):
+    def _set_keep(self, time_keep=None, freq_keep=None, corrprod_keep=None,
+                  weights_keep=None, flags_keep=None):
         """Set time, frequency and/or correlation product selection masks.
 
-        Set the selection masks for those parameters that are present.
+        Set the selection masks for those parameters that are present. Also
+        include weights and flags selections as options.
 
         Parameters
         ----------
@@ -531,6 +533,10 @@ class DataSet(object):
             Boolean selection mask with one entry per frequency channel
         corrprod_keep : array of bool, shape (*B*,), optional
             Boolean selection mask with one entry per correlation product
+        weights_keep : 'all' or string or sequence of strings, optional
+            Names of selected weight types (or 'all' for the lot)
+        flags_keep : 'all' or string or sequence of strings, optional
+            Names of selected flag types (or 'all' for the lot)
 
         """
         if time_keep is not None:
@@ -542,6 +548,10 @@ class DataSet(object):
             self._freq_keep = freq_keep
         if corrprod_keep is not None:
             self._corrprod_keep = corrprod_keep
+        if weights_keep is not None:
+            self._weights_keep = weights_keep
+        if flags_keep is not None:
+            self._flags_keep = flags_keep
 
     def select(self, **kwargs):
         """Select subset of data, based on time / frequency / corrprod filters.
@@ -795,7 +805,7 @@ class DataSet(object):
                 self._flags_keep = v
 
         # Ensure that updated selections make their way to sensor cache and potentially underlying datasets
-        self._set_keep(self._time_keep, self._freq_keep, self._corrprod_keep)
+        self._set_keep(self._time_keep, self._freq_keep, self._corrprod_keep, self._weights_keep, self._flags_keep)
         # Update the relevant data members based on selection made
         # These would all be more efficient as properties, but at the expense of extra lines of code...
         self.shape = (self._time_keep.sum(), self._freq_keep.sum(), self._corrprod_keep.sum())

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -364,50 +364,43 @@ class H5DataV1(DataSet):
         """
         return ConcatenatedLazyIndexer(self._vis_indexers())
 
-    def weights(self, names=None):
+    @property
+    def weights(self):
         """Visibility weights as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            List of names of weights to be multiplied together, as a sequence
-            or string of comma-separated names (combine all weights by default)
-
-        Returns
-        -------
-        weights : :class:`LazyIndexer` object of float32, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The weights data are returned as an array indexer of float32, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        # tell the user that there are no weights in the h5 file
-        logger.warning("No weights in v1 h5 data files, returning array of unity weights")
+        # Tell the user that there are no weights in the h5 file
+        logger.warning("No weights in HDF5 v1 data files, returning array of unity weights")
         ones = LazyTransform('ones', lambda data, keep: np.ones_like(data, dtype=np.float32), dtype=np.float32)
         return ConcatenatedLazyIndexer(self._vis_indexers(), transforms=[ones])
 
-    def flags(self, names=None):
-        """Visibility flags as a function of time, frequency and baseline.
+    @property
+    def flags(self):
+        """Flags as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            Ignored because HDF5 v1 files do not contain flags
-
-        Returns
-        -------
-        flags : :class:`LazyIndexer` object of bool, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The flags data are returned as an array indexer of bool, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        # tell the user that there are no flags in the h5 file
-        logger.warning("No flags in v1 h5 data files, returning array of zero flags")
+        # Tell the user that there are no flags in the h5 file
+        logger.warning("No flags in HDF5 v1 data files, returning array of zero flags")
         falses = LazyTransform('falses', lambda data, keep: np.zeros_like(data, dtype=np.bool), dtype=np.bool)
         return ConcatenatedLazyIndexer(self._vis_indexers(), transforms=[falses])
 

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -156,8 +156,8 @@ class H5DataV2(DataSet):
         True if synthesised timestamps should be used to partition data set even
         if real timestamps are irregular, thereby avoiding the slow loading of
         real timestamps at the cost of slightly inaccurate label borders
-    squeeze : {False, True}, optional
-        Don't force vis / weights / flags to be 3-dimensional
+    keepdims : {False, True}, optional
+        Force vis / weights / flags to be 3-dimensional, regardless of selection
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
 
@@ -168,7 +168,7 @@ class H5DataV2(DataSet):
 
     """
     def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r',
-                 quicklook=False, squeeze=False, **kwargs):
+                 quicklook=False, keepdims=False, **kwargs):
         DataSet.__init__(self, filename, ref_ant, time_offset)
 
         # Load file
@@ -228,7 +228,7 @@ class H5DataV2(DataSet):
         self._time_keep = np.ones(num_dumps, dtype=np.bool)
         self.start_time = katpoint.Timestamp(data_timestamps[0] - 0.5 * self.dump_period)
         self.end_time = katpoint.Timestamp(data_timestamps[-1] + 0.5 * self.dump_period)
-        self._squeeze = squeeze
+        self._keepdims = keepdims
 
         # ------ Extract flags ------
 
@@ -566,7 +566,7 @@ class H5DataV2(DataSet):
                             for dim_keep in keep]
             return data[tuple(keep_singles)]
         force_3dim = LazyTransform('force_3dim', _force_3dim)
-        transforms = [extractor] if self._squeeze else [extractor, force_3dim]
+        transforms = [extractor, force_3dim] if self._keepdims else [extractor]
         return LazyIndexer(dataset, stage1, transforms)
 
     @property

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -156,6 +156,8 @@ class H5DataV2(DataSet):
         True if synthesised timestamps should be used to partition data set even
         if real timestamps are irregular, thereby avoiding the slow loading of
         real timestamps at the cost of slightly inaccurate label borders
+    squeeze : {False, True}, optional
+        Don't force vis / weights / flags to be 3-dimensional
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
 
@@ -165,7 +167,8 @@ class H5DataV2(DataSet):
         Underlying HDF5 file, exposed via :mod:`h5py` interface
 
     """
-    def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r', quicklook=False, **kwargs):
+    def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r',
+                 quicklook=False, squeeze=False, **kwargs):
         DataSet.__init__(self, filename, ref_ant, time_offset)
 
         # Load file
@@ -225,6 +228,7 @@ class H5DataV2(DataSet):
         self._time_keep = np.ones(num_dumps, dtype=np.bool)
         self.start_time = katpoint.Timestamp(data_timestamps[0] - 0.5 * self.dump_period)
         self.end_time = katpoint.Timestamp(data_timestamps[-1] + 0.5 * self.dump_period)
+        self._squeeze = squeeze
 
         # ------ Extract flags ------
 
@@ -234,13 +238,19 @@ class H5DataV2(DataSet):
         # Obtain flag descriptions from file or recreate default flag description table
         self._flags_description = markup_group['flags_description'] if 'flags_description' in markup_group else \
             np.array(zip(FLAG_NAMES, FLAG_DESCRIPTIONS))
+        self._flags_select = np.array([0], dtype=np.uint8)
+        self._flags_keep = 'all'
 
         # ------ Extract weights ------
 
-        # check if weight group present, else use dummy weight data
+        # Check if weight group present, else use dummy weight data
         self._weights = markup_group['weights'] if 'weights' in markup_group else \
-            dummy_dataset('dummy_weights', shape=self._vis.shape[:-1] + (1,), dtype=np.float32, value=1.0)
-        self._weights_description = np.array(zip(WEIGHT_NAMES, WEIGHT_DESCRIPTIONS))
+            dummy_dataset('dummy_weights', shape=self._vis.shape[:-1], dtype=np.float32, value=1.0)
+        # Obtain weight descriptions from file or recreate default weight description table
+        self._weights_description = markup_group['weights_description'] if 'weights_description' in markup_group else \
+            np.array(zip(WEIGHT_NAMES, WEIGHT_DESCRIPTIONS))
+        self._weights_select = []
+        self._weights_keep = 'all'
 
         # ------ Extract sensors ------
 
@@ -443,6 +453,66 @@ class H5DataV2(DataSet):
         return '\n'.join(descr)
 
     @property
+    def _weights_keep(self):
+        known_weights = [row[0] for row in getattr(self, '_weights_description', [])]
+        return [known_weights[ind] for ind in self._weights_select]
+
+    @_weights_keep.setter
+    def _weights_keep(self, names):
+        known_weights = [row[0] for row in getattr(self, '_weights_description', [])]
+        # Ensure a sequence of weight names
+        names = known_weights if names == 'all' else \
+            names.split(',') if isinstance(names, basestring) else names
+        # Create index list for desired weights
+        selection = []
+        for name in names:
+            try:
+                selection.append(known_weights.index(name))
+            except ValueError:
+                logger.warning("%r is not a legitimate weight type for this file, "
+                               "supported ones are %s" % (name, known_weights))
+        if known_weights and not selection:
+            logger.warning('No valid weights were selected - setting all weights to 1.0 by default')
+        self._weights_select = selection
+
+    @property
+    def _flags_keep(self):
+        if not hasattr(self, '_flags_description'):
+            return []
+        known_flags = [row[0] for row in self._flags_description]
+        # Reverse flag indices as np.packbits has bit 0 as the MSB (we want LSB)
+        selection = np.flipud(np.unpackbits(self._flags_select))
+        assert len(known_flags) == len(selection), \
+            'Expected %d flag types in file, got %s' % (len(selection), self._flags_description)
+        return [name for name, bit in zip(known_flags, selection) if bit]
+
+    @_flags_keep.setter
+    def _flags_keep(self, names):
+        if not hasattr(self, '_flags_description'):
+            self._flags_select = np.array([0], dtype=np.uint8)
+            return
+        known_flags = [row[0] for row in self._flags_description]
+        # Ensure a sequence of flag names
+        names = known_flags if names == 'all' else \
+            names.split(',') if isinstance(names, basestring) else names
+        # Create boolean list for desired flags
+        selection = np.zeros(8, dtype=np.uint8)
+        assert len(known_flags) == len(selection), \
+            'Expected %d flag types in file, got %d' % (len(selection), self._flags_description)
+        for name in names:
+            try:
+                selection[known_flags.index(name)] = 1
+            except ValueError:
+                logger.warning("%r is not a legitimate flag type for this file, "
+                               "supported ones are %s" % (name, known_flags))
+        # Pack index list into bit mask
+        # Reverse flag indices as np.packbits has bit 0 as the MSB (we want LSB)
+        flagmask = np.packbits(np.flipud(selection))
+        if known_flags and not flagmask:
+            logger.warning('No valid flags were selected - setting all flags to False by default')
+        self._flags_select = flagmask
+
+    @property
     def timestamps(self):
         """Visibility timestamps in UTC seconds since Unix epoch.
 
@@ -456,6 +526,48 @@ class H5DataV2(DataSet):
         dump_period, time_offset = self.dump_period, self.time_offset
         extract_time = LazyTransform('extract_time', lambda t, keep: t + 0.5 * dump_period + time_offset)
         return LazyIndexer(self._timestamps, keep=self._time_keep, transforms=[extract_time])
+
+    def _vislike_indexer(self, dataset, extractor):
+        """Lazy indexer for vis-like datasets (vis / weights / flags).
+
+        This operates on datasets with shape (*T*, *F*, *B*) and potentially
+        different dtypes. The data type conversions are all left to the provided
+        extractor transform, while this method takes care of the common
+        selection issues, such as preserving singleton dimensions and dealing
+        with duplicate final dumps.
+
+        Parameters
+        ----------
+        dataset : :class:`h5py.Dataset` object or equivalent
+            Underlying vis-like dataset on which lazy indexing will be done
+        extractor : function, signature ``data = f(data, keep)``
+            Transform to apply to data (`keep` is user-provided 2nd-stage index)
+
+        Returns
+        -------
+        indexer : :class:`LazyIndexer` object
+            Lazy indexer with appropriate selectors and transforms included
+
+        """
+        # Create first-stage index from dataset selectors
+        time_keep = self._time_keep
+        # If there is a duplicate final dump, these lengths don't match -> ignore last dump in file
+        if len(time_keep) == len(dataset) - 1:
+            time_keep = np.zeros(len(dataset), dtype=np.bool)
+            time_keep[:len(self._time_keep)] = self._time_keep
+        stage1 = (time_keep, self._freq_keep, self._corrprod_keep)
+
+        def _force_3dim(data, keep):
+            """Keep singleton dimensions in stage 2 (i.e. final) indexing."""
+            # Ensure that keep tuple has length of 3 (truncate or pad with blanket slices as necessary)
+            keep = keep[:3] + (slice(None),) * (3 - len(keep))
+            # Final indexing ensures that returned data are always 3-dimensional (i.e. keep singleton dimensions)
+            keep_singles = [(np.newaxis if np.isscalar(dim_keep) else slice(None))
+                            for dim_keep in keep]
+            return data[tuple(keep_singles)]
+        force_3dim = LazyTransform('force_3dim', _force_3dim)
+        transforms = [extractor] if self._squeeze else [extractor, force_3dim]
+        return LazyIndexer(dataset, stage1, transforms)
 
     @property
     def vis(self):
@@ -473,110 +585,55 @@ class H5DataV2(DataSet):
         form of indexing on it. Only then will data be loaded into memory.
 
         """
-        def _extract_vis(vis, keep):
-            # Ensure that keep tuple has length of 3 (truncate or pad with blanket slices as necessary)
-            keep = keep[:3] + (slice(None),) * (3 - len(keep))
-            # Final indexing ensures that returned data are always 3-dimensional (i.e. keep singleton dimensions)
-            # Discard the 4th / last dimension, however, as this is subsumed in the complex view of the data
-            force_3dim = tuple([(np.newaxis if np.isscalar(dim_keep) else slice(None)) for dim_keep in keep] + [0])
-            return vis.view(np.complex64)[force_3dim]
-        extract_vis = LazyTransform('extract_vis', _extract_vis, lambda shape: shape[:-1], np.complex64)
-        return LazyIndexer(self._vis, (self._time_keep, self._freq_keep, self._corrprod_keep),
-                           transforms=[extract_vis])
+        extract = LazyTransform('extract_vis',
+                                # Discard the 4th / last dimension as this is subsumed in complex view
+                                lambda vis, keep: vis.view(np.complex64)[..., 0],
+                                lambda shape: shape[:-1], np.complex64)
+        return self._vislike_indexer(self._vis, extract)
 
-    def weights(self, names=None):
+    @property
+    def weights(self):
         """Visibility weights as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            List of names of weights to be multiplied together, as a sequence
-            or string of comma-separated names (combine all weights by default)
-
-        Returns
-        -------
-        weights : :class:`LazyIndexer` object of float32, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The weights data are returned as an array indexer of float32, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        names = names.split(',') if isinstance(names, basestring) else WEIGHT_NAMES if names is None else names
+        # We currently only cater for a single weight type (i.e. either select it or fall back to 1.0)
+        def transform(weights, keep):
+            return weights.astype(np.float32) if self._weights_select else \
+                np.ones_like(weights, dtype=np.float32)
+        extract = LazyTransform('extract_weights', transform, dtype=np.float32)
+        return self._vislike_indexer(self._weights, extract)
 
-        # Create index list for desired weights
-        selection = []
-        known_weights = [row[0] for row in self._weights_description]
-        for name in names:
-            try:
-                selection.append(known_weights.index(name))
-            except ValueError:
-                logger.warning("'%s' is not a legitimate weight type for this file" % (name,))
-        if not selection:
-            logger.warning('No valid weights were selected - setting all weights to 1.0 by default')
-
-        def _extract_weights(weights, keep):
-            # Ensure that keep tuple has length of 3 (truncate or pad with blanket slices as necessary)
-            keep = keep[:3] + (slice(None),) * (3 - len(keep))
-            # Final indexing ensures that returned data are always 3-dimensional (i.e. keep singleton dimensions)
-            force_3dim = tuple([(np.newaxis if np.isscalar(dim_keep) else slice(None)) for dim_keep in keep])
-            # Multiply selected weights together (or select lone weight)
-            # Strangely enough, if selection is [], prod produces the expected weights of 1.0 instead of an empty array
-            return weights[force_3dim][:, :, :, selection[0]] if len(selection) == 1 else \
-                weights[force_3dim][:, :, :, selection].prod(axis=-1)
-        extract_weights = LazyTransform('extract_weights', _extract_weights, lambda shape: shape[:-1], np.float32)
-        return LazyIndexer(self._weights, (self._time_keep, self._freq_keep, self._corrprod_keep),
-                           transforms=[extract_weights])
-
-    def flags(self, names=None):
+    @property
+    def flags(self):
         """Flags as a function of time, frequency and baseline.
 
-        Parameters
-        ----------
-        names : None or string or sequence of strings, optional
-            List of names of flags that will be OR'ed together, as a sequence or
-            a string of comma-separated names (use all flags by default)
-
-        Returns
-        -------
-        flags : :class:`LazyIndexer` object of bool, shape (*T*, *F*, *B*)
-            Array indexer with time along the first dimension, frequency along
-            the second dimension and correlation product ("baseline") index
-            along the third dimension. To get the data array itself from the
-            indexer `x`, do `x[:]` or perform any other form of indexing on it.
-            Only then will data be loaded into memory.
+        The flags data are returned as an array indexer of bool, shape
+        (*T*, *F*, *B*), with time along the first dimension, frequency along the
+        second dimension and correlation product ("baseline") index along the
+        third dimension. The number of integrations *T* matches the length of
+        :meth:`timestamps`, the number of frequency channels *F* matches the
+        length of :meth:`freqs` and the number of correlation products *B*
+        matches the length of :meth:`corr_products`. To get the data array
+        itself from the indexer `x`, do `x[:]` or perform any other form of
+        indexing on it. Only then will data be loaded into memory.
 
         """
-        known_flags = [row[0] for row in self._flags_description]
-
-        names = names.split(',') if isinstance(names, basestring) else known_flags if names is None else names
-
-        # Create index list for desired flags
-        flagmask = np.zeros(8, dtype=np.int)
-        for name in names:
-            try:
-                flagmask[known_flags.index(name)] = 1
-            except ValueError:
-                logger.warning("'%s' is not a legitimate flag type for this file" % (name,))
-        # Pack index list into bit mask
-        flagmask = np.packbits(flagmask)
-        if not flagmask:
-            logger.warning('No valid flags were selected - setting all flags to False by default')
-
-        def _extract_flags(flags, keep):
-            # Ensure that keep tuple has length of 3 (truncate or pad with blanket slices as necessary)
-            keep = keep[:3] + (slice(None),) * (3 - len(keep))
-            # Final indexing ensures that returned data are always 3-dimensional (i.e. keep singleton dimensions)
-            force_3dim = tuple([(np.newaxis if np.isscalar(dim_keep) else slice(None)) for dim_keep in keep])
-            flags_3dim = flags[force_3dim]
-            # Use flagmask to blank out the flags we don't want
-            total_flags = np.bitwise_and(flagmask, flags_3dim)
-            # Convert uint8 to bool: if any flag bits set, flag is set
-            return np.bool_(total_flags)
-        extract_flags = LazyTransform('extract_flags', _extract_flags, dtype=np.bool)
-        return LazyIndexer(self._flags, (self._time_keep, self._freq_keep, self._corrprod_keep),
-                           transforms=[extract_flags])
+        def transform(flags, keep):
+            """Use flagmask to blank out the flags we don't want."""
+            # Then convert uint8 to bool -> if any flag bits set, flag is set
+            return np.bool_(np.bitwise_and(self._flags_select, flags))
+        extract = LazyTransform('extract_flags', transform, dtype=np.bool)
+        return self._vislike_indexer(self._flags, extract)
 
     @property
     def temperature(self):

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -480,8 +480,8 @@ class H5DataV2(DataSet):
         if not hasattr(self, '_flags_description'):
             return []
         known_flags = [row[0] for row in self._flags_description]
-        # Reverse flag indices as np.packbits has bit 0 as the MSB (we want LSB)
-        selection = np.flipud(np.unpackbits(self._flags_select))
+        # The KAT-7 flagger uses the np.packbits convention (bit 0 = MSB) so don't flip
+        selection = np.unpackbits(self._flags_select)
         assert len(known_flags) == len(selection), \
             'Expected %d flag types in file, got %s' % (len(selection), self._flags_description)
         return [name for name, bit in zip(known_flags, selection) if bit]
@@ -506,8 +506,8 @@ class H5DataV2(DataSet):
                 logger.warning("%r is not a legitimate flag type for this file, "
                                "supported ones are %s" % (name, known_flags))
         # Pack index list into bit mask
-        # Reverse flag indices as np.packbits has bit 0 as the MSB (we want LSB)
-        flagmask = np.packbits(np.flipud(selection))
+        # The KAT-7 flagger uses the np.packbits convention (bit 0 = MSB) so don't flip
+        flagmask = np.packbits(selection)
         if known_flags and not flagmask:
             logger.warning('No valid flags were selected - setting all flags to False by default')
         self._flags_select = flagmask

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -134,8 +134,8 @@ class H5DataV3(DataSet):
         Override centre frequency if provided, in Hz
     band : string or None, optional
         Override receiver band if provided (e.g. 'l') - used to find ND models
-    squeeze : {False, True}, optional
-        Don't force vis / weights / flags to be 3-dimensional
+    keepdims : {False, True}, optional
+        Force vis / weights / flags to be 3-dimensional, regardless of selection
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
 
@@ -155,7 +155,7 @@ class H5DataV3(DataSet):
     """
     def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r',
                  time_scale=None, time_origin=None, rotate_bls=False,
-                 centre_freq=None, band=None, squeeze=False, **kwargs):
+                 centre_freq=None, band=None, keepdims=False, **kwargs):
         DataSet.__init__(self, filename, ref_ant, time_offset)
 
         # Load file
@@ -223,7 +223,7 @@ class H5DataV3(DataSet):
         else:
             raise BrokenFile('File contains no visibility data')
         self._timestamps = data_group['timestamps'][:]
-        self._squeeze = squeeze
+        self._keepdims = keepdims
 
         # Resynthesise timestamps from sample counter based on a different scale factor or origin
         old_scale = cbf_group.attrs['scale_factor_timestamp']
@@ -695,7 +695,7 @@ class H5DataV3(DataSet):
         transforms = []
         if extractor:
             transforms.append(extractor)
-        if self._squeeze:
+        if self._keepdims:
             transforms.append(force_full_dim)
         return LazyIndexer(dataset, stage1, transforms)
 

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -75,8 +75,9 @@ parser.add_option("-m", "--model-data", action="store_true", default=False,
                   help="Add MODEL_DATA and CORRECTED_DATA columns to the MS. "
                        "MODEL_DATA initialised to unity amplitude zero phase, "
                        "CORRECTED_DATA initialised to DATA.")
-parser.add_option("--flags",
-                  help="List of online flags to apply (from 'static,cam,detected_rfi,predicted_rfi', "
+parser.add_option("--flags", default="all",
+                  help="List of online flags to apply "
+                       "(from 'static,cam,data_lost,ingest_rfi,cal_rfi,predicted_rfi', "
                        "default is all flags, '' will apply no flags)")
 parser.add_option("--dumptime", type=float, default=0.0,
                   help="Output time averaging interval in seconds, default is no averaging.")
@@ -140,7 +141,7 @@ for win in range(len(h5.spectral_windows)):
     basename = ('%s_%s' % (os.path.splitext(args[0])[0], cen_freq)) + \
                ("." if len(args) == 1 else ".et_al.") + pol_for_name
 
-    h5.select(spw=win, scans='track')
+    h5.select(spw=win, scans='track', flags=options.flags)
 
     # create MS in current working directory
     ms_name = basename + ".ms"
@@ -300,9 +301,9 @@ for win in range(len(h5.spectral_windows)):
         # load all data for this scan up front, as this improves disk throughput
         scan_data = h5.vis[:]
         # load the weights for this scan.
-        scan_weight_data = h5.weights()[:]
+        scan_weight_data = h5.weights[:]
         # load flags selected from 'options.flags' for this scan
-        scan_flag_data = h5.flags(options.flags)[:]
+        scan_flag_data = h5.flags[:]
 
         # Get the average dump time for this scan (equal to scan length if the dump period is longer than a scan)
         dump_time_width = min(time_av, scan_len * h5.dump_period)

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -127,7 +127,7 @@ else:
     plt.figure(1)
     plt.clf()
     ax = plt.subplot(1, 1, 1)
-    im = ResampledImage(d.vis, extract=lambda data, x, y: np.abs(data[y, x, 0][:, :, 0]),
+    im = ResampledImage(d.vis, extract=lambda data, x, y: np.abs(data[y, x, 0]),
                         autoscale=opts.autoscale, ax=ax)
     ax.set_xlabel('Channel index')
     ax.set_ylabel('Dump index')


### PR DESCRIPTION
The main reason for this PR is to support the latest MeerKAT HDF5
files with proper weights. This also allows h5toms to work with these
files (currently broken).

In the process some long-standing warts have been removed in
the vis / weights / flags API. All three attributes are now properties,
where weights and flags used to be methods to allow selection.
The selection is now done via the usual select() call. Flags and
weights have also been properly extended to all file formats.

The `squeeze` parameter on v2 and v3 datasets has been renamed
to `keepdims` to match the corresponding concept in NumPy (and it
now has the opposite sense). Its default behaviour also changed,
so that singleton dimensions are now discarded where indexed away
by default. Use `keepdims=True` to obtain the old behaviour.

There is still a lot of duplication in the code (e.g. between v2 and v3)
but this needs more careful refactoring which is left for another
week.

This addresses JIRA ticket [MKAIV-345](https://skaafrica.atlassian.net/browse/MKAIV-345).

@bmerry gets it because he wrote the weights part on the ingest side...