### PR TITLE
Make katdal work with ipdb

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -235,7 +235,7 @@ try:
 except NameError:
     # IPython 0.10 and below (or normal Python shell)
     _ip = __builtins__.get('__IPYTHON__')
-if _ip is not None:
+if hasattr(_ip, 'set_hook'):
     _ip.set_hook('complete_command', _sensor_completer, re_key=r"(?:.*\=)?(.+?)\[")
 
 


### PR DESCRIPTION
When ipdb is running, _ip ends up being a boolean rather than a handle
to IPython. Calling set_hook thus crashes.