### PR TITLE
Order dumps by time in h5toms

### DIFF
--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -60,7 +60,7 @@ def block_and_average(vis, weight, flag, avsize, axis=0, flagav=False):
 
     # Workaround for numpy zero weight problem (set blocks with zero weight to weight 1
     # so that an average is returned for these blocks, otherwise numpy returns an error).
-    zeroweights = np.where(np.all(block_flag, axis=-1))
+    zeroweights = np.where(np.all(block_weight==0.0, axis=-1))
     block_weight[zeroweights] = 1.0
 
     # Average the data

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -310,31 +310,6 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     """
     num_vis_samples, num_channels, num_pols = vis_data.shape
     timestamps = np.atleast_1d(np.asarray(timestamps, dtype=np.float64))
-    try:
-        antenna1_index, t = np.broadcast_arrays(np.asarray(antenna1_index, np.int32), timestamps)
-    except ValueError:
-        raise ValueError("Length of 'antenna1_index' should be 1 or %d, is %d instead" %
-                         (num_vis_samples, len(antenna1_index)))
-    try:
-        antenna2_index, t = np.broadcast_arrays(np.asarray(antenna2_index, np.int32), timestamps)
-    except ValueError:
-        raise ValueError("Length of 'antenna2_index' should be 1 or %d, is %d instead" %
-                         (num_vis_samples, len(antenna2_index)))
-    try:
-        field_id, t = np.broadcast_arrays(np.asarray(field_id, np.int32), timestamps)
-    except ValueError:
-        raise ValueError("Length of 'field_id' should be 1 or %d, is %d instead" %
-                         (num_vis_samples, len(field_id)))
-    try:
-        state_id, t = np.broadcast_arrays(np.asarray(state_id, np.int32), timestamps)
-    except ValueError:
-        raise ValueError("Length of 'state_id' should be 1 or %d, is %d instead" %
-                         (num_vis_samples, len(state_id)))
-    try:
-        scan_number, t = np.broadcast_arrays(np.asarray(scan_number, np.int32), timestamps)
-    except ValueError:
-        raise ValueError("Length of 'scan_number' should be 1 or %d, is %d instead" %
-                         (num_vis_samples, len(scan_number)))
 
     main_dict = {}
     # ID of first antenna in interferometer (integer)
@@ -386,7 +361,7 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     # Modified Julian Dates in seconds (double)
     main_dict['TIME_CENTROID'] = timestamps
     # Vector with uvw coordinates (in metres) (double, 1-dim, shape=(3,))
-    main_dict['UVW'] = np.asarray(uvw_coordinates).transpose()
+    main_dict['UVW'] = np.asarray(uvw_coordinates)
     # Weight for each polarisation spectrum (float, 1-dim)
     main_dict['WEIGHT'] = np.ones((num_vis_samples, num_pols), dtype=np.float32)
     return main_dict

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -371,10 +371,10 @@ for win in range(len(h5.spectral_windows)):
         # Iterate over time in some multiple of dump average
         ntime = utc_seconds.size
         tsize = dump_av
+        ntime_av = ntime/tsize
 
-        for ltime in xrange(0, ntime, tsize):
-            utime = min(ltime + tsize, ntime)
-
+        for ltime in xrange(0,ntime-tsize+1,tsize):
+            utime = ltime + tsize
             tdiff = utime - ltime
             out_freqs = h5.channel_freqs
             nchan = out_freqs.size
@@ -482,9 +482,9 @@ for win in range(len(h5.spectral_windows)):
 
 
         s1 = time.time() - s
-        if average_data and np.shape(utc_seconds)[0] != np.shape(out_utc)[0]:
+        if average_data and utc_seconds.shape != ntime_av:
             print "Averaged %s x %s second dumps to %s x %s second dumps" % \
-                  (np.shape(utc_seconds)[0], h5.dump_period, np.shape(out_utc)[0], dump_time_width)
+                  (np.shape(utc_seconds)[0], h5.dump_period, ntime_av, dump_time_width)
         print "Wrote scan data (%f MB) in %f s (%f MBps)\n" % (sz_mb, s1, sz_mb / s1)
         scan_itr += 1
     main_table.close()

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -377,9 +377,10 @@ for win in range(len(h5.spectral_windows)):
         # Iterate over time in some multiple of dump average
         ntime = utc_seconds.size
         tsize = dump_av
-        ntime_av = ntime/tsize
+        ntime_av = 0
 
         for ltime in xrange(0,ntime-tsize+1,tsize):
+
             utime = ltime + tsize
             tdiff = utime - ltime
             out_freqs = h5.channel_freqs
@@ -414,6 +415,9 @@ for win in range(len(h5.spectral_windows)):
 
                 # Infer new time and channel dimensions from averaged data
                 tdiff, nchan = vis_data.shape[0], vis_data.shape[1]
+
+            #Increment the number of averaged dumps
+            ntime_av += tdiff
 
             model_data = None
             corrected_data = None

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -412,9 +412,8 @@ for win in range(len(h5.spectral_windows)):
                     averager.average_visibilities(vis_data, weight_data, flag_data, out_utc, out_freqs,
                                                   timeav=dump_av, chanav=chan_av, flagav=options.flagav)
 
-                # Time and channel dimensions change now
-                tdiff /= dump_av
-                nchan /= chan_av
+                # Infer new time and channel dimensions from averaged data
+                tdiff, nchan = vis_data.shape[0], vis_data.shape[1]
 
             model_data = None
             corrected_data = None

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -370,7 +370,7 @@ for win in range(len(h5.spectral_windows)):
 
         # Iterate over time in some multiple of dump average
         ntime = utc_seconds.size
-        tsize = dump_av*100
+        tsize = dump_av
 
         for ltime in xrange(0, ntime, tsize):
             utime = min(ltime + tsize, ntime)

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -437,13 +437,13 @@ for win in range(len(h5.spectral_windows)):
                 return (array.reshape(S).transpose(0,2,1,3)
                     .reshape(-1,nchan,npol))
 
-            def _create_uvw(a1, a2):
+            def _create_uvw(a1, a2, times):
                 """
-                Return a (ntime, 1, 3) array of UVW coordinates for baseline
+                Return a (ntime, 3) array of UVW coordinates for baseline
                 defined by a1 and a2
                 """
-                uvw = target.uvw(ant2[a2], timestamp=out_utc, antenna=ant1[a1])
-                return np.asarray(uvw).T[:,np.newaxis,:]
+                uvw = target.uvw(a2, timestamp=times, antenna=a1)
+                return np.asarray(uvw).T
 
             # Massage visibility, weight and flag data from
             # (ntime, nchan, nbl*npol) ordering to (ntime*nbl, nchan, npol)
@@ -451,10 +451,10 @@ for win in range(len(h5.spectral_windows)):
                 for a in (vis_data, weight_data, flag_data))
 
             # Iterate through baselines, computing UVW coordinates
-            # and concatenating along baseline.
-            # (ntime*nbl, 3)
-            uvw_coordinates = np.concatenate([_create_uvw(a1, a2)
-                for a1, a2 in itertools.izip(ant1_index, ant2_index)],
+            # for a chunk of timesteps
+            uvw_coordinates = np.concatenate([
+              _create_uvw(a1, a2, out_utc)[:,np.newaxis,:]
+              for a1, a2 in itertools.izip(ant1, ant2)],
                 axis=1).reshape(-1, 3)
 
             # Convert averaged UTC timestamps to MJD seconds.

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -371,12 +371,13 @@ for win in range(len(h5.spectral_windows)):
         # Iterate over time in some multiple of dump average
         ntime = utc_seconds.size
         tsize = dump_av*100
-        out_freqs = h5.channel_freqs
-        nchan = out_freqs.size
 
         for ltime in xrange(0, ntime, tsize):
             utime = min(ltime + tsize, ntime)
+
             tdiff = utime - ltime
+            out_freqs = h5.channel_freqs
+            nchan = out_freqs.size
 
             # load all visibility, weight and flag data
             # for this scan's timestamps.


### PR DESCRIPTION
Previously when handling a scan, h5toms would iterate over antenna pairs, handling all time, frequency and polarisation data for the associated baseline. This meant that data would be written to the Measurement Set in baseline ordering, rather than the more natural time ordering.

This commit modifies h5toms.py to iterate over chunks of time within a scan, thereby ordering
the MS by time. The time chunk size is chosen as a multiple of the time dump average.