### PR TITLE
Revert sensor output to be arrays and fix SR-877

### DIFF
--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -434,7 +434,7 @@ class CategoricalData(object):
             remap = np.arange(len(self.unique_values))
             remap[index:] -= 1
             self.indices = remap[self.indices[keep]]
-            self.events = np.r_[self.events[keep], self.events[-1]]
+            self.events = np.r_[self.events[:-1][keep], self.events[-1]]
             del self.unique_values[index]
 
     def add_unmatched(self, segments, match_dist=1):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -287,6 +287,13 @@ class CategoricalData(object):
     def __getitem__(self, key):
         """Look up sensor value at selected dumps.
 
+        Be aware that the dtype of the returned array may differ from that of
+        the :class:`CategoricalData` object if the sensor values are
+        multi-dimensional arrays themselves, in effect falling back to the
+        underlying dtype. For large multi-dimensional sensor values this
+        method may also cause memory issues as it will duplicate these arrays
+        into the final output array.
+
         Parameters
         ----------
         key : int or slice or sequence of int or sequence of bool
@@ -294,8 +301,8 @@ class CategoricalData(object):
 
         Returns
         -------
-        val : object or list of objects
-            Sensor values at selected dumps, either single value or list of them
+        val : object or array of objects
+            Sensor values at selected dumps, either single value or array of them
 
         """
         if isinstance(key, slice):
@@ -307,7 +314,7 @@ class CategoricalData(object):
         indices = self._lookup(key)
         # Interpret indices as either a sequence of ints or a single int
         try:
-            return [self.unique_values[index] for index in indices]
+            return np.array([self.unique_values[index] for index in indices])
         except TypeError:
             return self.unique_values[indices]
 


### PR DESCRIPTION
This addresses three issues:

- Revert the output of categorical sensors to be ndarrays as opposed to lists when `select=True`. This restores many use cases of noise diode sensors in standard reduction scripts.

- Fix katdal to work with NumPy 1.13. It is now a definite error if a boolean advanced index differs in length from the array it indexes. The main culprit is `CategoricalData` which applied the same index to `indices` and `events` attributes even though the latter is one longer than the former. This is JIRA ticket [SR-877](https://skaafrica.atlassian.net/browse/SR-877).

- Remove a NumPy FutureWarning which has no effect except being irritating. This points out that future interpretations of `array(a) == array(b)` for objects will not involve identity and that is the way we want it anyway.
