### PR TITLE
Fix categorical sensor parser

### DIFF
--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -722,7 +722,7 @@ def sensor_to_categorical(sensor_timestamps, sensor_values, dump_midtimes,
     if transform is not None:
         if wrapped_values:
             orig_transform = transform
-            def transform(value):   # noqa: E301
+            def transform(value):   # noqa: E306
                 """Unwrap wrapped value, transform and rewrap."""
                 return ComparableArrayWrapper(orig_transform(value.unwrapped))
         sensor_values = np.array([transform(y) for y in sensor_values])
@@ -737,7 +737,10 @@ def sensor_to_categorical(sensor_timestamps, sensor_values, dump_midtimes,
     # Clean up dump->event mapping, taking into account greedy values
     greedy_values = () if greedy_values is None else greedy_values
     greedy = [value in greedy_values for value in sensor_values]
-    cleaned_up = list(_single_event_per_dump(np.r_[events, num_dumps], greedy))
+    # Add one-past-last-dump terminator (will be removed again by `cleaned_up`)
+    events = np.r_[events, num_dumps]
+    # NB: `events` is mutated by `_single_event_per_dump`
+    cleaned_up = list(_single_event_per_dump(events, greedy))
     sensor_values = sensor_values[cleaned_up]
     events = events[cleaned_up]
     # Discard sensor events that do not change the (transformed) sensor value

--- a/katdal/test/test_categorical.py
+++ b/katdal/test/test_categorical.py
@@ -3,7 +3,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from katdal.categorical import _single_event_per_dump
+from katdal.categorical import _single_event_per_dump, sensor_to_categorical
 
 
 def test_dump_to_event_parsing():
@@ -16,3 +16,19 @@ def test_dump_to_event_parsing():
     assert_array_equal(cleaned, [0, 2, 4, 6, 7], 'Dump->event parser failed')
     assert_array_equal(new_values, list('ACEGH'), 'Dump->event parser failed')
     assert_array_equal(new_events, [0, 1, 3, 5, 6], 'Dump->event parser failed')
+
+
+def test_categorical_sensor_creation():
+    timestamps = [-363.784, 2.467, 8.839, 8.867, 15.924, 48.925, 54.897, 88.982]
+    values = ['stop', 'slew', 'track', 'slew', 'track', 'slew', 'track', 'slew']
+    dump_period = 8.
+    dump_times = np.arange(4., 100., dump_period)
+    categ = sensor_to_categorical(timestamps, values, dump_times, dump_period,
+                                  greedy_values=('slew', 'stop'),
+                                  initial_value='slew')
+    assert_array_equal(categ.unique_values, ['slew', 'track'],
+                       'Sensor->categorical failed')
+    assert_array_equal(categ.events, [0, 2, 6, 7, 11, 12],
+                       'Sensor->categorical failed')
+    assert_array_equal(categ.indices, [0, 1, 0, 1, 0],
+                       'Sensor->categorical failed')


### PR DESCRIPTION
The `_single_event_per_dump` filter is supposed to mutate the events array to simplify the process of pushing forward displaced events. Unfortunately the code in `sensor_to_categorical` passed it a copy of `events`, which defeats the whole purpose of the mutation.

Pass in the real `events`, slap on more warnings about the mutation and even add a unit test to verify the finicky sensor->categorical conversion.