### PR TITLE
Correct type to int for SOURCE_ID and correct dimensions of phase_cen…

### DIFF
--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -637,12 +637,12 @@ def populate_source_dict(phase_centers, time_origins, center_frequencies, field_
     completeness it is included here (with no time varying terms).
     """
     num_channels = len(center_frequencies)
-    phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))[:, np.newaxis, :]
+    phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))
     num_fields = len(phase_centers)
     if field_names is None:
         field_names = ['Source%d' % (field,) for field in range(num_fields)]
     source_dict = {}
-    source_dict['SOURCE_ID'] = np.arange(num_fields)
+    source_dict['SOURCE_ID'] = np.arange(num_fields,dtype=np.int32)
     source_dict['PROPER_MOTION'] = np.zeros((num_fields, 2), dtype=np.float32)
     source_dict['DIRECTION'] = phase_centers
     source_dict['CALIBRATION_GROUP'] = np.ones(num_fields) * -1


### PR DESCRIPTION
…ters.

So it looks like this change wasn't as innocuous as it first appeared. First of all CASA was unable to read the SOURCE table due to the SOURCE_ID's being floats rather than the required ints, then this opened up another much older problem in which the 'DIRECTION' field in the SOURCE table had 3 dimensions rather then the required 2 (as stated in Memo 229).

@spassmoor can you check you are happy with my corrections to yours
@ludwigschwardt you might also want to make sure you're happy with this.