### PR TITLE
Single pol

### DIFF
--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -119,7 +119,8 @@ h5 = katdal.open(args, ref_ant=options.ref_ant)
 pols_in_file = list(np.unique([(cp[0][-1] + cp[1][-1]).upper() for cp in h5.corr_products]))
 
 #Which polarisation do we want to write into the MS
-#all possible pols if full-pol selected, otherwise the selected polarisations via pols_to_use.
+#all possible pols if full-pol selected, otherwise the selected polarisations via pols_to_use
+#finally select any of HH,VV present (the default).
 pols_to_use = ['HH', 'HV', 'VH', 'VV'] if (options.full_pol or options.circular) else \
               options.pols_to_use.split(',') if options.pols_to_use else \
               [pol for pol in ['HH','VV'] if pol in pols_in_file]
@@ -184,12 +185,10 @@ for win in range(len(h5.spectral_windows)):
         print "\nThe MS can be converted into a uvfits file in casapy, with the command:"
         print "      exportuvfits(vis='%s', fitsfile='%s', datacolumn='data')\n" % (ms_name, uv_name)
 
-    if options.HH or options.VV:
-        print "\n#### Producing Stokes I MS using " + ('HH' if options.HH else 'VV') + " only ####\n"
-    elif options.full_pol:
+    if options.full_pol:
         print "\n#### Producing a full polarisation MS (HH,HV,VH,VV) ####\n"
     else:
-        print "\n#### Producing a two polarisation MS (HH, VV) ####\n"
+        print "\n#### Producing MS with %s polarisations ####\n"%(','.join(pols_to_use))
 
     # # Open HDF5 file
     # if len(args) == 1: args = args[0]

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -120,13 +120,13 @@ if not ms_extra.casacore_binding:
 else:
     print "Using '%s' casacore binding to produce MS" % (ms_extra.casacore_binding,)
 
-#  which polarisation do we want to write into the MS and pull from the HDF5 file
+# which polarisation do we want to write into the MS and pull from the HDF5 file
 pols_to_use = ['HH'] if options.HH else \
               ['VV'] if options.VV else \
               ['HH', 'HV', 'VH', 'VV'] if (options.full_pol or options.circular) else \
-              ['HH', 'VV']
-pol_for_name = 'hh' if options.HH else \
-               'vv' if options.VV else \
+              list(np.sort(np.unique([(inp[-1]*2).upper() for inp in h5.inputs])))
+pol_for_name = 'hh' if pols_to_use == ['HH'] else \
+               'vv' if pols_to_use == ['VV'] else \
                'full_pol' if options.full_pol else \
                'circular_pol' if options.circular else \
                'hh_vv'

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -132,7 +132,7 @@ if np.any([pol not in pols_in_file for pol in pols_to_use]):
 
 #Set full_pol if this is selected via options.pols_to_use
 if set(pols_to_use) == set(['HH', 'HV', 'VH', 'VV']) and not options.circular:
-    options.full_pol==True
+    options.full_pol=True
 
 pol_for_name = 'full_pol' if options.full_pol else \
                'circular_pol' if options.circular else \

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -61,7 +61,8 @@ parser.add_option("-v", "--verbose", action="store_true", default=False,
 parser.add_option("-w", "--stop-w", action="store_true", default=False,
                   help="Use W term to stop fringes for each baseline")
 parser.add_option("-p", "--pols-to-use", default=None,
-                  help="Select polarisation products to include in MS from HH,VV,HV,VH, default is all available from HH,VV")
+                  help="Select polarisation products to include in MS as comma separated list "
+                       "(from: HH, HV, VH, VV). Default is all available from HH, VV")
 parser.add_option("-u", "--uvfits", action="store_true", default=False,
                   help="Print command to convert MS to miriad uvfits in casapy")
 parser.add_option("-a", "--no-auto", action="store_true", default=False,

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -276,7 +276,6 @@ for win in range(len(h5.spectral_windows)):
     ms_dict['FEED'] = ms_extra.populate_feed_dict(len(h5.ants), num_receptors_per_feed=2)
     ms_dict['DATA_DESCRIPTION'] = ms_extra.populate_data_description_dict()
     ms_dict['POLARIZATION'] = ms_extra.populate_polarization_dict(ms_pols=pols_to_use,
-                                                                  stokes_i=(options.HH or options.VV),
                                                                   circular=options.circular)
     ms_dict['OBSERVATION'] = ms_extra.populate_observation_dict(start_time, end_time, telescope_name,
                                                                 h5.observer, h5.experiment_id)


### PR DESCRIPTION
Changes to allow h5toms to deal with single polarisation datasets by default.

I've removed the --HH and --VV options from h5toms.py. These previously would fake a Stokes I dataset using just a single pol, making CASA very unhappy as it looks for receptors that correspond to polarisations when it applies calibration models.
Instead I have now added a '--pols-to-use' option so that the user can specify which polarisations from the input h5 file that want in a (now correctly labelled) MS. The default behaviour is to look for any single pols in the input data and use these for the output (HH,VV if both are present or only one of these if that is all that is available).
I've added a bit of checking to make sure that --pols-to-use corresponds to pols that are available in the input file, and to enforce --full-pol in preference to any selected pols if it is used as an option.

@ludwigschwardt - this is for you.
