### PR TITLE
Load new-style noise diode sensors

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -558,9 +558,7 @@ class SensorCache(dict):
         self.virtual = virtual
         # Add sensor aliases
         for alias, original in aliases.iteritems():
-            for name, data in self.iteritems():
-                if name.endswith(original):
-                    self[name.replace(original, alias)] = data
+            self.add_aliases(alias, original)
 
     def __str__(self):
         """Verbose human-friendly string representation of sensor cache object."""
@@ -620,6 +618,25 @@ class SensorCache(dict):
     def iteritems(self):
         """Custom item iterator that avoids extracting sensor data."""
         return iter([(key, self.get(key, extract=False)) for key in self.iterkeys()])
+
+    def add_aliases(self, alias, original):
+        """Add alternate names / aliases for sensors.
+
+        Search for sensors with names ending in the `original` suffix and form
+        a corresponding alternate name by replacing `original` with `alias`.
+        The new aliased sensors will re-use the data of the original sensors.
+
+        Parameters
+        ----------
+        alias : string
+            The new sensor name suffix that replaces `original`
+        original : string
+            Sensors with names that end in this will get aliases
+
+        """
+        for name, data in self.iteritems():
+            if name.endswith(original):
+                self[name.replace(original, alias)] = data
 
     def get(self, name, select=False, extract=True, **kwargs):
         """Sensor values interpolated to correlator data timestamps.


### PR DESCRIPTION
The latest noise diode sensors have the band identifier as part of their name. For example, the old L-band `dig_noise_diode` is now `dig_l_band_noise_diode`. This caters for the different origins of the sensors as not all digitisers are served by the MeerKAT DMC.

Modify the main alias `nd_coupler` manually if a new-style noise diode sensor was found (else remain with the default 'dig_noise_diode'). This should have been a proper sensor alias, but that machinery can only change suffixes and we need to move from `TelescopeState` to `Antennas` as well.

Also ensure that all sensors ending in `noise_diode` are interpreted correctly. And allow aliases to be added to the `SensorCache` after construction for posterity.

This addresses JIRA ticket [MKAT-99](https://skaafrica.atlassian.net/browse/MKAT-99).