### PR TITLE
Don't crash if CBF reports a different number of channels to the data shape

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -476,8 +476,10 @@ class H5DataV3(DataSet):
         # XXX Cater for future narrowband mode, at some stage
         num_chans = cbf_group.attrs['n_chans']
         if num_chans != self._vis.shape[1]:
-            raise BrokenFile('Number of channels received from correlator '
-                             '(%d) differs from number of channels in data (%d)' % (num_chans, self._vis.shape[1]))
+            logger.warning('Number of channels received from correlator (%d) differs '
+                           'from number of channels in data (%d) - trusting the latter',
+                           num_chans, self._vis.shape[1])
+            num_chans = self._vis.shape[1]
         bandwidth = cbf_group.attrs['bandwidth']
         # Work around a bc856M4k CBF bug active from 2016-04-28 to 2016-06-01 that got the bandwidth wrong
         if bandwidth == 857152196.0:


### PR DESCRIPTION
Since [MRTS-373](https://skaafrica.atlassian.net/browse/MRTS-373) the SDP ingest can select a subset of channels to avoid huge data files for RTS holography.

The problem is that katdal checks the actual number of channels against CBF's idea and crashes on a mismatch. Soften this to a warning instead and invalidate the centre frequency for now (we don't have a nice way to get the output channel range except for digging around in telstate).

Tested on 1487169336.h5 - attaching the result...
![reduced_channels](https://cloud.githubusercontent.com/assets/392144/22981400/fe25f948-f3a4-11e6-9ec3-3536b35abcea.png)

