### PR TITLE
Fix upside-down MeerKAT images

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -144,6 +144,7 @@ class SpectralWindow(object):
         self.channel_width = channel_width
         self.num_chans = num_chans
         self.product = product if product is not None else ''
+        self.sideband = sideband
         self.band = band
         # Don't subtract half a channel width as channel 0 is centred on 0 Hz in baseband
         self.channel_freqs = centre_freq + sideband * channel_width * (np.arange(num_chans) - num_chans / 2)
@@ -262,7 +263,7 @@ def _calc_uvw(cache, name, antA, antB):
     u, v, w = np.empty(len(cache.timestamps)), np.empty(len(cache.timestamps)), np.empty(len(cache.timestamps))
     targets = cache.get('Observation/target')
     for segm, target in targets.segments():
-        u[segm], v[segm], w[segm] = target.uvw(antennaB, cache.timestamps[segm], antennaA)
+        u[segm], v[segm], w[segm] = target.uvw(antennaA, cache.timestamps[segm], antennaB)
     cache[antA_group + 'u_%s' % (antB,)] = u
     cache[antA_group + 'v_%s' % (antB,)] = v
     cache[antA_group + 'w_%s' % (antB,)] = w
@@ -940,6 +941,9 @@ class DataSet(object):
         matches the length of :meth:`freqs` and the number of correlation
         products *B* matches the length of :meth:`corr_products`.
 
+        The sign convention of the imaginary part is consistent with an
+        electric field of :math:`e^{i(\omega t - jz)}` i.e. phase that
+        increases with time.
         """
         raise NotImplementedError
 
@@ -1123,7 +1127,8 @@ class DataSet(object):
 
         This calculates the *u* coordinate of the baseline vector of each
         correlation product as a function of time while tracking the target.
-        It is returned as an array of float, shape (*T*, *B*).
+        It is returned as an array of float, shape (*T*, *B*). The sign
+        convention is :math:`u_1 - u_2` for baseline (ant1, ant2).
 
         """
         return self._sensor_per_corrprod('u')
@@ -1134,7 +1139,8 @@ class DataSet(object):
 
         This calculates the *v* coordinate of the baseline vector of each
         correlation product as a function of time while tracking the target.
-        It is returned as an array of float, shape (*T*, *B*).
+        It is returned as an array of float, shape (*T*, *B*). The sign
+        convention is :math:`v_1 - v_2` for baseline (ant1, ant2).
 
         """
         return self._sensor_per_corrprod('v')
@@ -1145,7 +1151,8 @@ class DataSet(object):
 
         This calculates the *w* coordinate of the baseline vector of each
         correlation product as a function of time while tracking the target.
-        It is returned as an array of float, shape (*T*, *B*).
+        It is returned as an array of float, shape (*T*, *B*).The sign
+        convention is :math:`w_1 - w_2` for baseline (ant1, ant2).
 
         """
         return self._sensor_per_corrprod('w')

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -335,7 +335,8 @@ class H5DataV1(DataSet):
             keep = keep[:3] + (slice(None),) * (3 - len(keep))
             # Final indexing ensures that returned data are always 3-dimensional (i.e. keep singleton dimensions)
             force_3dim = tuple((np.newaxis if np.isscalar(dim_keep) else slice(None)) for dim_keep in keep)
-            return np.dstack([tf[str(corrind)][force_3dim[:2]] for corrind in
+            # Conjugate the data to correct for the lower sideband downconversion
+            return np.dstack([tf[str(corrind)][force_3dim[:2]].conjugate() for corrind in
                               np.nonzero(corrprod_keep)[0]])[:, :, keep[2]][:, :, force_3dim[2]]
         extract_vis = LazyTransform('extract_vis_v1', index_corrprod,
                                     lambda shape: (shape[0], shape[1], corrprod_keep.sum()), np.complex64)
@@ -361,6 +362,9 @@ class H5DataV1(DataSet):
         data array itself from the indexer `x`, do `x[:]` or perform any other
         form of indexing on it. Only then will data be loaded into memory.
 
+        The sign convention of the imaginary part is consistent with an
+        electric field of :math:`e^{i(\omega t - jz)}` i.e. phase that
+        increases with time.
         """
         return ConcatenatedLazyIndexer(self._vis_indexers())
 

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -584,10 +584,14 @@ class H5DataV2(DataSet):
         data array itself from the indexer `x`, do `x[:]` or perform any other
         form of indexing on it. Only then will data be loaded into memory.
 
+        The sign convention of the imaginary part is consistent with an
+        electric field of :math:`e^{i(\omega t - jz)}` i.e. phase that
+        increases with time.
         """
         extract = LazyTransform('extract_vis',
                                 # Discard the 4th / last dimension as this is subsumed in complex view
-                                lambda vis, keep: vis.view(np.complex64)[..., 0],
+                                # The visibilities are conjugated due to using the lower sideband
+                                lambda vis, keep: vis.view(np.complex64)[..., 0].conjugate(),
                                 lambda shape: shape[:-1], np.complex64)
         return self._vislike_indexer(self._vis, extract)
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -813,10 +813,19 @@ class H5DataV3(DataSet):
         data array itself from the indexer `x`, do `x[:]` or perform any other
         form of indexing on it. Only then will data be loaded into memory.
 
+        The sign convention of the imaginary part is consistent with an
+        electric field of :math:`e^{i(\omega t - jz)}` i.e. phase that
+        increases with time.
         """
+        if self.spectral_windows[self.spw].sideband == 1:
+            # Discard the 4th / last dimension as this is subsumed in complex view
+            convert = lambda vis, keep: vis.view(np.complex64)[..., 0]
+        else:
+            # Lower side-band has the conjugate visibilities, and this isn't
+            # corrected in the correlator.
+            convert = lambda vis, keep: vis.view(np.complex64)[..., 0].conjugate()
         extract = LazyTransform('extract_vis',
-                                # Discard the 4th / last dimension as this is subsumed in complex view
-                                lambda vis, keep: vis.view(np.complex64)[..., 0],
+                                convert,
                                 lambda shape: shape[:-1], np.complex64)
         return self._vislike_indexer(self._vis, extract)
 

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -446,9 +446,13 @@ for win in range(len(h5.spectral_windows)):
             def _create_uvw(a1, a2, times):
                 """
                 Return a (ntime, 3) array of UVW coordinates for baseline
-                defined by a1 and a2
+                defined by a1 and a2. The sign convention matches `CASA`_,
+                rather than the Measurement Set `definition`_.
+
+                .. _CASA: https://casa.nrao.edu/Memos/CoordConvention.pdf
+                .. _definition: https://casa.nrao.edu/Memos/229.html#SECTION00064000000000000000
                 """
-                uvw = target.uvw(a2, timestamp=times, antenna=a1)
+                uvw = target.uvw(a1, timestamp=times, antenna=a2)
                 return np.asarray(uvw).T
 
             # Massage visibility, weight and flag data from


### PR DESCRIPTION
There are two major changes:

1. When the spectral window uses lower sideband, conjugate the
visibilities on load, because the correlator/ingest do not correct for
it. This brings all data to the MeerKAT sign convention for
visibility phase. For v1 and v2 it's hardcoded (since they hardcode for
lower sideband), while for v3 it is dependent on the band.

2. Change the sign of UVW coordinates to match the CASA convention.

For MeerKAT the second change will make images made via h5toms come out
the right way up. For KAT-7 the two changes will cancel out when
imaging, although the sign conventions will now match MeerKAT.

Fixes SR-811.