### PR TITLE
Fix receiver serial numbers

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -443,8 +443,12 @@ class H5DataV3(DataSet):
                            'please provide it via band parameter')
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
-            rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
+            # Try sanitised version of RX serial number first
+            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
             rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
+            if rx_serial == 0:
+                rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
+                rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
             if band:
                 self.receivers[ant] = '%s.%d' % (band, rx_serial)
             nd_sensor = 'TelescopeState/%s_dig_%s_band_noise_diode' % (ant, band)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -210,8 +210,12 @@ class VisibilityDataV4(DataSet):
                            'please provide it via band parameter')
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
-            rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
+            # Try sanitised version of RX serial number first
+            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
             rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
+            if rx_serial == 0:
+                rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
+                rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
             if band:
                 self.receivers[ant] = '%s.%d' % (band, rx_serial)
             nd_sensor = 'TelescopeState/%s_dig_%s_band_noise_diode' % (ant, band)


### PR DESCRIPTION
The underlying sensor has changed from the raw "rsc_rxl_serial_number" to "rx_serial_number". Since August, cam2telstate picks the appropriate sensor based on the subarray band, crucially renames it and then ignores the rest. This behaviour has now also been rolled out to RTS, hence the fix.