### PR TITLE
Use python-casacore's pending MeasurementSet creation functionality for creating Fixed Shape columns

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+0.9 (xxxx-yy-zz)
+----------------
+* Utilise python-casacore and casacore internals to create Measurement Sets,
+  rather than conditioning blank.ms. Requires casacore 2.3.0 and
+  python-casacore 2.2.1.
+
 0.8 (2017-08-08)
 ----------------
 * Fix upside-down MeerKAT images

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -116,10 +116,10 @@ def kat_ms_desc(nflagcat, nchan, ncorr):
 
     table_desc = {
         'WEIGHT': tiled_array("Weight for each polarization spectrum",
-                            'float', 1, 'WeightHyperColumn', shape=[nchan]),
+                            'float', 1, 'WeightHyperColumn', shape=[ncorr]),
         'SIGMA': tiled_array("Estimated rms noise for channel "
                             "with unity bandpass response",
-                            'float', 1, 'SigmaHyperColumn', shape=[nchan]),
+                            'float', 1, 'SigmaHyperColumn', shape=[ncorr]),
         'IMAGING_WEIGHT': tiled_array("Weight set by imaging task "
                             "(e.g. uniform weighting)",
                             'float', 1, 'ImagingWeightHyperColumn', shape=[nchan]),

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -715,7 +715,7 @@ def populate_source_dict(phase_centers, time_origins, center_frequencies, field_
     completeness it is included here (with no time varying terms).
     """
     num_channels = len(center_frequencies)
-    phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))[:, np.newaxis, :]
+    phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))
     num_fields = len(phase_centers)
     if field_names is None:
         field_names = ['Source%d' % (field,) for field in range(num_fields)]

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -25,6 +25,7 @@ This can use either casapy (the default) or pyrap to create the MS.
 #
 
 import sys
+import os
 import os.path
 from copy import deepcopy
 
@@ -118,7 +119,7 @@ def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
 
     def dmspec(shape, extra_shape):
         """
-        Create data manager spec, mostly be adding a DEFAULTTILESHAPE
+        Create data manager spec, mostly by adding a DEFAULTTILESHAPE
         composed of reversed shape with extra_shape appended to it.
         """
         rs = list(reversed(shape)) # Reverse, annoying
@@ -272,7 +273,11 @@ elif casacore_binding == 'pyrap':
         return t if type(t) == tables.table else None
 
     def create_ms(filename, table_desc=None, dm_info=None):
-        tables.default_ms(filename, table_desc, dm_info)
+        with tables.default_ms(filename, table_desc, dm_info) as T:
+            # Add the SOURCE subtable
+            source_filename = os.path.join(os.getcwd(), filename, "SOURCE")
+            tables.default_ms_subtable("SOURCE", source_filename)
+            T.putkeyword("SOURCE", "Table: %s" % source_filename)
 
 else:
     def open_table(filename, readonly=False):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -290,7 +290,7 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     # Sequential scan number from on-line system (integer)
     main_dict['SCAN_NUMBER'] = scan_number
     # Estimated rms noise for channel with unity bandpass response (float, 1-dim)
-    main_dict['SIGMA'] = np.ones((num_vis_samples, num_channels), dtype=np.float32)
+    main_dict['SIGMA'] = np.ones((num_vis_samples, num_pols), dtype=np.float32)
     # ID for this observing state (integer)
     main_dict['STATE_ID'] = state_id
     # Modified Julian Dates in seconds (double)
@@ -300,7 +300,7 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     # Vector with uvw coordinates (in metres) (double, 1-dim, shape=(3,))
     main_dict['UVW'] = np.asarray(uvw_coordinates)
     # Weight for each polarisation spectrum (float, 1-dim)
-    main_dict['WEIGHT'] = np.ones((num_vis_samples, num_channels), dtype=np.float32)
+    main_dict['WEIGHT'] = np.ones((num_vis_samples, num_pols), dtype=np.float32)
     return main_dict
 
 

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -96,153 +96,55 @@ def define_hypercolumn(desc):
                                           dict(HCdatanames=[k], HCndim=v['ndim'] + 1))
                                          for k, v in desc.iteritems() if v['dataManagerType'] == 'TiledShapeStMan'])
 
-ms_desc = {}
+def kat_ms_desc(nflagcat, nchan, ncorr):
+    """
+    Creates additional columns and hypercolumns for creating a MeasurementSet
+    suitable for holding MeerKAT data.
 
-ms_desc['MAIN'] = {
-    'ANTENNA1': std_scalar('ID of first antenna in interferometer'),
-    'ANTENNA2': std_scalar('ID of second antenna in interferometer'),
-    'ARRAY_ID': std_scalar('ID of array or subarray'),
-    'CORRECTED_DATA': tiled_array('The corrected data column', 'complex', 2, 'CorrectedDataColumn'),
-    'DATA': tiled_array('The data column', 'complex', 2, 'dataHyperColumn'),
-    'DATA_DESC_ID': std_scalar('The data description table index'),
-    'EXPOSURE': std_scalar('The effective integration time', 'double'),
-    'FEED1': std_scalar('The feed index for ANTENNA1'),
-    'FEED2': std_scalar('The feed index for ANTENNA2'),
-    'FIELD_ID': std_scalar('Unique id for this pointing'),
-    'FLAG': tiled_array('The data flags, array of bools with same shape as data', 'boolean', 2, 'FlagColumn'),
-    'FLAG_CATEGORY': tiled_array('The flag category, NUM_CAT flags for each datum', 'boolean', 3, 'flagHyperColumn'),
-    'FLAG_ROW': std_scalar('Row flag - flag all data in this row if True', valueType='boolean'),
-    'IMAGING_WEIGHT': tiled_array('Weight set by imaging task (e.g. uniform weighting)',
-                                  'float', 1, 'imWeightHyperColumn'),
-    'INTERVAL': std_scalar('The sampling interval', 'double'),
-    'MODEL_DATA': tiled_array('The model data column', 'complex', 2, 'ModelDataColumn'),
-    'OBSERVATION_ID': std_scalar('ID for this observation, index in OBSERVATION table'),
-    'PROCESSOR_ID': std_scalar('Id for backend processor, index in PROCESSOR table'),
-    'SCAN_NUMBER': std_scalar('Sequential scan number from on-line system'),
-    'SIGMA': tiled_array('Estimated rms noise for channel with unity bandpass response', 'float', 1, 'SigmaColumn'),
-    'STATE_ID': std_scalar('ID for this observing state'),
-    'TIME': std_scalar('Modified Julian Day', 'double'),
-    'TIME_CENTROID': std_scalar('Modified Julian Day', 'double'),
-    'UVW': fixed_array('Vector with uvw coordinates (in meters)', 'double', [3]),
-    'WEIGHT': tiled_array('Weight for each polarization spectrum', 'float', 1, 'WeightColumn'),
-}
+    Columns are given fixed shapes in terms of the arguments to this function.
+    Hypercolumns are defined over them.
 
-ms_desc['ANTENNA'] = {
-    'DISH_DIAMETER': std_scalar('Physical diameter of dish', 'double'),
-    'FLAG_ROW': std_scalar('Flag for this row', 'boolean'),
-    'MOUNT': std_scalar('Mount type e.g. alt-az, equatorial, etc.', 'string'),
-    'NAME': std_scalar('Antenna name, e.g. VLA22, CA03', 'string'),
-    'OFFSET': fixed_array('Axes offset of mount to FEED REFERENCE point', 'double', [3]),
-    'POSITION': fixed_array('Antenna X,Y,Z phase reference position', 'double', [3]),
-    'STATION': std_scalar('Station (antenna pad) name', 'string'),
-    'TYPE': std_scalar('Antenna type (e.g. SPACE-BASED)', 'string'),
-}
+    Columns are DATA, MODEL_DATA, CORRECTED_DATA, FLAG,
+    FLAG_CATEGORY, WEIGHT, SIGMA, IMAGING_WEIGHT.
 
-ms_desc['FEED'] = {
-    'ANTENNA_ID': std_scalar('ID of antenna in this array'),
-    'BEAM_ID': std_scalar('Id for BEAM model'),
-    'BEAM_OFFSET': std_array('Beam position offset (on sky but in antennareference frame)', 'double', 2),
-    'FEED_ID': std_scalar('Feed id'),
-    'INTERVAL': std_scalar('Interval for which this set of parameters is accurate', 'double'),
-    'NUM_RECEPTORS': std_scalar('Number of receptors on this feed (probably 1 or 2'),
-    'POLARIZATION_TYPE': std_array('Type of polarization to which a given RECEPTOR responds', 'string', 1),
-    'POL_RESPONSE': std_array('D-matrix i.e. leakage between two receptors', 'complex', 2),
-    'POSITION': fixed_array('Position of feed relative to feed reference position', 'double', [3]),
-    'RECEPTOR_ANGLE': std_array('The reference angle for polarization', 'double', 1),
-    'SPECTRAL_WINDOW_ID': std_scalar('ID for this spectral window setup'),
-    'TIME': std_scalar('Midpoint of time for which this set of parameters is accurate', 'double'),
-}
+    :param nflagcat: Number of flag categories. 1 is a sensible option here.
+    :param nchan: Number of channels.
+    :param ncorr: Number of correlations.
+    :return: Returns a table description describing the extra columns and
+             hypercolumns
+    """
 
-ms_desc['DATA_DESCRIPTION'] = {
-    'FLAG_ROW': std_scalar('Flag this row', 'boolean'),
-    'POLARIZATION_ID': std_scalar('Pointer to polarization table'),
-    'SPECTRAL_WINDOW_ID': std_scalar('Pointer to spectralwindow table'),
-}
+    table_desc = {
+        'WEIGHT': tiled_array("Weight for each polarization spectrum",
+                            'float', 1, 'WeightColumn', shape=[nchan]),
+        'SIGMA': tiled_array("Estimated rms noise for channel "
+                            "with unity bandpass response",
+                            'float', 1, 'SigmaColumn', shape=[nchan]),
+        'IMAGING_WEIGHT': tiled_array("Weight set by imaging task "
+                            "(e.g. uniform weighting)",
+                            'float', 1, 'imWeightHyperColumn', shape=[nchan]),
+        'DATA': tiled_array("The data column",
+                            'complex', 2, 'dataHyperColumn',
+                            shape=[nchan, ncorr]),
+        'MODEL_DATA': tiled_array("The model data column",
+                            'complex', 2, 'ModelDataColumn',
+                            shape=[nchan, ncorr]),
+        'CORRECTED_DATA': tiled_array("The corrected data column",
+                            'complex', 2, 'CorrectedDataColumn',
+                            shape=[nchan, ncorr]),
+        'FLAG': tiled_array("The data flags, "
+                            "array of bools with same shape as data",
+                            'boolean', 2, 'FlagColumn',
+                            shape=[nchan, ncorr]),
+        'FLAG_CATEGORY': tiled_array("The flag category, "
+                            "NUM_CAT flags for each datum",
+                            'boolean', 3, 'flagHyperColumn',
+                            shape=[nflagcat, nchan, ncorr]),
+    }
 
-ms_desc['POLARIZATION'] = {
-    'CORR_PRODUCT': std_array('Indices describing receptors of feed going into correlation', 'integer', 2),
-    'CORR_TYPE': std_array('The polarization type for each correlation product, as a Stokes enum.', 'integer', 1),
-    'FLAG_ROW': std_scalar('Row flag', 'boolean'),
-    'NUM_CORR': std_scalar('Number of correlation products'),
-}
+    define_hypercolumn(table_desc)
 
-ms_desc['OBSERVATION'] = {
-    'FLAG_ROW': std_scalar('Row flag', 'boolean'),
-    'LOG': std_array('Observing log', 'string', 1),
-    'PROJECT': std_scalar('Project identification string', 'string'),
-    'OBSERVER': std_scalar('Name of observer(s)', 'string'),
-    'RELEASE_DATE': std_scalar('Release date when data becomes public', 'double'),
-    'SCHEDULE': std_array('Observing schedule', 'string', 1),
-    'SCHEDULE_TYPE': std_scalar('Observing schedule type', 'string'),
-    'TELESCOPE_NAME': std_scalar('Telescope Name (e.g. WSRT, VLBA)', 'string'),
-    'TIME_RANGE': fixed_array('Start and end of observation', 'double', [2]),
-}
-
-ms_desc['SPECTRAL_WINDOW'] = {
-    'CHAN_FREQ': std_array('Center frequencies for each channel in the data matrix', 'double', 1),
-    'CHAN_WIDTH': std_array('Channel width for each channel', 'double', 1),
-    'EFFECTIVE_BW': std_array('Effective noise bandwidth of each channel', 'double', 1),
-    'FLAG_ROW': std_scalar('Row flag', 'boolean'),
-    'FREQ_GROUP': std_scalar('Frequency group'),
-    'FREQ_GROUP_NAME': std_scalar('Frequency group name', 'string'),
-    'IF_CONV_CHAIN': std_scalar('The IF conversion chain number'),
-    'MEAS_FREQ_REF': std_scalar('Frequency Measure reference'),
-    'NAME': std_scalar('Spectral window name', 'string'),
-    'NET_SIDEBAND': std_scalar('Net sideband'),
-    'NUM_CHAN': std_scalar('Number of spectral channels'),
-    'REF_FREQUENCY': std_scalar('The reference frequency', 'double'),
-    'RESOLUTION': std_array('The effective noise bandwidth for each channel', 'double', 1),
-    'TOTAL_BANDWIDTH': std_scalar('The total bandwidth for this window', 'double'),
-}
-
-ms_desc['FIELD'] = {
-    'CODE': std_scalar('Special characteristics of field, e.g. Bandpass calibrator', 'string'),
-    'DELAY_DIR': std_array('Direction of delay center (e.g. RA, DEC)as polynomial in time.', 'double', 2),
-    'FLAG_ROW': std_scalar('Row Flag', 'boolean'),
-    'NAME': std_scalar('Name of this field', 'string'),
-    'NUM_POLY': std_scalar('Polynomial order of _DIR columns'),
-    'PHASE_DIR': std_array('Direction of phase center (e.g. RA, DEC).', 'double', 2),
-    'REFERENCE_DIR': std_array('Direction of REFERENCE center (e.g. RA, DEC).as polynomial in time.', 'double', 2),
-    'SOURCE_ID': std_scalar('Source id'),
-    'TIME': std_scalar('Time origin for direction and rate', 'double'),
-}
-
-ms_desc['STATE'] = {
-    'SIG': std_scalar('True if the source signal is being observed.'),
-    'REF': std_scalar('True for a reference phase.'),
-    'CAL': std_scalar('Noise calibration temperature (zero if not added).'),
-    'LOAD': std_scalar('Load temperature (zero if no load).'),
-    'SUB_SCAN': std_scalar('Sub-scan number, relative to the SCAN_NUMBER in MAIN.'),
-    'OBS_MODE': std_scalar('Observing mode, defined by a set of reserved keywords.'),
-    'FLAG_ROW': std_scalar('Row Flag', 'boolean'),
-}
-
-ms_desc['SOURCE'] = {
-    'DIRECTION': std_array('Source direction at specified time', 'double', 2),
-    'PROPER_MOTION': std_array('Source proper motion at specified time', 'double', 2),
-    'SOURCE_ID': std_scalar('Source identifier as specified in FIELD table', 'integer'),
-    'TIME': std_scalar('Mid point of time interval for which this row is valid', 'double'),
-    'CALIBRATION_GROUP': std_scalar('Cal group to which this source belongs', 'integer'),
-    'NAME': std_scalar('Name of this source', 'string'),
-    'NUM_LINES': std_scalar('Number of line transitions associated with this source', 'integer'),
-    'REST_FREQUENCY': std_scalar('Rest frequency of line', 'double'),
-    'SYSVEL': std_scalar('Systemic velocity of line', 'double'),
-}
-
-ms_desc['POINTING'] = {
-    'ANTENNA_ID': std_scalar('Antenna Id'),
-    'DIRECTION': std_array('Antenna pointing direction as polynomial in time', 'double', 2),
-    'INTERVAL': std_scalar('Time interval', 'double'),
-    'NAME': std_scalar('Pointing position name', 'string'),
-    'NUM_POLY': std_scalar('Series order'),
-    'TARGET': std_array('target direction as polynomial in time', 'double', -1),
-    'TIME': std_scalar('Time interval midpoint', 'double'),
-    'TIME_ORIGIN': std_scalar('Time origin for direction', 'double'),
-    'TRACKING': std_scalar('Tracking flag - True if on position', 'boolean'),
-}
-
-for sub_table in ms_desc:
-    define_hypercolumn(ms_desc[sub_table])
+    return table_desc
 
 caltable_desc = {}
 caltable_desc['TIME'] = std_scalar('Timestamp of solution', 'double', option=5)

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -377,7 +377,7 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     # Sequential scan number from on-line system (integer)
     main_dict['SCAN_NUMBER'] = scan_number
     # Estimated rms noise for channel with unity bandpass response (float, 1-dim)
-    main_dict['SIGMA'] = np.ones((num_vis_samples, num_pols), dtype=np.float32)
+    main_dict['SIGMA'] = np.ones((num_vis_samples, num_channels), dtype=np.float32)
     # ID for this observing state (integer)
     main_dict['STATE_ID'] = state_id
     # Modified Julian Dates in seconds (double)
@@ -387,7 +387,7 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, timestamps, antenna
     # Vector with uvw coordinates (in metres) (double, 1-dim, shape=(3,))
     main_dict['UVW'] = np.asarray(uvw_coordinates)
     # Weight for each polarisation spectrum (float, 1-dim)
-    main_dict['WEIGHT'] = np.ones((num_vis_samples, num_pols), dtype=np.float32)
+    main_dict['WEIGHT'] = np.ones((num_vis_samples, num_channels), dtype=np.float32)
     return main_dict
 
 

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -116,29 +116,29 @@ def kat_ms_desc(nflagcat, nchan, ncorr):
 
     table_desc = {
         'WEIGHT': tiled_array("Weight for each polarization spectrum",
-                            'float', 1, 'WeightColumn', shape=[nchan]),
+                            'float', 1, 'WeightHyperColumn', shape=[nchan]),
         'SIGMA': tiled_array("Estimated rms noise for channel "
                             "with unity bandpass response",
-                            'float', 1, 'SigmaColumn', shape=[nchan]),
+                            'float', 1, 'SigmaHyperColumn', shape=[nchan]),
         'IMAGING_WEIGHT': tiled_array("Weight set by imaging task "
                             "(e.g. uniform weighting)",
-                            'float', 1, 'imWeightHyperColumn', shape=[nchan]),
+                            'float', 1, 'ImagingWeightHyperColumn', shape=[nchan]),
         'DATA': tiled_array("The data column",
-                            'complex', 2, 'dataHyperColumn',
+                            'complex', 2, 'DataHyperColumn',
                             shape=[nchan, ncorr]),
         'MODEL_DATA': tiled_array("The model data column",
-                            'complex', 2, 'ModelDataColumn',
+                            'complex', 2, 'ModelDataHyperColumn',
                             shape=[nchan, ncorr]),
         'CORRECTED_DATA': tiled_array("The corrected data column",
-                            'complex', 2, 'CorrectedDataColumn',
+                            'complex', 2, 'CorrectedDataHyperColumn',
                             shape=[nchan, ncorr]),
         'FLAG': tiled_array("The data flags, "
                             "array of bools with same shape as data",
-                            'boolean', 2, 'FlagColumn',
+                            'boolean', 2, 'FlagHyperColumn',
                             shape=[nchan, ncorr]),
         'FLAG_CATEGORY': tiled_array("The flag category, "
                             "NUM_CAT flags for each datum",
-                            'boolean', 3, 'flagHyperColumn',
+                            'boolean', 3, 'FlagCategoryHyperColumn',
                             shape=[nflagcat, nchan, ncorr]),
     }
 

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -44,26 +44,6 @@ except:
     except ImportError:
         casacore_binding = ''
 
-# Table descriptions for the standard MS tables
-# ---------------------------------------------
-# These dicts are used to create a new MS via pyrap. They are obtained by first
-# creating a blank MS in CASA, using::
-#
-#   sm.open('blank.ms')
-#   sm.close()
-#
-# The structure of this MS is then extracted in pyrap by getting the description
-# of the MAIN and sub-tables::
-#
-#   import pyrap.tables as tables
-#   import os
-#   ms_name = 'blank.ms'
-#   ms_desc = {'MAIN' : tables.table(ms_name).getdesc(actual=False)}
-#   for sub_table in os.walk(ms_name).next()[1]:
-#       ms_desc[sub_table] = tables.table(os.path.join(ms_name, sub_table)).getdesc(actual=False)
-#   ...
-#
-
 
 def std_scalar(comment, valueType='integer', option=0, **kwargs):
     """Description for standard scalar column."""
@@ -113,6 +93,9 @@ def kat_ms_desc(nflagcat, nchan, ncorr):
     :return: Returns a table description describing the extra columns and
              hypercolumns
     """
+
+    if not casacore_binding == 'pyrap':
+
 
     table_desc = {
         'WEIGHT': tiled_array("Weight for each polarization spectrum",

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -93,7 +93,7 @@ def tiled_array(comment, valueType, ndim, dataManagerGroup, **kwargs):
 def define_hypercolumn(desc):
     """Add hypercolumn definitions to table description."""
     desc['_define_hypercolumn_'] = dict([(v['dataManagerGroup'],
-                                          dict(HCdatanames=[k], HCndim=v['ndim'] + 1, HCcoordnames=[], HCidnames=[]))
+                                          dict(HCdatanames=[k], HCndim=v['ndim'] + 1))
                                          for k, v in desc.iteritems() if v['dataManagerType'] == 'TiledShapeStMan'])
 
 ms_desc = {}

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -192,6 +192,7 @@ def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
     dm_group = 'FlagCategory'
     shape = [1, nchan, ncorr]
     extra_table_desc["FLAG_CATEGORY"].update(options=4,
+        keywords={},
         shape=shape, ndim=len(shape),
         dataManagerGroup=dm_group,
         dataManagerType='TiledColumnStMan')

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -174,15 +174,26 @@ if casacore_binding == 'casapy':
         success = tb.open(filename, nomodify=readonly, **kwargs)
         return tb if success else None
 
+    def create_ms(filename):
+        raise NotImplementedError("create_ms not implemented for casapy")
+
 elif casacore_binding == 'pyrap':
     def open_table(filename, readonly=False, ack=False, **kwargs):
         t = tables.table(filename, readonly=readonly, ack=ack, **kwargs)
 
         return t if type(t) == tables.table else None
 
+    def create_ms(filename, table_desc=None):
+        tables.default_ms(filename, table_desc)
+
 else:
     def open_table(filename, readonly=False):
-        raise ImportError("Cannot open MS '%s', as neither casapy nor pyrap were found" % (filename,))
+        raise NotImplementedError("Cannot open MS '%s', as neither "
+                                    "casapy nor pyrap were found" % (filename,))
+
+    def create_ms(filename):
+        raise NotImplementedError("Cannot create MS '%s', as neither "
+                                    "casapy nor pyrap were found" % (filename,))
 
 
 # -------- Routines that create MS data structures in dictionaries -----------

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -403,11 +403,9 @@ for win in range(len(h5.spectral_windows)):
         field_id = field_names.index(target.name)
 
         # Determine the observation tag for this scan
-        obs_tag = []
-        for tag in target.tags:
-            if tag in tag_to_intent:
-                obs_tag.append(tag_to_intent[tag])
-        obs_tag = ','.join(obs_tag)
+        obs_tag = ','.join(tag_to_intent[tag] for tag in target.tags
+                                            if tag in tag_to_intent)
+
         # add tag to obs_modes list
         if obs_tag and obs_tag not in obs_modes:
             obs_modes.append(obs_tag)

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -345,8 +345,9 @@ for win in range(len(h5.spectral_windows)):
     total_size = 0
 
     # Create the MeasurementSet
-    table_desc = ms_extra.kat_ms_desc(nflagcat=1, nchan=nchan, ncorr=npol)
-    ms_extra.create_ms(ms_name, table_desc)
+    table_desc, dminfo = ms_extra.kat_ms_desc_and_dminfo(nbl=nbl,
+      nchan=nchan, ncorr=npol, model_data=options.model_data)
+    ms_extra.create_ms(ms_name, table_desc, dminfo)
 
     #  prepare to write main dict
     main_table = ms_extra.open_main(ms_name, verbose=options.verbose)

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -218,11 +218,6 @@ for win in range(len(h5.spectral_windows)):
     # The first step is to copy the blank template MS to our desired output (making sure it's not already there)
     if os.path.exists(ms_name):
         raise RuntimeError("MS '%s' already exists - please remove it before running this script" % (ms_name,))
-    try:
-        shutil.copytree(options.blank_ms, ms_name)
-    except OSError:
-        raise RuntimeError("Failed to copy blank MS from %s to %s - please check presence "
-                           "of blank MS and/or permissions" % (options.blank_ms, ms_name))
 
     print "Will create MS output in", ms_name
 

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -148,17 +148,16 @@ def corrprod_index_and_missing_mask(h5):
   npol = len(pols_to_use)
 
   # Create actual correlator product index
-  cp_index = np.asarray([_cp_index(a1, a2, p)
-                         for a1, a2 in itertools.izip(ant1, ant2)
-                         for p in pols_to_use])
+  cp_index = [_cp_index(a1, a2, p)
+                 for a1, a2 in itertools.izip(ant1, ant2)
+                 for p in pols_to_use]
 
   # Identify missing correlator products
-  # Reshape for broadcast on time and frequency dimensions
   missing_cp = np.logical_not([i is not None for i in cp_index])
-
-  # Zero any None indices, but use the above masks to reason
-  # about there existence in later code
-  cp_index[missing_cp] = 0
+  
+  # Now create ndarray containing all integers
+  # missing_cp will be used to identify bad entries
+  cp_index = np.asarray([i if i else 0 for i in cp_index])
 
   CPInfo = namedtuple("CPInfo", ["ant1_index", "ant2_index",
                                 "ant1", "ant2",

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -273,18 +273,22 @@ for win in range(len(h5.spectral_windows)):
     # Are we averaging?
     average_data = False
 
+    # Determine the number of channels
+    nchan = len(h5.channels)
+
     # Work out channel average and frequency increment
     if options.chanbin > 1:
         average_data = True
         # Check how many channels we are dropping
-        numchans = len(h5.channels)
-        chan_remainder = numchans % options.chanbin
+        chan_remainder = nchan % options.chanbin
+        avg_nchan = int(nchan / min(nchan, options.chanbin))
         print "Averaging %s channels, output ms will have %s channels." % \
-              (options.chanbin, int(numchans / min(numchans, options.chanbin)))
+              (options.chanbin, avg_nchan)
         if chan_remainder > 0:
             print "The last %s channels in the data will be dropped during averaging " \
-                  "(%s does not divide %s)." % (chan_remainder, options.chanbin, numchans)
+                  "(%s does not divide %s)." % (chan_remainder, options.chanbin, nchan)
         chan_av = options.chanbin
+        nchan = avg_nchan
     else:
         # No averaging in channel
         chan_av = 1
@@ -334,7 +338,6 @@ for win in range(len(h5.spectral_windows)):
 
     cp_info = corrprod_index_and_missing_mask(h5)
     nbl = cp_info.ant1_index.size
-    nchan = h5.channel_freqs.size
     npol = len(pols_to_use)
 
     field_names, field_centers, field_times = [], [], []

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -514,11 +514,13 @@ for win in range(len(h5.spectral_windows)):
                 # corrected data set copied from vis_data
                 corrected_data = vis_data
 
-            # write the data to the ms.
-            main_dict = ms_extra.populate_main_dict(uvw_coordinates, vis_data, flag_data,
-                                                    out_mjd, a1, a2,
-                                                    dump_time_width, big_field_id, big_state_id,
-                                                    big_scan_itr, model_data, corrected_data)
+            # Populate dictionary for write to MS
+            main_dict = ms_extra.populate_main_dict(uvw_coordinates, vis_data,
+                                flag_data, out_mjd, a1, a2,
+                                dump_time_width, big_field_id, big_state_id,
+                                big_scan_itr, model_data, corrected_data)
+
+            # Write data to MS.
             ms_extra.write_rows(main_table, main_dict, verbose=options.verbose)
 
             # Calculate bytes written from the summed arrays in the dict
@@ -526,17 +528,23 @@ for win in range(len(h5.spectral_windows)):
                               if isinstance(a, np.ndarray))
 
         s1 = time.time() - s
+
         if average_data and utc_seconds.shape != ntime_av:
-            print "Averaged %s x %s second dumps to %s x %s second dumps" % \
-                  (np.shape(utc_seconds)[0], h5.dump_period, ntime_av, dump_time_width)
+            print "Averaged %s x %s second dumps to %s x %s second dumps" % (
+                                    np.shape(utc_seconds)[0], h5.dump_period,
+                                    ntime_av, dump_time_width)
 
         scan_size_mb = float(scan_size) / (1024**2)
-        print "Wrote scan data (%f MB) in %f s (%f MBps)\n" % (scan_size_mb, s1, scan_size_mb / s1)
+
+        print "Wrote scan data (%f MB) in %f s (%f MBps)\n" % (
+                                    scan_size_mb, s1, scan_size_mb / s1)
+
         scan_itr += 1
         total_size += scan_size
 
     if total_size == 0:
-        raise RuntimeError("No usable data found in HDF5 file (pick another reference antenna, maybe?)")
+        raise RuntimeError("No usable data found in HDF5 file "
+                           "(pick another reference antenna, maybe?)")
 
     # Remove spaces from source names, unless otherwise specified
     field_names = [f.replace(' ', '') for f in field_names] if not options.keep_spaces else field_names


### PR DESCRIPTION
Previously, h5toms created variable length data columns when creating a MeasurementSet. Catering for this variability means the MS's are not performant. This PR 

1. Modifies h5toms to use python-casacore's upcoming functionality for creating canonical Measurement Set's. This removes the need to maintain table definitions for the MS within katdal.
2. Modfies h5toms to define fixed shape columns for `DATA`, `MODEL_DATA`, `CORRECTED_DATA`, `FLAG`, `FLAG_CATEGORY`, `IMAGING_WEIGHTS`, `WEIGHTS` and `SIGMA`, as well as the original hypercolumn definitions that were bases on these columns.

Depends on https://github.com/casacore/python-casacore/pull/72.