### PR TITLE
Correct creation of model and corrected data

### DIFF
--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -421,14 +421,6 @@ for win in range(len(h5.spectral_windows)):
             #Increment the number of averaged dumps
             ntime_av += tdiff
 
-            model_data = None
-            corrected_data = None
-            if options.model_data:
-                # unity intensity zero phase model data set, same shape as vis_data
-                model_data = np.ones(vis_data.shape, dtype=np.complex64)
-                # corrected data set copied from vis_data
-                corrected_data = vis_data
-
             def _separate_baselines_and_pols(array):
                 """
                 (1) Separate correlator product into baseline and polarisation,
@@ -474,6 +466,16 @@ for win in range(len(h5.spectral_windows)):
             big_field_id = np.full((tdiff*nbl,), field_id, dtype=np.int32)
             big_state_id = np.full((tdiff*nbl,), state_id, dtype=np.int32)
             big_scan_itr = np.full((tdiff*nbl,), scan_itr, dtype=np.int32)
+
+            # Setup model_data and corrected_data if required
+            model_data = None
+            corrected_data = None
+
+            if options.model_data:
+                # unity intensity zero phase model data set, same shape as vis_data
+                model_data = np.ones(vis_data.shape, dtype=np.complex64)
+                # corrected data set copied from vis_data
+                corrected_data = vis_data
 
             # write the data to the ms.
             main_dict = ms_extra.populate_main_dict(uvw_coordinates, vis_data, flag_data,


### PR DESCRIPTION
https://github.com/ska-sa/katdal/pull/64 modified h5toms to output visibility data in time ordered format. The optional creation of MODEL_DATA and CORRECTED_DATA columns was not modified to handle this new ordering, leading to table conformance errors caused by incorrectly shaped arrays.

This commit moves the creation MODEL_DATA and CORRECTED_DATA forward in the script to the point where the shape of vis_data has been reshaped into the expected (ntime\*nbl, nchan, npol) ordering, instead of the previous location where the shape of vis_data was (ntime, nchan, nbl\*npol).