### PR TITLE
Fix band selection after intro of cam2telstate

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -402,7 +402,10 @@ class H5DataV3(DataSet):
         if not band and 'TelescopeState' in f.file:
             try:
                 band = f.file['TelescopeState'].attrs['sub_band']
-            except KeyError:
+                # The telstate attributes were serialised via str() until 2016-11-29
+                if band not in ('l', 's', 'u', 'x'):
+                    band = pickle.loads(band)
+            except (KeyError, pickle.UnpicklingError):
                 try:
                     band = self.sensor['TelescopeState/sub_band'][-1]
                 except KeyError:


### PR DESCRIPTION
Two things changed in the new cam2telstate world:

  - The sub sensors become telstate attributes as they should be
    (previously these were flip-flopping between attrs and sensors)
  - Like sensors their values are stored as pickles instead of str()s

This lets katdal deal with the new reality, specifically getting
a decent band value from the sub_band sensor to get the centre
frequency right.