### PR TITLE
Access sensor data in a TelescopeState object

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -242,8 +242,10 @@ if hasattr(_ip, 'set_hook'):
 # Setup library logger and add a print-like handler used when no logging is configured
 class _NoConfigFilter(_logging.Filter):
     """Filter which only allows event if top-level logging is not configured."""
+
     def filter(self, record):
         return 1 if not _logging.root.handlers else 0
+
 _no_config_handler = _logging.StreamHandler()
 _no_config_handler.setFormatter(_logging.Formatter(_logging.BASIC_FORMAT))
 _no_config_handler.addFilter(_NoConfigFilter())

--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -18,10 +18,11 @@ import numpy as np
 
 
 def block_and_average(vis, weight, flag, avsize, axis=0, flagav=False):
-    """ 'block_and_average' does the dirty work of averaging for 'average_visibilities'.
-    It blocks an input array in its last axis at a list of array indices calculated
-    from the input avsize and the shape of the input visibility array.
-    It then weighted-averages the blocked data. For time and channel
+    """Low-level blockwise averaging of visibilities, flags and weights.
+
+    It blocks an input array in its last axis at a list of array indices
+    calculated from the input avsize and the shape of the input visibility
+    array. It then weighted-averages the blocked data. For time and channel
     averaging of 2d input arrays (as with 'average_visibilities') the function
     is run twice.
 
@@ -40,8 +41,8 @@ def block_and_average(vis, weight, flag, avsize, axis=0, flagav=False):
     av_weight: array of averaged weights.
     av_flag: array of averaged_flags.
     indices: array of indices where the blocks were constructed.
-    """
 
+    """
     # Get the array indices for blocking (if the avsize is bigger than the
     # array dimension to be averaged, use the size of the array dimension
     # instead).
@@ -87,16 +88,18 @@ def block_and_average(vis, weight, flag, avsize, axis=0, flagav=False):
 
 
 def average_visibilities(vis, weight, flag, timestamps, channel_freqs, timeav=10, chanav=8, flagav=False):
-    """ 'average_visibilities' performs the task of averaging of visibilities and
-    flags and weights. Visibilities are weight-averaged using the weights in the weight
-    array with flagged data set to weight zero. The averaged weights are the sum of the input
-    weights for each average block. An average flag is retained if all of the data in an
-    averageing block is flagged (the averaged visibility in this case is the unweighted
-    average of the input visibilities). In cases where the averaging size in channel or time
-    does not evenly divide the size of the input data- the remaining channels or timestamps
-    at the end of the array after averaging are discarded. Channels are averaged first and
-    the timestamps are second. An array of timestamps and and frequencies corresponding to
-    each channel is also directly averaged and returned.
+    """Average visibilities, flags and weights.
+
+    Visibilities are weight-averaged using the weights in the `weight` array
+    with flagged data set to weight zero. The averaged weights are the sum of
+    the input weights for each average block. An average flag is retained if
+    all of the data in an averaging block is flagged (the averaged visibility
+    in this case is the unweighted average of the input visibilities). In cases
+    where the averaging size in channel or time does not evenly divide the size
+    of the input data, the remaining channels or timestamps at the end of the
+    array after averaging are discarded. Channels are averaged first and the
+    timestamps are second. An array of timestamps and frequencies corresponding
+    to each channel is also directly averaged and returned.
 
     Inputs
     ------

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -104,7 +104,27 @@ class ComparableArrayWrapper(object):
 
 
 def infer_dtype(values):
-    """Figure out dtype of sequence of sensor values, or None if unavailable."""
+    """Figure out dtype of sequence of sensor values.
+
+    The common dtype is determined by implicit NumPy coercion. If the values
+    are array-like themselves, treat them as opaque objects to simplify
+    sensor processing. If the sequence is empty, the dtype is unknown and
+    set to None. In addition, short-circuit to an actual dtype for objects
+    with this attribute to simplify calling this on a mixed collection of
+    sensor data.
+
+    Parameters
+    ----------
+    values : sequence, or object with dtype
+        Sequence of sensor values (typically a list), or a sensor data object
+        with a dtype attribute (like ndarray or :class:`SensorData`)
+
+    Returns
+    -------
+    dtype : :class:`numpy.dtype` object or None
+        Inferred dtype, or None if `values` is an empty sequence
+
+    """
     # If values already has a dtype (because it is an ndarray, SensorData,
     # CategoricalData, etc), return that instead
     if hasattr(values, 'dtype'):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -45,8 +45,8 @@ class HashableValueWrapper(object):
     Note
     ----
     The current implementation uses pickle to make generic objects hashable,
-    even though it is not recommended - see e.g.
-    http://www.aminus.org/blogs/index.php/2007/11/03/pickle_dumps_not_suitable_for_hashing
+    even though it is not recommended - see e.g. this `blog post
+    <http://www.aminus.org/blogs/index.php/2007/11/03/pickle_dumps_not_suitable_for_hashing>`_.
     The main problem is with unordered data like dicts and sets, where the item
     order in the pickle string may differ even though the objects are equal;
 

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -106,7 +106,7 @@ class ComparableArrayWrapper(object):
 def infer_dtype(values):
     """Figure out dtype of sequence of sensor values.
 
-    The common dtype is determined by implicit NumPy coercion. If the values
+    The common dtype is determined by explicit NumPy promotion. If the values
     are array-like themselves, treat them as opaque objects to simplify
     sensor processing. If the sequence is empty, the dtype is unknown and
     set to None. In addition, short-circuit to an actual dtype for objects
@@ -124,6 +124,15 @@ def infer_dtype(values):
     dtype : :class:`numpy.dtype` object or None
         Inferred dtype, or None if `values` is an empty sequence
 
+    Notes
+    -----
+    This is almost, but not quite, entirely like :func:`numpy.result_type`.
+    The differences are that this accepts generic objects in the sequence,
+    treats ndarrays as objects regardless of their underlying dtype, supports
+    a dtype of None and short-circuits the check if the sequence itself is an
+    object with a dtype. And this accepts the sequence as the first parameter
+    as opposed to being unpacked across the argument list.
+
     """
     # If values already has a dtype (because it is an ndarray, SensorData,
     # CategoricalData, etc), return that instead
@@ -131,7 +140,7 @@ def infer_dtype(values):
         return values.dtype
     if not values:
         return None
-    # Put all values into array to find maximum length of any string type
+    # Put all values into array to perform explicit NumPy type promotion
     test_data = np.array(values)
     # Beware array-valued sensors; treat their values as opaque objects
     # This forces sensor values to be 1-D at all times (an invariant)

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -45,9 +45,10 @@ class HashableValueWrapper(object):
     Note
     ----
     The current implementation uses pickle to make generic objects hashable,
-    even though it is not recommended (see http://bit.ly/2ruNkH2). The main
-    problem is with unordered data like dicts and sets, where the item order
-    in the pickle string may differ even though the objects are equal. E.g.
+    even though it is not recommended - see e.g.
+    http://www.aminus.org/blogs/index.php/2007/11/03/pickle_dumps_not_suitable_for_hashing
+    The main problem is with unordered data like dicts and sets, where the item
+    order in the pickle string may differ even though the objects are equal;
 
       pickle.dumps({1: 0, 9: 0}) == pickle.dumps({9: 0, 1: 0})
 
@@ -118,7 +119,7 @@ def unique_in_order(elements, unwrap=False, return_inverse=False):
         If True, unwrap any objects wrapped in a :class:`HashableValueWrapper`
     return_inverse : {False, True}, optional
         If True, also return sequence of indices that can be used to reconstruct
-        original `elements` sequence via `unique_elements[inverse]`
+        original `elements` sequence via `[unique_elements[i] for i in inverse]`
 
     Returns
     -------
@@ -385,7 +386,7 @@ class CategoricalData(object):
             remap[index:] -= 1
             self.indices = remap[self.indices[keep]]
             self.events = np.r_[self.events[keep], self.events[-1]]
-            self.unique_values = self.unique_values[:index] + self.unique_values[index + 1:]
+            del self.unique_values[index]
 
     def add_unmatched(self, segments, match_dist=1):
         """Add duplicate events for segment starts that don't match sensor events.

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -219,6 +219,7 @@ class CategoricalData(object):
     ----------
     unique_values : list, length *M*
         List of unique sensor values in order they were found in `sensor_values`
+        with any :class:`ComparableArrayWrapper` objects unwrapped
     indices : array of int, shape (*N*,)
         Array of indices into `unique_values`, one per sensor event
     dtype : :class:`numpy.dtype` object
@@ -226,6 +227,11 @@ class CategoricalData(object):
 
     Notes
     -----
+    Any object values wrapped in a :class:`ComparableArrayWrapper` will be
+    unwrapped before adding it to `unique_values`. When adding, removing and
+    comparing values to this container, any object values will be wrapped again
+    temporarily to ensure proper comparisons.
+
     It is discouraged to have a sensor value of None as this value is given
     a special meaning in methods such as :meth:`CategoricalData.add` and
     :meth:`sensor_to_categorical`. On the other hand, it is the most sensible

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -42,6 +42,18 @@ class HashableValueWrapper(object):
         The wrapped version of a sensor value - if not available, use static
         method :meth:`wrap` instead (current implementation expects a pickle)
 
+    Note
+    ----
+    The current implementation uses pickle to make generic objects hashable,
+    even though it is not recommended (see http://bit.ly/2ruNkH2). The main
+    problem is with unordered data like dicts and sets, where the item order
+    in the pickle string may differ even though the objects are equal. E.g.
+
+      pickle.dumps({1: 0, 9: 0}) == pickle.dumps({9: 0, 1: 0})
+
+    evaluates to False, even though the dicts are equal. On top of this there
+    is also the issue of potentially differing pickle protocols.
+
     """
     def __init__(self, hashable_value):
         self.hashable_value = hashable_value
@@ -172,6 +184,8 @@ class CategoricalData(object):
         List of unique sensor values in order they were found in `sensor_values`
     indices : array of int, shape (*N*,)
         Array of indices into `unique_values`, one per sensor event
+    dtype : :class:`numpy.dtype` object
+        Sensor data type as NumPy dtype (found on demand from `unique_values`)
 
     Notes
     -----

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -77,7 +77,7 @@ class CategoricalData(object):
     Parameters
     ----------
     sensor_values : sequence, length *N*
-        Sequence of sensor values (of any type except None)
+        Sequence of sensor values (of any type, preferably not None [see Notes])
     events : sequence of non-negative ints, length *N* + 1
         Corresponding monotonic sequence of dump indices where each sensor value
         came into effect. The last event is one past the last dump where the
@@ -90,6 +90,14 @@ class CategoricalData(object):
         Array of unique sensor values, in order they were found in `sensor_values`
     indices : array of int, shape (*N*,)
         Array of indices into `unique_values`, one per sensor event
+
+    Notes
+    -----
+    It is discouraged to have a sensor value of None as this value is given
+    a special meaning in methods such as :meth:`CategoricalData.add` and
+    :meth:`sensor_to_categorical`. On the other hand, it is the most sensible
+    dummy object value and any Nones entering through this initialiser will
+    probably not cause any issues.
 
     """
     def __init__(self, sensor_values, events):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -278,7 +278,7 @@ class CategoricalData(object):
 
     def __repr__(self):
         """Short human-friendly string representation of categorical data object."""
-        return "<katdal.CategoricalData events=%d values=%d type='%s' at 0x%x>" % \
+        return "<katdal.CategoricalData events=%d values=%d type=%s at 0x%x>" % \
                (len(self.indices), len(self.unique_values), self.dtype, id(self))
 
     def __str__(self):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -19,89 +19,6 @@
 import numpy as np
 
 
-def unique(ar, return_index=False, return_inverse=False):
-    """Find the unique elements of an array.
-
-    Returns the sorted unique elements of an array. There are two optional
-    outputs in addition to the unique elements: the indices of the input array
-    that give the unique values, and the indices of the unique array that
-    reconstruct the input array.
-
-    Parameters
-    ----------
-    ar : array_like
-        Input array. This will be flattened if it is not already 1-D.
-    return_index : bool, optional
-        If True, also return the indices of `ar` that result in the unique
-        array.
-    return_inverse : bool, optional
-        If True, also return the indices of the unique array that can be used
-        to reconstruct `ar`.
-
-    Returns
-    -------
-    unique : ndarray
-        The sorted unique values.
-    unique_indices : ndarray, optional
-        The indices of the first occurrences of the unique values in the
-        (flattened) original array. Only provided if `return_index` is True.
-    unique_inverse : ndarray, optional
-        The indices to reconstruct the (flattened) original array from the
-        unique array. Only provided if `return_inverse` is True.
-
-    Notes
-    -----
-    This is a copy of :func:`numpy.unique` from NumPy 1.6.2, backported to make
-    katdal work with NumPy 1.3.0 (which did not have the return_index and
-    return_inverse keyword arguments). Once backwards compatibility is not
-    required anymore, this function may be removed and replaced by np.unique.
-
-    """
-    # Attempt to use the new np.unique interface first, otherwise reimplement it
-    try:
-        return np.unique(ar, return_index, return_inverse)
-    except TypeError:
-        pass
-
-    try:
-        ar = ar.flatten()
-    except AttributeError:
-        if not return_inverse and not return_index:
-            items = sorted(set(ar))
-            return np.asarray(items)
-        else:
-            ar = np.asanyarray(ar).flatten()
-
-    if ar.size == 0:
-        if return_inverse and return_index:
-            return ar, np.empty(0, np.bool), np.empty(0, np.bool)
-        elif return_inverse or return_index:
-            return ar, np.empty(0, np.bool)
-        else:
-            return ar
-
-    if return_inverse or return_index:
-        if return_index:
-            perm = ar.argsort(kind='mergesort')
-        else:
-            perm = ar.argsort()
-        aux = ar[perm]
-        flag = np.concatenate(([True], aux[1:] != aux[:-1]))
-        if return_inverse:
-            iflag = np.cumsum(flag) - 1
-            iperm = perm.argsort()
-            if return_index:
-                return aux[flag], perm[flag], iflag[iperm]
-            else:
-                return aux[flag], iflag[iperm]
-        else:
-            return aux[flag], perm[flag]
-    else:
-        ar.sort()
-        flag = np.concatenate(([True], ar[1:] != ar[:-1]))
-        return ar[flag]
-
-
 def unique_in_order(elements, return_inverse=False):
     """Extract unique elements from *elements* while preserving original order.
 
@@ -128,7 +45,7 @@ def unique_in_order(elements, return_inverse=False):
         raise TypeError("Cannot identify unique objects of %s as it has no __lt__ or __cmp__ methods" %
                         (elements[0].__class__,))
     # Find unique elements based on sorting
-    unique_elements, indices = unique(elements, return_inverse=True)
+    unique_elements, indices = np.unique(elements, return_inverse=True)
     # Shuffle unique values back into their original order as they were found in elements
     indices_list = indices.tolist()
     original_order = np.argsort([indices_list.index(n) for n in range(len(unique_elements))])
@@ -399,7 +316,7 @@ class CategoricalData(object):
         events = segments[segments_with_event]
         # When multiple sensor events are associated with the same segment, only keep the final one
         final = np.nonzero(np.diff(events) > 0)[0]
-        subset, self.indices = unique(self.indices[final], return_inverse=True)
+        subset, self.indices = np.unique(self.indices[final], return_inverse=True)
         self.unique_values = self.unique_values[subset]
         self.events = np.r_[events[final], events[-1]]
 

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -56,6 +56,7 @@ class HashableValueWrapper(object):
     is also the issue of potentially differing pickle protocols.
 
     """
+
     def __init__(self, hashable_value):
         self.hashable_value = hashable_value
 
@@ -109,7 +110,7 @@ class HashableValueWrapper(object):
 
 
 def unique_in_order(elements, unwrap=False, return_inverse=False):
-    """Extract unique elements from *elements* while preserving original order.
+    """Extract unique elements from `elements` while preserving original order.
 
     Parameters
     ----------
@@ -202,6 +203,7 @@ class CategoricalData(object):
     then need to be unpacked at some later stage which is also tricky.
 
     """
+
     def __init__(self, sensor_values, events):
         self.unique_values, self.indices = unique_in_order(sensor_values, unwrap=True,
                                                            return_inverse=True)
@@ -216,7 +218,7 @@ class CategoricalData(object):
             return self.unique_values
 
     def _lookup(self, dumps):
-        """Look up relevant indices occurring at specified *dumps*.
+        """Look up relevant indices occurring at specified `dumps`.
 
         Parameters
         ----------
@@ -392,7 +394,7 @@ class CategoricalData(object):
         """Add duplicate events for segment starts that don't match sensor events.
 
         Given a sequence of segments, this matches each segment start to the
-        nearest sensor event dump (within *match_dist*). Any unmatched segment
+        nearest sensor event dump (within `match_dist`). Any unmatched segment
         starts are added as duplicate sensor events (or ignored if they fall
         outside the sensor event range).
 

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -210,7 +210,7 @@ class ConcatenatedSensorData(SensorData):
 
     Parameters
     ----------
-    data : sequence of recarray-like with fields 'timestamp', 'value' ('status')
+    data : sequence of recarray-like with fields 'timestamp', 'value' and optionally 'status'
         Uncached sensor data as a list of record arrays or equivalent (such as
         an :class:`h5py.Dataset`)
 

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -236,7 +236,7 @@ class ConcatenatedSensorData(SensorData):
 
     def __bool__(self):
         """True if sensor has at least one data point."""
-        return any([bool(sd) for sd in self._data])
+        return any(bool(sd) for sd in self._data)
 
     __nonzero__ = __bool__
 

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -29,7 +29,6 @@ from .dataset import DataSet
 
 class ConcatenationError(Exception):
     """Sequence of objects could not be concatenated due to incompatibility."""
-    pass
 
 # -------------------------------------------------------------------------------------------------
 # -- CLASS :  ConcatenatedLazyIndexer
@@ -62,6 +61,7 @@ class ConcatenatedLazyIndexer(LazyIndexer):
         If transform chain does not obey restrictions on changing the data shape
 
     """
+
     def __init__(self, indexers, transforms=None):
         # Only keep those indexers that have any data selected on first axis (unless nothing at all is selected)
         self.indexers = [indexer for indexer in indexers if indexer.shape[0]]
@@ -215,6 +215,7 @@ class ConcatenatedSensorData(SensorData):
         an :class:`h5py.Dataset`)
 
     """
+
     def __init__(self, data):
         self._data = data
         names = unique_in_order([sd.name for sd in data])
@@ -268,6 +269,7 @@ class ConcatenatedSensorCache(SensorCache):
         be applied to sensor data (this can be disabled on data retrieval)
 
     """
+
     def __init__(self, caches, keep=None):
         self.caches = caches
         # Collect the names and types of all actual and virtual sensors in caches, as well as properties
@@ -409,6 +411,7 @@ class ConcatenatedDataSet(DataSet):
         List of existing data sets
 
     """
+
     def __init__(self, datasets):
         DataSet.__init__(self, '', datasets[0].ref_ant, datasets[0].time_offset)
 

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -255,8 +255,12 @@ class ConcatenatedSensorData(SensorData):
         self._data = data
         names = unique_in_order([sd.name for sd in data])
         if len(names) != 1:
-            raise ConcatenationError('Cannot concatenate sensor %r with different '
-                                     'underlying names: %s' % (self.name, names))
+            # XXX This is probably not a serious restriction; consider removal.
+            # It is a weak verification that we are combining like sensors,
+            # but underlying names may legitimately differ for datasets of
+            # different minor versions (even within the same version...).
+            raise ConcatenationError('Cannot concatenate sensor with different '
+                                     'underlying names: %s' % (names,))
         self.name = names[0]
         dtypes = infer_dtypes(data)
         if len(dtypes) != 1:
@@ -305,7 +309,8 @@ class ConcatenatedSensorCache(SensorCache):
 
     def __init__(self, caches, keep=None):
         self.caches = caches
-        # Collect the names and types of all actual and virtual sensors in caches, as well as properties
+        # Collect all actual and virtual sensors in caches as well as properties
+        # The main point is to discover the name and dtype of each known sensor
         actual, virtual, self.props = {}, {}, {}
         for cache in caches:
             actual.update(cache.iteritems())

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -33,12 +33,10 @@ logger = logging.getLogger(__name__)
 
 class WrongVersion(Exception):
     """Trying to access data using accessor class with the wrong version."""
-    pass
 
 
 class BrokenFile(Exception):
     """Data set could not be loaded because file is inconsistent or misses critical bits."""
-    pass
 
 
 def array_equal(a1, a2):
@@ -78,6 +76,7 @@ class Subarray(object):
         List of correlator input labels found in `corr_products`, e.g. 'ant1h'
 
     """
+
     def __init__(self, ants, corr_products):
         self.corr_products = np.array([(inpA.lower(), inpB.lower()) for inpA, inpB in corr_products])
         # Extract all inputs (and associated antennas) from correlation product list
@@ -138,6 +137,7 @@ class SpectralWindow(object):
         Centre frequency of each frequency channel (assuming LSB mixing), in Hz
 
     """
+
     def __init__(self, centre_freq, channel_width, num_chans, product=None,
                  sideband=-1, band='L'):
         self.centre_freq = centre_freq
@@ -371,6 +371,7 @@ class DataSet(object):
         Size of selected visibility data array, in bytes
 
     """
+
     def __init__(self, name, ref_ant='', time_offset=0.0):
         self.name = name
         self.ref_ant = ref_ant
@@ -580,11 +581,11 @@ class DataSet(object):
         The selection criteria are divided into groups, based on whether they
         affect the time, frequency or correlation product dimension::
 
-        * Time: *dumps*, *timerange*, *scans*, *compscans*, *targets*
-        * Frequency: *channels*, *freqrange*
-        * Correlation product: *corrprods*, *ants*, *inputs*, *pol*
+        * Time: `dumps`, `timerange`, `scans`, `compscans`, `targets`
+        * Frequency: `channels`, `freqrange`
+        * Correlation product: `corrprods`, `ants`, `inputs`, `pol`
 
-        The *subarray* and *spw* criteria are special, as they affect multiple
+        The `subarray` and `spw` criteria are special, as they affect multiple
         dimensions (time + correlation product and time + frequency,
         respectively), are always active and are forced to be a single index.
 
@@ -593,12 +594,12 @@ class DataSet(object):
         criterion (e.g. `targets=['Hyd A', 'Vir A']`) are ORed together. When a
         second select() call is done, all new selections replace previous
         selections on the same dimension, while existing selections on other
-        dimensions are preserved. The *reset* parameter finetunes this behaviour.
+        dimensions are preserved. The `reset` parameter finetunes this behaviour.
 
         If :meth:`select` is called without any parameters the selection is
         reset to the original data set.
 
-        In addition, the *weights* and *flags* criteria are lists of names that
+        In addition, the `weights` and `flags` criteria are lists of names that
         select which weights and flags to include in the corresponding data set
         property.
 
@@ -657,14 +658,14 @@ class DataSet(object):
             that will be modified by the new selections and leaves the selections
             on unaffected dimensions intact except if `select` is called without
             any parameters, in which case all selections are cleared. By setting
-            reset to '', new selections apply on top of existing selections.
+            `reset` to '', new selections apply on top of existing selections.
 
         Raises
         ------
         TypeError
-            If a keyword argument is unknown and strict_select is enabled
+            If a keyword argument is unknown and `strict` is enabled
         IndexError
-            If *spw* or *subarray* is out of range
+            If `spw` or `subarray` is out of range
 
         """
         time_selectors = ['dumps', 'timerange', 'scans', 'compscans', 'targets']
@@ -930,7 +931,7 @@ class DataSet(object):
 
     @property
     def vis(self):
-        """Complex visibility data as a function of time, frequency and corrprod.
+        r"""Complex visibility data as a function of time, frequency and corrprod.
 
         The visibility data are returned as an array of complex64, shape
         (*T*, *F*, *B*), with time along the first dimension, frequency along the

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -88,6 +88,7 @@ class H5DataV1(DataSet):
         Underlying HDF5 file, exposed via :mod:`h5py` interface
 
     """
+
     def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r', **kwargs):
         DataSet.__init__(self, filename, ref_ant, time_offset)
 
@@ -349,7 +350,7 @@ class H5DataV1(DataSet):
 
     @property
     def vis(self):
-        """Complex visibility data as a function of time, frequency and baseline.
+        r"""Complex visibility data as a function of time, frequency and baseline.
 
         The visibility data are returned as an array indexer of complex64, shape
         (*T*, *F*, *B*), with time along the first dimension, frequency along the

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -25,7 +25,7 @@ import katpoint
 
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray, SpectralWindow,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS, _robust_target)
-from .sensordata import SensorData, SensorCache
+from .sensordata import RecordSensorData, SensorCache
 from .categorical import CategoricalData
 from .lazy_indexer import LazyIndexer, LazyTransform
 from .concatdata import ConcatenatedLazyIndexer
@@ -153,7 +153,7 @@ class H5DataV1(DataSet):
                 # Assume sensor dataset name is AntennaN/Sensors/dataset and rename it to Antennas/{ant}/dataset
                 ant_name = obj.parent.parent.attrs['description'].split(',')[0]
                 standardised_name = 'Antennas/%s/%s' % (ant_name, name.split('/')[-1])
-                cache[standardised_name] = SensorData(obj, standardised_name)
+                cache[standardised_name] = RecordSensorData(obj, standardised_name)
         ants_group.visititems(register_sensor)
         # Use estimated data timestamps for now, to speed up data segmentation
         # This will linearly interpolate pointing coordinates to correlator data timestamps (on access)

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -305,7 +305,7 @@ class H5DataV2(DataSet):
             # Fall back to basic RFE7 LO frequency, as this supported multiple spectral windows before k7_capture did
             # This assumes WBC mode, though (NBC modes only fully supported since HDF5 v2.1)
             centre_freq = self.sensor.get('RFE/rfe7.lo1.frequency')
-            centre_freq.unique_values -= 4200e6
+            centre_freq.unique_values = [freq - 4200e6 for freq in centre_freq.unique_values]
         num_chans = get_single_value(config_group['Correlator'], 'n_chans')
         if num_chans != self._vis.shape[1]:
             raise BrokenFile('Number of channels received from correlator '

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -167,6 +167,7 @@ class H5DataV2(DataSet):
         Underlying HDF5 file, exposed via :mod:`h5py` interface
 
     """
+
     def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r',
                  quicklook=False, keepdims=False, **kwargs):
         DataSet.__init__(self, filename, ref_ant, time_offset)
@@ -571,7 +572,7 @@ class H5DataV2(DataSet):
 
     @property
     def vis(self):
-        """Complex visibility data as a function of time, frequency and baseline.
+        r"""Complex visibility data as a function of time, frequency and baseline.
 
         The visibility data are returned as an array indexer of complex64, shape
         (*T*, *F*, *B*), with time along the first dimension, frequency along the

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -24,7 +24,7 @@ import katpoint
 
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray, SpectralWindow,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS, _robust_target)
-from .sensordata import SensorData, SensorCache
+from .sensordata import RecordSensorData, SensorCache
 from .categorical import CategoricalData, sensor_to_categorical
 from .lazy_indexer import LazyIndexer, LazyTransform
 
@@ -263,7 +263,7 @@ class H5DataV2(DataSet):
                obj.dtype.names == ('timestamp', 'value', 'status'):
                 # Rename pedestal sensors from the old regime to become sensors of the corresponding antenna
                 name = ('Antennas/ant' + name[13:]) if name.startswith('Pedestals/ped') else name
-                cache[name] = SensorData(obj, name)
+                cache[name] = RecordSensorData(obj, name)
         sensors_group.visititems(register_sensor)
         # Use estimated data timestamps for now, to speed up data segmentation
         self.sensor = SensorCache(cache, data_timestamps, self.dump_period, keep=self._time_keep,

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -29,7 +29,7 @@ except ImportError:
 
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray, SpectralWindow,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS, _robust_target)
-from .sensordata import SensorData, SensorCache, TelstateSensorData
+from .sensordata import SensorData, SensorCache, H5TelstateSensorData
 from .categorical import CategoricalData
 from .lazy_indexer import LazyIndexer, LazyTransform
 
@@ -200,7 +200,7 @@ class H5DataV3(DataSet):
                 if isinstance(obj, h5py.Dataset) and obj.shape != () and \
                    set(obj.dtype.names) == {'timestamp', 'value'}:
                     name = 'TelescopeState/' + name
-                    cache[name] = TelstateSensorData(obj, name)
+                    cache[name] = H5TelstateSensorData(obj, name)
             f.file['TelescopeState'].visititems(register_telstate_sensor)
 
         # ------ Extract vis and timestamps ------

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -159,6 +159,7 @@ class H5DataV3(DataSet):
       timestamp = sample_counter / time_scale + time_origin
 
     """
+
     def __init__(self, filename, ref_ant='', time_offset=0.0, mode='r',
                  time_scale=None, time_origin=None, rotate_bls=False,
                  centre_freq=None, band=None, keepdims=False, **kwargs):
@@ -554,7 +555,7 @@ class H5DataV3(DataSet):
 
     @staticmethod
     def _get_corrprods(f, rotate_bls=False):
-        """Load the correlation products list from an open file
+        """Load the correlation products list from an open file.
 
         Parameters
         ----------
@@ -802,7 +803,7 @@ class H5DataV3(DataSet):
 
     @property
     def vis(self):
-        """Complex visibility data as a function of time, frequency and baseline.
+        r"""Complex visibility data as a function of time, frequency and baseline.
 
         The visibility data are returned as an array indexer of complex64, shape
         (*T*, *F*, *B*), with time along the first dimension, frequency along the

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -180,7 +180,7 @@ class LazyIndexer(object):
 
     def __repr__(self):
         """Short human-friendly string representation of lazy indexer object."""
-        return "<katdal.%s '%s': shape %s, type '%s' at 0x%x>" % \
+        return "<katdal.%s '%s': shape %s, type %s at 0x%x>" % \
                (self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
 
     def _name_shape_dtype(self, name, shape, dtype):

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -27,7 +27,6 @@ import numpy as np
 
 class InvalidTransform(Exception):
     """Transform changes data shape in unallowed way."""
-    pass
 
 
 class LazyTransform(object):
@@ -60,6 +59,7 @@ class LazyTransform(object):
         Type of output array after transformation (None if same as input array)
 
     """
+
     def __init__(self, name=None, transform=lambda d, k: d, new_shape=lambda s: tuple(s), dtype=None):
         self.name = 'unnamed' if name is None else name
         self.transform = transform
@@ -148,6 +148,7 @@ class LazyIndexer(object):
         If transform chain does not obey restrictions on changing the data shape
 
     """
+
     def __init__(self, dataset, keep=slice(None), transforms=None):
         self.dataset = dataset
         self.transforms = [] if transforms is None else transforms

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -98,7 +98,7 @@ class SensorData(object):
                (self.__class__.__name__, self.name, len(self), self.dtype, id(self))
 
 
-def _telstate_unpack(s):
+def _h5_telstate_unpack(s):
     """This unpacks a telstate value from its string representation."""
     try:
         # Since 2016-05-09 the HDF5 TelescopeState contains pickled values
@@ -113,8 +113,8 @@ def _telstate_unpack(s):
             return s
 
 
-class TelstateSensorData(SensorData):
-    """Raw (uncached) sensor data in TelescopeState record array form.
+class H5TelstateSensorData(SensorData):
+    """Raw (uncached) sensor data in HDF5 TelescopeState record array form.
 
     This wraps the telstate sensors stored in recent HDF5 files. It differs
     in two ways from the normal HDF5 sensors: no 'status' column and values
@@ -138,15 +138,15 @@ class TelstateSensorData(SensorData):
 
     """
     def __init__(self, data, name=None):
-        super(TelstateSensorData, self).__init__(data, name)
+        super(H5TelstateSensorData, self).__init__(data, name)
         # Unpickle first value to derive dtype (should be simple for sensors)
-        self.dtype = np.array([_telstate_unpack(data['value'][0])]).dtype
+        self.dtype = np.array([_h5_telstate_unpack(data['value'][0])]).dtype
 
     def __getitem__(self, key):
         """Extract timestamp, value and status of each sensor data point."""
         if key == 'value':
             # Unpickle sensor data upon request
-            return np.array([_telstate_unpack(s) for s in self.data[key]])
+            return np.array([_h5_telstate_unpack(s) for s in self.data[key]])
         elif key == 'status':
             # Fake the missing status column
             return np.repeat('nominal', len(self))
@@ -154,6 +154,7 @@ class TelstateSensorData(SensorData):
             # WARNING: if key is an index or slice, values will still be pickled
             # It is safer to extract data explicitly into recarray in __init__
             return np.asarray(self.data[key])
+
 
 # -------------------------------------------------------------------------------------------------
 # -- Utility functions

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -82,7 +82,7 @@ class SensorData(object):
         self.dtype = dtype
 
     def __getitem__(self, key):
-        """Extract timestamp, value and status of each sensor data point.
+        """Extract timestamp and value (and status) of each sensor data point.
 
         Parameters
         ----------
@@ -203,7 +203,7 @@ class H5TelstateSensorData(RecordSensorData):
             self.dtype = test_data.dtype if test_data.ndim == 1 else np.object
 
     def __getitem__(self, key):
-        """Extract timestamp, value and status of each sensor data point."""
+        """Extract timestamp and value of each sensor data point."""
         if key == 'timestamp':
             return np.asarray(self._data[key])
         elif key == 'value':

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -401,8 +401,8 @@ def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
     return RecordSensorData(data, name)
 
 
-def remove_duplicates_and_failures(sensor):
-    """Remove duplicate timestamp values and failures from sensor data.
+def remove_duplicates_and_invalid_values(sensor):
+    """Remove duplicate timestamps and invalid values from sensor data.
 
     This sorts the 'timestamp' field of the sensor record array and removes any
     duplicate values, updating the corresponding 'value' and 'status' fields as
@@ -410,22 +410,23 @@ def remove_duplicates_and_failures(sensor):
     of the last of these timestamps are selected. If the values differ for the
     same timestamp, a warning is logged (and the last one is still picked).
 
-    In addition, if there is a 'status' field, get rid of data with a 'failure'
-    status which indicates that the sensor could not be read and the
-    corresponding value will therefore be meaningless. Afterwards, remove the
-    'status' field from the data as this is the only place it plays a role.
+    In addition, if there is a 'status' field, get rid of data with a status
+    other than 'nominal', 'warn' or 'error', which indicates that the sensor
+    could not be read and the corresponding value will therefore be invalid.
+    Afterwards, remove the 'status' field from the data as this is the only
+    place it plays a role.
 
     Parameters
     ----------
-    sensor : :class:`SensorData` object, length N
+    sensor : :class:`SensorData` object, length *N*
         Raw sensor dataset, which acts like a record array with fields
         'timestamp', 'value' and optionally 'status'
 
     Returns
     -------
-    clean_sensor : :class:`RecordSensorData` object, length M
-        Sensor data with duplicate timestamps and failures removed (M <= N),
-        and only 'timestamp' and 'value' fields left
+    clean_sensor : :class:`RecordSensorData` object, length *M*
+        Sensor data with duplicate timestamps and invalid values removed
+        (*M* <= *N*), and only 'timestamp' and 'value' fields left
 
     """
     x = np.atleast_1d(sensor['timestamp'])
@@ -682,7 +683,7 @@ class SensorCache(dict):
             # Clean up sensor data if non-empty
             if sensor_data:
                 # Sort sensor events in chronological order and discard duplicates and unreadable sensor values
-                sensor_data = remove_duplicates_and_failures(sensor_data)
+                sensor_data = remove_duplicates_and_invalid_values(sensor_data)
             if not sensor_data:
                 sensor_data = dummy_sensor_data(name, value=props.get('initial_value'), dtype=sensor_data.dtype)
                 logger.warning("No usable data found for sensor '%s' - replaced with dummy data (%r)" %

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -70,6 +70,9 @@ class SensorData(object):
     making it a light-weight wrapper focussing on sensor metadata. All data
     access should be via __getitem__ of the appropriate field.
 
+    Where possible, object-valued sensors (including sensors with ndarrays as
+    values) will have values wrapped by :class:`ComparableArrayWrapper`.
+
     Parameters
     ----------
     name : string
@@ -129,6 +132,12 @@ class RecordSensorData(SensorData):
     is a simpler version of a recarray that only provides item-style access to
     fields and not attribute-style access.
 
+    Object-valued sensors are not treated specially in this class, as it is
+    assumed that any wrapping already occurred in the construction of the
+    recarray-like `data` input and will be reflected in its dtype. The original
+    HDF5 sensor datasets also did not contain any objects as they only support
+    standard KATCP types, so there was no need for wrapping there.
+
     Parameters
     ----------
     data : recarray-like, with fields 'timestamp', 'value' and optionally 'status'
@@ -187,6 +196,9 @@ class H5TelstateSensorData(RecordSensorData):
     TODO: This is a temporary fix to get at missing sensors in telstate and
     should be replaced by a proper wrapping of any telstate object.
 
+    Object-valued sensors (including sensors with ndarrays as values) will have
+    its values wrapped by :class:`ComparableArrayWrapper`.
+
     Parameters
     ----------
     data : recarray-like, with fields ('timestamp', 'value')
@@ -226,6 +238,9 @@ class TelstateSensorData(SensorData):
     should be fine as a SensorData object is typically replaced by either
     a CategoricalData object or a NumPy array as part of sensor extraction,
     right after the caching occurs.
+
+    Object-valued sensors (including sensors with ndarrays as values) will have
+    its values wrapped by :class:`ComparableArrayWrapper`.
 
     Parameters
     ----------

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -55,47 +55,107 @@ except ImportError:
 
 
 class SensorData(object):
-    """Raw (uncached) sensor data in record array form.
+    """Raw (uninterpolated) sensor data wrapper.
 
-    This is a convenient container for uncached sensor data which resembles
-    a record array with fields ('timestamp', 'value', 'status'). This is also
-    the typical format of HDF5 datasets used to store sensor data. Its main
-    advantage is that it exposes the sensor data dtype (from the 'value' field)
-    as a top-level attribute, making it compatible with NumPy arrays and
-    :class:`CategoricalData` objects when used together in a sensor cache. It
-    also exposes the sensor name, if available.
+    This is a convenient wrapper for uninterpolated sensor data which resembles
+    a structured array with fields 'timestamp', 'value' and optionally 'status'.
+
+    Its main advantage is that it exposes the sensor data dtype (from the
+    'value' field) as a top-level attribute, making it compatible with NumPy
+    arrays and :class:`CategoricalData` objects when used together in a sensor
+    cache. It also exposes the sensor name, if available.
+
+    The idea is that the raw sensor data is not initially cached in this object,
+    making it a light-weight wrapper focussing on sensor metadata. All data
+    access should be via __getitem__ of the appropriate field.
 
     Parameters
     ----------
-    data : recarray-like, with fields ('timestamp', 'value', 'status')
-        Uncached sensor data as record array or equivalent (such as a
-        :class:`h5py.Dataset`)
-    name : string or None, optional
-        Sensor name (assumed to be data.name by default, if it exists)
-
-    Attributes
-    ----------
+    name : string
+        Sensor name
     dtype : :class:`numpy.dtype` object
         Type of sensor data, as a NumPy dtype
 
     """
+    def __init__(self, name, dtype):
+        self.name = name
+        self.dtype = dtype
+
+    def __getitem__(self, key):
+        """Extract timestamp, value and status of each sensor data point.
+
+        Parameters
+        ----------
+        key : {'timestamp', 'value', 'status'}
+            Name of field to access ('status' is optional and may raise error)
+
+        Returns
+        -------
+        field : :class:`numpy.ndarray` object, shape (N,)
+            Requested field as 1-D array of appropriate dtype (float,
+            self.dtype or string, respectively, for timestamp / value / status)
+
+        Raises
+        ------
+        ValueError
+            If *key* is unsupported field name
+
+        """
+        raise NotImplementedError
+
+    def __bool__(self):
+        """True if sensor has at least one data point."""
+        raise NotImplementedError
+
+    __nonzero__ = __bool__
+
+    def __repr__(self):
+        """Short human-friendly string representation of sensor data object."""
+        return "<katdal.%s '%s' type='%s' at 0x%x>" % \
+               (self.__class__.__name__, self.name, self.dtype, id(self))
+
+
+class RecordSensorData(SensorData):
+    """Raw (uninterpolated) sensor data in record array form.
+
+    This is a wrapper for uninterpolated sensor data which resembles a record
+    array with fields 'timestamp', 'value' and optionally 'status'. This is
+    also the typical format of HDF5 datasets used to store sensor data.
+
+    Technically, the data is interpreted as a NumPy "structured" array, which
+    is a simpler version of a recarray that only provides item-style access to
+    fields and not attribute-style access.
+
+    Parameters
+    ----------
+    data : recarray-like, with fields 'timestamp', 'value' ('status' optional)
+        Uninterpolated sensor data as structured array or equivalent (such as
+        an :class:`h5py.Dataset`)
+    name : string or None, optional
+        Sensor name (assumed to be data.name by default, if it exists)
+
+    """
     def __init__(self, data, name=None):
-        self.data = data
-        self.name = name if name is not None else getattr(data, 'name', '')
-        self.dtype = self.data.dtype.fields['value'][0]
+        name = name if name is not None else getattr(data, 'name', '')
+        dtype = data.dtype.fields['value'][0]
+        super(RecordSensorData, self).__init__(name, dtype)
+        self._data = data
 
     def __getitem__(self, key):
         """Extract timestamp, value and status of each sensor data point."""
-        return np.asarray(self.data[key])
+        return np.asarray(self._data[key])
 
-    def __len__(self):
-        """Number of sensor data points."""
-        return len(self.data)
+    def __bool__(self):
+        """True if sensor has at least one data point."""
+        return len(self._data) > 0
+
+    __nonzero__ = __bool__
 
     def __repr__(self):
         """Short human-friendly string representation of sensor data object."""
         return "<katdal.%s '%s' len=%d type='%s' at 0x%x>" % \
-               (self.__class__.__name__, self.name, len(self), self.dtype, id(self))
+               (self.__class__.__name__, self.name,
+                len(self._data), self.dtype, id(self))
 
 
 def _h5_telstate_unpack(s):
@@ -113,11 +173,11 @@ def _h5_telstate_unpack(s):
             return s
 
 
-class H5TelstateSensorData(SensorData):
-    """Raw (uncached) sensor data in HDF5 TelescopeState record array form.
+class H5TelstateSensorData(RecordSensorData):
+    """Raw (uninterpolated) sensor data in HDF5 TelescopeState recarray form.
 
     This wraps the telstate sensors stored in recent HDF5 files. It differs
-    in two ways from the normal HDF5 sensors: no 'status' column and values
+    in two ways from the normal HDF5 sensors: no 'status' field and values
     stored as pickles.
 
     TODO: This is a temporary fix to get at missing sensors in telstate and
@@ -126,34 +186,37 @@ class H5TelstateSensorData(SensorData):
     Parameters
     ----------
     data : recarray-like, with fields ('timestamp', 'value')
-        Uncached sensor data as record array or equivalent (such as a
-        :class:`h5py.Dataset`)
+        Uninterpolated sensor data as structured array or equivalent (such as
+        an :class:`h5py.Dataset`)
     name : string or None, optional
         Sensor name (assumed to be data.name by default, if it exists)
-
-    Attributes
-    ----------
-    dtype : :class:`numpy.dtype` object
-        Type of sensor data, as a NumPy dtype
 
     """
     def __init__(self, data, name=None):
         super(H5TelstateSensorData, self).__init__(data, name)
-        # Unpickle first value to derive dtype (should be simple for sensors)
-        self.dtype = np.array([_h5_telstate_unpack(data['value'][0])]).dtype
+        # Unpickle first value to derive proper dtype
+        if len(data['value']) > 0:
+            test_data = np.array([_h5_telstate_unpack(data['value'][0])])
+            # Beware array-valued sensors; treat their values as opaque objects
+            # otherwise they will turn 'value' into a mega-array of e.g. float.
+            # This forces sensor values to be 1-D at all times (an invariant).
+            self.dtype = test_data.dtype if test_data.ndim == 1 else np.object
 
     def __getitem__(self, key):
         """Extract timestamp, value and status of each sensor data point."""
-        if key == 'value':
+        if key == 'timestamp':
+            return np.asarray(self._data[key])
+        elif key == 'value':
             # Unpickle sensor data upon request
-            return np.array([_h5_telstate_unpack(s) for s in self.data[key]])
-        elif key == 'status':
-            # Fake the missing status column
-            return np.repeat('nominal', len(self))
+            values = [_h5_telstate_unpack(s) for s in self._data[key]]
+            # Do element-wise assignment from list into array of right shape
+            # and dtype, which ensures that array values remain opaque objects
+            # without incurring a performance penalty for plain old values.
+            values_array = np.empty(len(values), dtype=self.dtype)
+            values_array[:] = values
+            return values_array
         else:
-            # WARNING: if key is an index or slice, values will still be pickled
-            # It is safer to extract data explicitly into recarray in __init__
-            return np.asarray(self.data[key])
+            raise ValueError("Sensor %r data has no key '%s'" % (self.name, key))
 
 
 # -------------------------------------------------------------------------------------------------
@@ -217,11 +280,12 @@ def _safe_linear_interp(xi, yi, x):
 def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
     """Create a SensorData object with a single default value based on type.
 
-    This creates a dummy :class:`SensorData` object based on a default value
-    or a type, for use when no sensor data are available, but filler data are
-    required (e.g. when concatenating sensors from different datasets and one
-    dataset lacks the sensor). The dummy dataset contains a single data point
-    with the filler value and a configurable timestamp (defaulting to way back).
+    This creates a dummy :class:`RecordSensorData` object based on a default
+    value or a type, for use when no sensor data are available, but filler data
+    is required (e.g. when concatenating sensors from different datasets and
+    one dataset lacks the sensor). The dummy dataset contains a single data
+    point with the filler value and a configurable timestamp (defaulting to
+    way back).
 
     Parameters
     ----------
@@ -236,8 +300,8 @@ def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
 
     Returns
     -------
-    data : :class:`SensorData` object
-        Dummy sensor data object
+    data : :class:`RecordSensorData` object, shape (1,)
+        Dummy sensor data object with 'timestamp' and 'value' fields
 
     """
     if value is None:
@@ -250,15 +314,17 @@ def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
             value = ''
         elif np.issubdtype(dtype, np.bool):
             value = False
+        elif np.issubdtype(dtype, np.object):
+            value = None
     else:
         dtype = np.array(value).dtype
-    data = np.rec.fromarrays([[timestamp], [value], ['nominal']],
-                             dtype=[('timestamp', np.float64), ('value', dtype), ('status', '|S7')])
-    return SensorData(data, name)
+    data = np.array(zip([timestamp], [value]),
+                    dtype=[('timestamp', np.float64), ('value', dtype)])
+    return RecordSensorData(data, name)
 
 
-def remove_duplicates(sensor):
-    """Remove duplicate timestamp values from sensor data.
+def remove_duplicates_and_failures(sensor):
+    """Remove duplicate timestamp values and failures from sensor data.
 
     This sorts the 'timestamp' field of the sensor record array and removes any
     duplicate values, updating the corresponding 'value' and 'status' fields as
@@ -266,21 +332,30 @@ def remove_duplicates(sensor):
     of the last of these timestamps are selected. If the values differ for the
     same timestamp, a warning is logged (and the last one is still picked).
 
+    In addition, if there is a 'status' field, get rid of data with a 'failure'
+    status which indicates that the sensor could not be read and the
+    corresponding value will therefore be meaningless. Afterwards, remove the
+    'status' field from the data as this is the only place it plays a role.
+
     Parameters
     ----------
     sensor : :class:`SensorData` object, length N
-        Sensor dataset, which acts like a record array with fields 'timestamp',
-        'value' and 'status'
+        Raw sensor dataset, which acts like a record array with fields
+        'timestamp', 'value' and optionally 'status'
 
     Returns
     -------
-    unique_sensor : :class:`SensorData` object, length M
-        Sensor data with duplicate timestamps removed (M <= N)
+    clean_sensor : :class:`RecordSensorData` object, length M
+        Sensor data with duplicate timestamps and failures removed (M <= N),
+        and only 'timestamp' and 'value' fields left
 
     """
     x = np.atleast_1d(sensor['timestamp'])
     y = np.atleast_1d(sensor['value'])
-    z = np.atleast_1d(sensor['status'])
+    try:
+        z = np.atleast_1d(sensor['status'])
+    except ValueError:
+        z = None
     # Sort x via mergesort, as it is usually already sorted and stability is important
     sort_ind = np.argsort(x, kind='mergesort')
     x, y = x[sort_ind], y[sort_ind]
@@ -290,18 +365,34 @@ def remove_duplicates(sensor):
     unique_ind = last_of_run.nonzero()[0]
     # Determine the index of the x value chosen to represent each original x value (used to pick y values too)
     replacement = unique_ind[len(unique_ind) - np.cumsum(last_of_run[::-1])[::-1]]
-    # All duplicates should have the same y and z values - complain otherwise, but continue
-    if not np.all(y[replacement] == y) or not np.all(z[replacement] == z):
-        logger.debug("Sensor '%s' has duplicate timestamps with different values or statuses" % (sensor.name,))
-        for ind in (y[replacement] != y).nonzero()[0]:
-            logger.debug("At %s, sensor '%s' has values of %s and %s - keeping last one" %
-                         (katpoint.Timestamp(x[ind]).local(), sensor.name, y[ind], y[replacement][ind]))
+    # All duplicates should have the same y and z values - complain otherwise, but continue.
+    # It is a bit tricky to compare objects since array values will result in
+    # arrays of bools, so leverage np.array_equal for all objects instead.
+    same_y = np.array([np.array_equal(y1, y2)
+                       for y1, y2 in zip(y[replacement], y)]) \
+        if y.dtype == np.object else (y[replacement] == y)
+    if not all(same_y):
+        logger.debug("Sensor %r has duplicate timestamps with different values",
+                     sensor.name)
+        for ind in (~same_y).nonzero()[0]:
+            logger.debug("At %s, sensor %r has values of %s and %s - "
+                         "keeping last one", katpoint.Timestamp(x[ind]).local(),
+                         sensor.name, y[ind], y[replacement][ind])
+    if z is not None and not np.all(z[replacement] == z):
+        logger.debug("Sensor %r has duplicate timestamps with different statuses",
+                     sensor.name)
         for ind in (z[replacement] != z).nonzero()[0]:
-            logger.debug("At %s, sensor '%s' has statuses of '%s' and '%s' - keeping last one" %
-                         (katpoint.Timestamp(x[ind]).local(), sensor.name, z[ind], z[replacement][ind]))
-    return SensorData(np.rec.fromarrays([x[unique_ind], y[unique_ind], z[unique_ind]],
-                                        dtype=[('timestamp', x.dtype), ('value', y.dtype), ('status', z.dtype)]),
-                      sensor.name)
+            logger.debug("At %s, sensor %r has statuses of %r and %r - "
+                         "keeping last one", katpoint.Timestamp(x[ind]).local(),
+                         sensor.name, z[ind], z[replacement][ind])
+    # Remove entries where 'status' equals 'failure', if 'status' is present
+    if z is not None:
+        # Explicitly cast status to string type, as k7_augment produced sensors with integer statuses
+        unique_ind = unique_ind[z[unique_ind].astype('|S7') != 'failure']
+    # Strip 'status' / z field from final output as its job is done
+    data = np.array(zip(x[unique_ind], y[unique_ind]),
+                    dtype=[('timestamp', x.dtype), ('value', y.dtype)])
+    return RecordSensorData(data, sensor.name)
 
 # -------------------------------------------------------------------------------------------------
 # -- CLASS :  SensorCache
@@ -315,13 +406,13 @@ class SensorCache(dict):
     values may be numerical or non-numerical (*categorical*), and the timestamps
     are monotonically increasing but not necessarily regularly spaced.
 
-    A *sensor cache* stores sensor data with dictionary-like lookup based on the
-    sensor name. Since the extraction of sensor data from e.g. HDF5 files may be
-    costly, the data are first represented in uncached (raw) form as
+    A *sensor cache* stores sensor data with dictionary-like lookup based on
+    the sensor name. Since the extraction of sensor data from e.g. HDF5 files
+    may be costly, the data is first represented in uncached (raw) form as
     :class:`SensorData` objects, which typically wrap the underlying sensor
-    HDF5 datasets. After extraction, the sensor data are stored either as a NumPy
-    array (for numerical data) or as a :class:`CategoricalData` object (for
-    non-numerical data).
+    HDF5 datasets. After extraction, the sensor data are stored either as
+    a NumPy array (for numerical data) or as a :class:`CategoricalData` object
+    (for non-numerical data).
 
     The sensor cache stores a timestamp array (or indexer) onto which the sensor
     data will be interpolated, together with a boolean selection mask that
@@ -399,10 +490,10 @@ class SensorCache(dict):
 
     def __repr__(self):
         """Short human-friendly string representation of sensor cache object."""
-        sensor_data = [self.get(name, extract=False) for name in self.iterkeys()]
+        sensors = [self.get(name, extract=False) for name in self.iterkeys()]
         return "<katdal.%s sensors=%d cached=%d at 0x%x>" % \
-               (self.__class__.__name__, len(sensor_data),
-                np.sum([not isinstance(data, SensorData) for data in sensor_data]), id(self))
+               (self.__class__.__name__, len(sensors),
+                np.sum([not isinstance(s, SensorData) for s in sensors]), id(self))
 
     def __getitem__(self, name):
         """Sensor values interpolated to correlator data timestamps.
@@ -456,9 +547,9 @@ class SensorCache(dict):
         name : string
             Sensor name
         select : {False, True}, optional
-            True if preset time selection will be applied to returned data
+            True if preset time selection will be applied to interpolated data
         extract : {True, False}, optional
-            True if sensor data should be extracted from HDF5 file and cached
+            True if sensor data should be extracted, interpolated and cached
         categorical : {None, True, False}, optional
             Interpret sensor data as categorical or numerical (by default, data
             of type float is numerical and of any other type is categorical)
@@ -479,10 +570,14 @@ class SensorCache(dict):
 
         Raises
         ------
+        ValueError
+            If select=True and extract=False, as select requires interpolation
         KeyError
             If sensor name was not found in cache and did not match virtual template
 
         """
+        if select and not extract:
+            raise ValueError('Cannot apply selection on raw sensor data')
         try:
             # First try to load the actual sensor data from cache (remember to call base class here!)
             sensor_data = super(SensorCache, self).__getitem__(name)
@@ -509,12 +604,10 @@ class SensorCache(dict):
             # Any properties passed directly to this method takes precedence
             props.update(kwargs)
             # Clean up sensor data if non-empty
-            if len(sensor_data) > 0:
+            if sensor_data:
                 # Sort sensor events in chronological order and discard duplicates and unreadable sensor values
-                sensor_data = remove_duplicates(sensor_data)
-                # Explicitly cast status to string type, as k7_augment produced sensors with integer statuses
-                sensor_data.data = np.atleast_1d(sensor_data[sensor_data['status'].astype('|S7') != 'failure'])
-            if len(sensor_data) == 0:
+                sensor_data = remove_duplicates_and_failures(sensor_data)
+            if not sensor_data:
                 sensor_data = dummy_sensor_data(name, value=props.get('initial_value'), dtype=sensor_data.dtype)
                 logger.warning("No usable data found for sensor '%s' - replaced with dummy data (%r)" %
                                (name, sensor_data['value'][0]))

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -87,7 +87,8 @@ class SensorData(object):
         Parameters
         ----------
         key : {'timestamp', 'value', 'status'}
-            Name of field to access ('status' is optional and may raise error)
+            Name of field to access ('status' is optional and raises ValueError
+            if not supported)
 
         Returns
         -------
@@ -128,7 +129,7 @@ class RecordSensorData(SensorData):
 
     Parameters
     ----------
-    data : recarray-like, with fields 'timestamp', 'value' ('status' optional)
+    data : recarray-like, with fields 'timestamp', 'value' and optionally 'status'
         Uninterpolated sensor data as structured array or equivalent (such as
         an :class:`h5py.Dataset`)
     name : string or None, optional
@@ -457,8 +458,8 @@ def remove_duplicates_and_failures(sensor):
     if z is not None:
         # Explicitly cast status to string type, as k7_augment produced sensors with integer statuses
         status = z[unique_ind].astype('|S7')
-        has_valid_value = np.array([['nominal'], ['warn'], ['error']])
-        unique_ind = unique_ind[(status == has_valid_value).any(axis=0)]
+        unique_ind = unique_ind[(status == 'nominal') | (status == 'warn') |
+                                (status == 'error')]
     # Strip 'status' / z field from final output as its job is done
     data = np.array(zip(x[unique_ind], y[unique_ind]),
                     dtype=[('timestamp', x.dtype), ('value', y.dtype)])

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -77,6 +77,7 @@ class SensorData(object):
         Sensor data type as NumPy dtype (beware that string lengths may be wrong)
 
     """
+
     def __init__(self, name, dtype):
         self.name = name
         self.dtype = dtype
@@ -99,7 +100,7 @@ class SensorData(object):
         Raises
         ------
         ValueError
-            If *key* is unsupported field name
+            If `key` is unsupported field name
 
         """
         raise NotImplementedError
@@ -136,6 +137,7 @@ class RecordSensorData(SensorData):
         Sensor name (assumed to be data.name by default, if it exists)
 
     """
+
     def __init__(self, data, name=None):
         name = name if name is not None else getattr(data, 'name', '')
         dtype = data.dtype.fields['value'][0]
@@ -160,7 +162,7 @@ class RecordSensorData(SensorData):
 
 
 def _h5_telstate_unpack(s):
-    """This unpacks a telstate value from its string representation."""
+    """Unpack a telstate value from its string representation."""
     try:
         # Since 2016-05-09 the HDF5 TelescopeState contains pickled values
         return pickle.loads(s)
@@ -193,6 +195,7 @@ class H5TelstateSensorData(RecordSensorData):
         Sensor name (assumed to be data.name by default, if it exists)
 
     """
+
     def __init__(self, data, name=None):
         super(H5TelstateSensorData, self).__init__(data, name)
         # Unpickle first value to derive proper dtype.
@@ -245,6 +248,7 @@ class TelstateSensorData(SensorData):
         If sensor name is not found in telstate or it is an attribute instead
 
     """
+
     def __init__(self, telstate, name):
         self._telstate = telstate
         # This cache simplifies separate 'timestamp' / 'value' access pattern
@@ -301,13 +305,13 @@ class TelstateSensorData(SensorData):
 def _safe_linear_interp(xi, yi, x):
     """Linearly interpolate (xi, yi) values to x positions, safely.
 
-    Given a set of N ``(x, y)`` points, provided in the *xi* and *yi* arrays,
+    Given a set of N ``(x, y)`` points, provided in the `xi` and `yi` arrays,
     this will calculate ``y``-coordinate values for a set of M ``x``-coordinates
-    provided in the *x* array, using linear interpolation.
+    provided in the `x` array, using linear interpolation.
 
-    It is safe in the sense that if *xi* and *yi* only contain a single point
+    It is safe in the sense that if `xi` and `yi` only contain a single point
     it will revert to zeroth-order interpolation. In addition, data will not
-    be extrapolated linearly past the edges of *xi*, but the closest value
+    be extrapolated linearly past the edges of `xi`, but the closest value
     will be used instead (i.e. also zeroth-order interpolation).
 
     Parameters
@@ -366,7 +370,7 @@ def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
     name : string
         Sensor name
     value : object, optional
-        Filler value (default is None, meaning *dtype* will be used instead)
+        Filler value (default is None, meaning `dtype` will be used instead)
     dtype : :class:`numpy.dtype` object or equivalent, optional
         Desired sensor data type, used if no explicit value is given
     timestamp : float, optional
@@ -531,6 +535,7 @@ class SensorCache(dict):
         the aliased names and the data of the original sensors.
 
     """
+
     def __init__(self, cache, timestamps, dump_period, keep=slice(None), props=None, virtual={}, aliases={}):
         # Initialise cache via dict constructor
         super(SensorCache, self).__init__(cache)


### PR DESCRIPTION
This introduces the ```TelstateSensorData``` class which wraps raw (uninterpolated) sensor data stored in a ```TelescopeState``` object. The existing class with the same name is renamed to ```H5TelstateSensorData``` to highlight that it is wrapping telstate stored in HDF5 as opposed to the live database.

In the process, clarify the ```SensorData``` API, add the ```ComparableArrayWrapper``` class to support object-valued sensors like "cal_product_B" and clean up ```dtype``` support. This also required quite a bit of tinkering with ```CategoricalData``` and concatenated versions of these classes.
