### PR TITLE
Handle output L0 stream attributes

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -492,8 +492,8 @@ class H5DataV3(DataSet):
         spw_params['channel_width'] = bandwidth / num_chans
         # Continue with different channel count, but invalidate centre freq (keep channel width though)
         if num_chans != self._vis.shape[1]:
-            logger.warning('Number of channels received from CBF / ingest (%d) differs '
-                           'from number of channels in data (%d) - trusting the latter',
+            logger.warning('Number of channels reported in metadata (%d) differs '
+                           'from actual number of channels in data (%d) - trusting the latter',
                            num_chans, self._vis.shape[1])
             num_chans = self._vis.shape[1]
             spw_params.pop('centre_freq', None)
@@ -574,12 +574,12 @@ class H5DataV3(DataSet):
 
         If the raw value is a member of `no_unpickle`, returns it directly
         rather than attempting to unpickle it. This is to support older files
-        in which the attributes were not pickled.
+        (created before 2016-11-30) in which the attributes were not pickled.
+
         """
         try:
             value = self.file['TelescopeState'].attrs[key]
             if value in no_unpickle:
-                # Telstate attributes were serialised via str() until 2016-11-29
                 return value
             else:
                 return pickle.loads(value)


### PR DESCRIPTION
This is to handle the new attributes written by ingest
(ska-sa/katsdpingest#194) and filewriter (ska-sa/katsdpdata#71), which
allow for
- The file to contain either the continuum or spectral L0 stream
  (disambiguated by an HDF5 attribute on the /Data group);
- The file to contain only a subset of channels, and thus have separate
  n_chans, bandwidth, centre frequency to the CBF.

An area that will need some review is the precedence of the different
ways of determining centre frequency. Currently I've made it trust the
SDP-written value (e.g. sdp_l0_center_freq) over anything else, because
values determined from the band don't take account of channel subsetting
in ingest. However, that in turn means trusting the CAM centre
frequency, which is probably not correct for Ku band. I propose that the
right way to handle that is to fix CAM to be Ku band aware before trying
to update RTS with the latest ingest and filewriter.