### PR TITLE
The Chunk Store

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -18,10 +18,11 @@
 
 import contextlib
 
+import numpy as np
+
 
 class StoreUnavailable(OSError):
-    """The interaction with the underlying storage medium failed, e.g. due
-       to it being offline, authentication failure, misconfiguration, etc."""
+    """Could not access underlying storage medium (offline, auth failed, etc)."""
 
 
 class ChunkNotFound(KeyError):
@@ -82,7 +83,7 @@ class ChunkStore(object):
             Identifier of parent array `x` of chunk
         slices : sequence of unit-stride slice objects
             Identifier of individual chunk, to be extracted as `x[slices]`
-        dtype : :class:`numpy.dtype` object
+        dtype : :class:`numpy.dtype` object or equivalent
             Data type of array `x`
 
         Returns
@@ -156,7 +157,7 @@ class ChunkStore(object):
             Identifier of individual chunk, to be extracted as `x[slices]`
         chunk : :class:`numpy.ndarray` object, optional
             Actual chunk data as ndarray (used to validate shape / dtype)
-        dtype : :class:`numpy.dtype` object, optional
+        dtype : :class:`numpy.dtype` object or equivalent, optional
             Data type of array `x` (used for validation only)
 
         Returns
@@ -174,7 +175,7 @@ class ChunkStore(object):
 
         """
         try:
-            shape = tuple([s.stop - s.start for s in slices])
+            shape = tuple(s.stop - s.start for s in slices)
         except (TypeError, AttributeError):
             raise BadChunk('Array {!r}: chunk ID should be a sequence of '
                            'slice objects, not {}'.format(array_name, slices))
@@ -194,7 +195,7 @@ class ChunkStore(object):
         if chunk is not None and chunk.dtype.hasobject:
             raise BadChunk('Chunk {!r}: actual dtype {} cannot contain '
                            'objects'.format(chunk_name, chunk.dtype))
-        if dtype is not None and dtype.hasobject:
+        if dtype is not None and np.dtype(dtype).hasobject:
             raise BadChunk('Chunk {!r}: Requested dtype {} cannot contain '
                            'objects'.format(chunk_name, dtype))
         return chunk_name, shape

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -168,36 +168,3 @@ class ChunkStore(object):
             raise ValueError('Chunk {!r}: Requested dtype {} cannot contain '
                              'objects'.format(chunk_name, dtype))
         return chunk_name, shape
-
-
-class DictChunkStore(ChunkStore):
-    """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays.
-
-    This interprets all keyword arguments as NumPy arrays and stores them in
-    an `arrays` dict. Each array is identified by its corresponding keyword.
-    """
-
-    def __init__(self, **kwargs):
-        self.arrays = kwargs
-
-    def get(self, array_name, slices, dtype):
-        """See the docstring of :meth:`ChunkStore.get`."""
-        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
-        try:
-            chunk = self.arrays[array_name][slices]
-        except KeyError:
-            raise OSError('Array {!r} not found in DictChunkStore which has {}'
-                          .format(array_name, self.arrays.keys()))
-        if dtype != chunk.dtype:
-            raise ValueError('Chunk {!r}: requested dtype {} differs from '
-                             'actual dtype {}'
-                             .format(chunk_name, dtype, chunk.dtype))
-        return chunk
-
-    def put(self, array_name, slices, chunk):
-        """See the docstring of :meth:`ChunkStore.put`."""
-        self.chunk_metadata(array_name, slices, chunk=chunk)
-        self.get(array_name, slices, chunk.dtype)[:] = chunk
-
-    get.__doc__ = ChunkStore.get.__doc__
-    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -95,7 +95,7 @@ class ChunkStore(object):
         return ChunkStore.join(array_name, idx)
 
 
-class DictOfArraysChunkStore(ChunkStore):
+class DictChunkStore(ChunkStore):
     """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays.
 
     This interprets all keyword arguments as NumPy arrays and stores them in

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -54,10 +54,10 @@ class ChunkStore(object):
         ----------
         array_name : string
             Identifier of parent array `x` of chunk
-        slices : sequence of slice objects
+        slices : sequence of unit-stride slice objects
             Identifier of individual chunk, to be extracted as `x[slices]`
         dtype : :class:`numpy.dtype` object
-            Dtype of array `x`
+            Data type of array `x`
 
         Returns
         -------
@@ -66,10 +66,11 @@ class ChunkStore(object):
 
         Raises
         ------
-        OSError
-            If requested chunk was not found in store (or connection failed)
         ValueError
             If requested `dtype` does not match underlying parent array dtype
+            or `slices` has wrong specification
+        OSError
+            If requested chunk was not found in store (or connection failed)
         """
         raise NotImplementedError
 
@@ -80,10 +81,17 @@ class ChunkStore(object):
         ----------
         array_name : string
             Identifier of parent array `x` of chunk
-        slices : sequence of slice objects
+        slices : sequence of unit-stride slice objects
             Identifier of individual chunk, to be extracted as `x[slices]`
         chunk : :class:`numpy.ndarray` object
             Chunk as ndarray with shape commensurate with `slices`
+
+        Raises
+        ------
+        ValueError
+            If `slices` is wrong or its shape does not match that of `chunk`
+        OSError
+            If connection to store failed (or `array_name` is incompatible)
         """
         raise NotImplementedError
 
@@ -102,12 +110,64 @@ class ChunkStore(object):
         return name.split(cls.NAME_SEP, maxsplit)
 
     @classmethod
-    def chunk_name(cls, array_name, slices):
-        """Form chunk name from array name and `slices` chunk identifier."""
+    def chunk_metadata(cls, array_name, slices, chunk=None, dtype=None):
+        """Turn array name and chunk identifier into chunk name and shape.
+
+        Form the full chunk name from `array_name` and `slices` and extract
+        the chunk shape from `slices`, validating it in the process. If `chunk`
+        or `dtype` is given, check that `chunk` is commensurate with `slices`
+        and that `dtype` contains no objects which would cause nasty segfaults.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of parent array `x` of chunk
+        slices : sequence of unit-stride slice objects
+            Identifier of individual chunk, to be extracted as `x[slices]`
+        chunk : :class:`numpy.ndarray` object, optional
+            Actual chunk data as ndarray (used to validate shape / dtype)
+        dtype : :class:`numpy.dtype` object, optional
+            Data type of array `x` (used for validation only)
+
+        Returns
+        -------
+        chunk_name : string
+            Full chunk name used to find chunk in underlying storage medium
+        shape : tuple of int
+            Chunk shape tuple associated with `slices`
+
+        Raises
+        ------
+        ValueError
+            If `slices` has wrong specification or its shape does not match
+            that of `chunk`, or any dtype contains objects
+
+        """
+        try:
+            shape = tuple([s.stop - s.start for s in slices])
+        except (TypeError, AttributeError):
+            raise ValueError('Array {!r}: chunk ID should be a sequence of '
+                             'slice objects, not {}'.format(array_name, slices))
+        # Verify that all slice strides are unity (i.e. it's a "simple" slice)
+        if not all([s.step in (1, None) for s in slices]):
+            raise ValueError('Array {!r}: chunk ID {} contains non-unit strides'
+                             .format(array_name, slices))
+        # Construct chunk name from array_name + slices
         index = [s.start for s in slices]
-        idx = '_'.join(["{:0{width}d}".format(i, width=cls.NAME_INDEX_WIDTH)
-                        for i in index])
-        return ChunkStore.join(array_name, idx)
+        idxstr = '_'.join(["{:0{width}d}".format(i, width=cls.NAME_INDEX_WIDTH)
+                           for i in index])
+        chunk_name = cls.join(array_name, idxstr)
+        if chunk is not None and chunk.shape != shape:
+            raise ValueError('Chunk {!r}: shape {} implied by slices does not '
+                             'match actual shape {}'
+                             .format(chunk_name, shape, chunk.shape))
+        if chunk is not None and chunk.dtype.hasobject:
+            raise ValueError('Chunk {!r}: actual dtype {} cannot contain '
+                             'objects'.format(chunk_name, chunk.dtype))
+        if dtype is not None and dtype.hasobject:
+            raise ValueError('Chunk {!r}: Requested dtype {} cannot contain '
+                             'objects'.format(chunk_name, dtype))
+        return chunk_name, shape
 
 
 class DictChunkStore(ChunkStore):
@@ -122,18 +182,21 @@ class DictChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
+        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         try:
             chunk = self.arrays[array_name][slices]
         except KeyError:
-            raise OSError('Array %r not found in DictChunkStore which has %s' %
-                          (array_name, self.arrays.keys()))
+            raise OSError('Array {!r} not found in DictChunkStore which has {}'
+                          .format(array_name, self.arrays.keys()))
         if dtype != chunk.dtype:
-            raise ValueError('Requested dtype %s differs from chunk dtype %s'
-                             % (dtype, chunk.dtype))
+            raise ValueError('Chunk {!r}: requested dtype {} differs from '
+                             'actual dtype {}'
+                             .format(chunk_name, dtype, chunk.dtype))
         return chunk
 
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
+        self.chunk_metadata(array_name, slices, chunk=chunk)
         self.get(array_name, slices, chunk.dtype)[:] = chunk
 
     get.__doc__ = ChunkStore.get.__doc__

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -1,0 +1,119 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Base class for accessing a store of chunks (i.e. N-dimensional arrays)."""
+
+CHUNK_NAME_SEP = '/'
+# Width is large enough to store any dump / channel / corrprod index for MeerKAT
+CHUNK_NAME_INDEX_WIDTH = 5
+
+
+class ChunkStore(object):
+    """Base class for accessing a store of chunks (i.e. N-dimensional arrays).
+
+    A *chunk* is a simple (i.e. unit-stride) slice of an N-dimensional array
+    known as its *parent array*. The array is identified by a string name,
+    while the chunk within the array is identified by a sequence of slice
+    objects which may be used to extract the chunk from the array. The array
+    is a :class:`numpy.ndarray` object with an associated *dtype*.
+
+    The basic idea is that the chunk store contains multiple arrays addressed
+    by name. The list of available arrays and all array metadata (shape,
+    chunks and dtype) are stored elsewhere. The metadata is used to identify
+    chunks, while the chunk store takes care of storing and retrieving
+    bytestrings of actual chunk data. These are packaged back into NumPy
+    arrays for the user.
+    """
+
+    def get(self, array_name, slices, dtype=None):
+        """Get chunk from the store.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of parent array `x` of chunk
+        slices : sequence of slice objects
+            Identifier of individual chunk, to be extracted as `x[slices]`
+        dtype : :class:`numpy.dtype` object, optional
+            Dtype of array (useful if unknown or different to that of `x`)
+
+        Returns
+        -------
+        chunk : :class:`numpy.ndarray` object
+            Chunk as ndarray with dtype `dtype` and shape dictated by `slices`
+        """
+        raise NotImplementedError
+
+    def put(self, array_name, slices, chunk):
+        """Put chunk into the store.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of parent array `x` of chunk
+        slices : sequence of slice objects
+            Identifier of individual chunk, to be extracted as `x[slices]`
+        chunk : :class:`numpy.ndarray` object
+            Chunk as ndarray with shape commensurate with `slices`
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def join(*names):
+        """Join components of chunk name with supported separator."""
+        return CHUNK_NAME_SEP.join(names)
+
+    @staticmethod
+    def split(name, maxsplit=-1):
+        """Split chunk name into components based on supported separator."""
+        return name.split(CHUNK_NAME_SEP, maxsplit)
+
+    @staticmethod
+    def chunk_name(array_name, slices):
+        """Form chunk name from array name and `slices` chunk identifier."""
+        index = [s.start for s in slices]
+        idx = '_'.join(["{:0{width}d}".format(i, width=CHUNK_NAME_INDEX_WIDTH)
+                        for i in index])
+        return ChunkStore.join(array_name, idx)
+
+
+class DictOfArraysChunkStore(ChunkStore):
+    """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays.
+
+    This interprets all keyword arguments as NumPy arrays and stores them in
+    an `arrays` dict. Each array is identified by its corresponding keyword.
+    """
+
+    def __init__(self, **kwargs):
+        self.arrays = kwargs
+
+    def get(self, array_name, slices, dtype=None):
+        """See the docstring of :meth:`ChunkStore.get`."""
+        chunk = self.arrays[array_name][slices]
+        # If the requested dtype differs from the underlying type, do a view
+        if dtype is not None and dtype != chunk.dtype:
+            chunk = chunk.view(dtype)
+            # In addition, merge the final dimension if new dtype swallows it
+            if len(slices) == chunk.ndim - 1:
+                chunk = chunk.squeeze(axis=-1)
+        return chunk
+
+    def put(self, array_name, slices, chunk):
+        """See the docstring of :meth:`ChunkStore.put`."""
+        self.get(array_name, slices, chunk.dtype)[:] = chunk
+
+    get.__doc__ = ChunkStore.get.__doc__
+    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -215,6 +215,12 @@ class ChunkStore(object):
         try:
             yield
         except tuple(self._error_map) as e:
-            ChunkStoreError = self._error_map[type(e)]
+            try:
+                ChunkStoreError = self._error_map[type(e)]
+            except KeyError:
+                # The exception has to be a subclass of one of the error_map
+                # keys, so pick the first one found
+                FirstBase = next(c for c in self._error_map if isinstance(e, c))
+                ChunkStoreError = self._error_map[FirstBase]
             prefix = 'Chunk {!r}: '.format(chunk_name) if chunk_name else ''
             raise ChunkStoreError(prefix + str(e))

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -57,6 +57,8 @@ class ChunkStore(object):
 
         Raises
         ------
+        OSError
+            If requested chunk was not found in store (or connection failed)
         ValueError
             If requested `dtype` does not match underlying parent array dtype
         """
@@ -107,7 +109,11 @@ class DictChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
-        chunk = self.arrays[array_name][slices]
+        try:
+            chunk = self.arrays[array_name][slices]
+        except KeyError:
+            raise OSError('Array %r not found in DictChunkStore which has %s' %
+                          (array_name, self.arrays.keys()))
         if dtype != chunk.dtype:
             raise ValueError('Requested dtype %s differs from chunk dtype %s'
                              % (dtype, chunk.dtype))

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -39,7 +39,9 @@ class DictChunkStore(ChunkStore):
         """See the docstring of :meth:`ChunkStore.get`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         with self._standard_errors(chunk_name):
-            chunk = self.arrays[array_name][slices]
+            array = self.arrays[array_name]
+            # Ensure that chunk is array (otherwise 0-dim array becomes number)
+            chunk = array[slices] if slices != () else array
         if dtype != chunk.dtype:
             raise BadChunk('Chunk {!r}: requested dtype {} differs from '
                            'actual dtype {}'
@@ -49,7 +51,7 @@ class DictChunkStore(ChunkStore):
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
         self.chunk_metadata(array_name, slices, chunk=chunk)
-        self.get(array_name, slices, chunk.dtype)[:] = chunk
+        self.get(array_name, slices, chunk.dtype)[()] = chunk
 
     get.__doc__ = ChunkStore.get.__doc__
     put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -1,0 +1,52 @@
+################################################################################
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays."""
+
+from .chunkstore import ChunkStore
+
+
+class DictChunkStore(ChunkStore):
+    """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays.
+
+    This interprets all keyword arguments as NumPy arrays and stores them in
+    an `arrays` dict. Each array is identified by its corresponding keyword.
+    """
+
+    def __init__(self, **kwargs):
+        self.arrays = kwargs
+
+    def get(self, array_name, slices, dtype):
+        """See the docstring of :meth:`ChunkStore.get`."""
+        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
+        try:
+            chunk = self.arrays[array_name][slices]
+        except KeyError:
+            raise OSError('Array {!r} not found in DictChunkStore which has {}'
+                          .format(array_name, self.arrays.keys()))
+        if dtype != chunk.dtype:
+            raise ValueError('Chunk {!r}: requested dtype {} differs from '
+                             'actual dtype {}'
+                             .format(chunk_name, dtype, chunk.dtype))
+        return chunk
+
+    def put(self, array_name, slices, chunk):
+        """See the docstring of :meth:`ChunkStore.put`."""
+        self.chunk_metadata(array_name, slices, chunk=chunk)
+        self.get(array_name, slices, chunk.dtype)[:] = chunk
+
+    get.__doc__ = ChunkStore.get.__doc__
+    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -16,7 +16,7 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays."""
 
-from .chunkstore import ChunkStore, ChunkNotFound
+from .chunkstore import ChunkStore, ChunkNotFound, BadChunk
 
 
 class DictChunkStore(ChunkStore):
@@ -41,9 +41,9 @@ class DictChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             chunk = self.arrays[array_name][slices]
         if dtype != chunk.dtype:
-            raise ValueError('Chunk {!r}: requested dtype {} differs from '
-                             'actual dtype {}'
-                             .format(chunk_name, dtype, chunk.dtype))
+            raise BadChunk('Chunk {!r}: requested dtype {} differs from '
+                           'actual dtype {}'
+                           .format(chunk_name, dtype, chunk.dtype))
         return chunk
 
     def put(self, array_name, slices, chunk):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -55,7 +55,7 @@ class NpyFileChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
-        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         filename = os.path.join(self.path, chunk_name) + '.npy'
         try:
             chunk = np.load(filename, allow_pickle=False)
@@ -68,7 +68,7 @@ class NpyFileChunkStore(ChunkStore):
 
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
-        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         filename = os.path.join(self.path, chunk_name) + '.npy'
         # Ensure any subdirectories are in place
         try:

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -1,0 +1,73 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+
+import numpy as np
+
+from .chunkstore import ChunkStore
+
+
+class NpyFileChunkStore(ChunkStore):
+    """A store of chunks (i.e. N-dimensional arrays) based on NPY files.
+
+    Each chunk is stored in a separate binary file in NumPy ``.npy`` format.
+    The filename is constructed as
+
+      "<path>/<array>/<idx>.npy"
+
+    where "<path>" is the chunk store directory specified on construction,
+    "<array>" is the name of the parent array of the chunk and "<idx>" is
+    the index string of each chunk (e.g. "00001_00512").
+
+    For a description of the ``.npy`` format, see the module docstring
+    of `numpy.lib.format` or the NumPy Enhancement Proposal
+    http://docs.scipy.org/doc/numpy/neps/npy-format.html
+
+    Parameters
+    ----------
+    path : string
+        Top-level directory that contains NPY files of chunk store
+
+    Raises
+    ------
+    IOError
+        If path does not exist / is not readable
+    """
+
+    def __init__(self, path):
+        if not os.path.isdir(path):
+            raise IOError('Directory %r does not exist' % (path,))
+        self.path = path
+
+    def get(self, array_name, slices, dtype=None):
+        """See the docstring of :meth:`ChunkStore.get`."""
+        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        filename = os.path.join(self.path, chunk_name) + '.npy'
+        return np.load(filename)
+
+    def put(self, array_name, slices, chunk):
+        """See the docstring of :meth:`ChunkStore.put`."""
+        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        filename = os.path.join(self.path, chunk_name) + '.npy'
+        # Ensure any subdirectories are in place
+        dirname, _ = os.path.split(filename)
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname)
+        np.save(filename, chunk)
+
+    get.__doc__ = ChunkStore.get.__doc__
+    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -53,11 +53,15 @@ class NpyFileChunkStore(ChunkStore):
             raise IOError('Directory %r does not exist' % (path,))
         self.path = path
 
-    def get(self, array_name, slices, dtype=None):
+    def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         chunk_name = ChunkStore.chunk_name(array_name, slices)
         filename = os.path.join(self.path, chunk_name) + '.npy'
-        return np.load(filename)
+        chunk = np.load(filename)
+        if dtype != chunk.dtype:
+            raise ValueError('Requested dtype %s differs from NPY file dtype %s'
+                             % (dtype, chunk.dtype))
+        return chunk
 
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
+"""A store of chunks (i.e. N-dimensional arrays) based on NPY files."""
 
 import os
 import contextlib

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -20,7 +20,7 @@ import os
 
 import numpy as np
 
-from .chunkstore import ChunkStore, StoreUnavailable, ChunkNotFound
+from .chunkstore import ChunkStore, StoreUnavailable, ChunkNotFound, BadChunk
 
 
 class NpyFileChunkStore(ChunkStore):
@@ -46,7 +46,7 @@ class NpyFileChunkStore(ChunkStore):
 
     Raises
     ------
-    OSError
+    :exc:`chunkstore.StoreUnavailable`
         If path does not exist / is not readable
     """
 
@@ -63,8 +63,8 @@ class NpyFileChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             chunk = np.load(filename, allow_pickle=False)
         if dtype != chunk.dtype:
-            raise ValueError('Requested dtype %s differs from NPY file dtype %s'
-                             % (dtype, chunk.dtype))
+            raise BadChunk('Requested dtype %s differs from NPY file dtype %s'
+                           % (dtype, chunk.dtype))
         return chunk
 
     def put(self, array_name, slices, chunk):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -53,7 +53,7 @@ class NpyFileChunkStore(ChunkStore):
     def __init__(self, path):
         super(NpyFileChunkStore, self).__init__({IOError: ChunkNotFound})
         if not os.path.isdir(path):
-            raise StoreUnavailable('Directory %r does not exist' % (path,))
+            raise StoreUnavailable('Directory {!r} does not exist'.format(path))
         self.path = path
 
     def get(self, array_name, slices, dtype):
@@ -63,8 +63,8 @@ class NpyFileChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             chunk = np.load(filename, allow_pickle=False)
         if dtype != chunk.dtype:
-            raise BadChunk('Requested dtype %s differs from NPY file dtype %s'
-                           % (dtype, chunk.dtype))
+            raise BadChunk('Requested dtype {} differs from NPY file dtype {}'
+                           .format(dtype, chunk.dtype))
         return chunk
 
     def put(self, array_name, slices, chunk):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -33,9 +33,9 @@ class NpyFileChunkStore(ChunkStore):
     "<array>" is the name of the parent array of the chunk and "<idx>" is
     the index string of each chunk (e.g. "00001_00512").
 
-    For a description of the ``.npy`` format, see the module docstring
-    of `numpy.lib.format` or the NumPy Enhancement Proposal
-    http://docs.scipy.org/doc/numpy/neps/npy-format.html
+    For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`
+    or the relevant NumPy Enhancement Proposal
+    `here <http://docs.scipy.org/doc/numpy/neps/npy-format.html>`_.
 
     Parameters
     ----------

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -1,0 +1,81 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""A store of chunks (i.e. N-dimensional arrays) based on the Ceph RADOS API."""
+
+import numpy as np
+try:
+    import rados
+except ImportError:
+    # librados (i.e. direct Ceph access) is only really available on Linux
+    rados = None
+
+from .chunkstore import ChunkStore
+
+
+class RadosChunkStore(ChunkStore):
+    """A store of chunks (i.e. N-dimensional arrays) based on the Ceph RADOS API.
+
+    The full identifier of each chunk (the "chunk name"), which is also the
+    object key for the RADOS interface, is given by
+
+     "<array>/<idx>"
+
+    where "<array>" is the name of the parent array of the chunk and "<idx>" is
+    the index string of each chunk (e.g. "00001_00512").
+
+    Parameters
+    ----------
+    ceph_conf : string
+        Path to the ceph.conf config file used to connect to target Ceph cluster
+    ceph_pool : string
+        Name of the Ceph pool
+
+    Raises
+    ------
+    ImportError
+        If rados is not installed (it's an optional dependency otherwise)
+    IOError
+        If requested Ceph pool is not available in cluster
+    """
+
+    def __init__(self, ceph_conf, ceph_pool):
+        if not rados:
+            raise ImportError('Please install rados for katdal RADOS support')
+        cluster = rados.Rados(conffile=ceph_conf)
+        cluster.connect()
+        available_pools = cluster.list_pools()
+        if ceph_pool not in available_pools:
+            raise IOError("Specified pool %s not available in this cluster (%s)"
+                          % (ceph_pool, available_pools))
+        self.ioctx = cluster.open_ioctx(ceph_pool)
+
+    def get(self, array_name, slices, dtype):
+        """See the docstring of :meth:`ChunkStore.get`."""
+        shape = tuple([s.stop - s.start for s in slices])
+        key = ChunkStore.chunk_name(array_name, slices)
+        num_bytes = np.prod(shape) * dtype.itemsize
+        data_str = self.ioctx.read(key, num_bytes)
+        return np.ndarray(shape, dtype, data_str)
+
+    def put(self, array_name, slices, chunk):
+        """See the docstring of :meth:`ChunkStore.put`."""
+        key = ChunkStore.chunk_name(array_name, slices)
+        data_str = chunk.tobytes()
+        self.ioctx.write_full(key, data_str)
+
+    get.__doc__ = ChunkStore.get.__doc__
+    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -83,8 +83,7 @@ class RadosChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
-        shape = tuple([s.stop - s.start for s in slices])
-        key = ChunkStore.chunk_name(array_name, slices)
+        key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         num_bytes = np.prod(shape) * dtype.itemsize
         with _convert_rados_errors():
             data_str = self.ioctx.read(key, num_bytes)
@@ -92,7 +91,7 @@ class RadosChunkStore(ChunkStore):
 
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
-        key = ChunkStore.chunk_name(array_name, slices)
+        key, shape = self.chunk_name(array_name, slices, chunk=chunk)
         data_str = chunk.tobytes()
         with _convert_rados_errors():
             self.ioctx.write_full(key, data_str)

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -99,6 +99,7 @@ class RadosChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
+        dtype = np.dtype(dtype)
         key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         num_bytes = int(np.prod(shape)) * dtype.itemsize
         with self._standard_errors(key):

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -100,7 +100,7 @@ class RadosChunkStore(ChunkStore):
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
-        num_bytes = np.prod(shape) * dtype.itemsize
+        num_bytes = int(np.prod(shape)) * dtype.itemsize
         with self._standard_errors(key):
             # Try to read an extra byte to see if data is more than expected
             data_str = self.ioctx.read(key, num_bytes + 1)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -16,7 +16,6 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API."""
 
-import io
 import contextlib
 
 import numpy as np

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -51,9 +51,16 @@ class S3ChunkStore(ChunkStore):
     ----------
     client : :class:`botocore.client.S3` object
         Pre-configured botocore S3 client
+
+    Raises
+    ------
+    ImportError
+        If botocore is not installed (it's an optional dependency otherwise)
     """
 
     def __init__(self, client):
+        if not botocore:
+            raise ImportError('Please install botocore for katdal S3 support')
         error_map = {EndpointConnectionError: StoreUnavailable,
                      client.exceptions.NoSuchKey: ChunkNotFound,
                      client.exceptions.NoSuchBucket: ChunkNotFound}

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -1,0 +1,95 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API."""
+
+import io
+
+import numpy as np
+try:
+    import botocore
+except ImportError:
+    botocore = None
+else:
+    import botocore.config
+    import botocore.session
+
+from .chunkstore import ChunkStore
+
+
+class S3ChunkStore(ChunkStore):
+    """A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API.
+
+    S3 authentication (i.e. the access + secret keys) is handled externally
+    via the botocore config file or environment variables. The full identifier
+    of each chunk (the "chunk name") is given by
+
+      "<bucket>/<path>/<idx>"
+
+    where "<bucket>" refers to the relevant S3 bucket, "<bucket>/<path>" is the
+    name of the parent array of the chunk and "<idx>" is the index string
+    of each chunk (e.g. "00001_00512"). The corresponding S3 key string of
+    a chunk is therefore "<path>/<idx>".
+
+    This object encapsulates the S3 client / session and its underlying
+    connection pool, which allows subsequent get and put calls to share the
+    connections.
+
+    Parameters
+    ----------
+    url : string
+        Endpoint of S3 service, e.g. 'http://127.0.0.1:9000'
+
+    Raises
+    ------
+    ImportError
+        If botocore is not installed (it's an optional dependency otherwise)
+    """
+
+    def __init__(self, url):
+        if not botocore:
+            raise ImportError('Please install botocore for katdal S3 support')
+        session = botocore.session.get_session()
+        config = botocore.config.Config(max_pool_connections=200,
+                                        s3={'addressing_style': 'path'})
+        self.client = session.create_client(service_name='s3',
+                                            endpoint_url=url, config=config)
+
+    def get(self, array_name, slices, dtype):
+        """See the docstring of :meth:`ChunkStore.get`."""
+        shape = tuple([s.stop - s.start for s in slices])
+        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        bucket, key = ChunkStore.split(chunk_name, 1)
+        response = self.client.get_object(Bucket=bucket, Key=key)
+        stream = response['Body']
+        # Read data buffer and convert to ndarray without further copying
+        data_str = stream.read()
+        stream.close()
+        return np.ndarray(shape, dtype, data_str)
+
+    def put(self, array_name, slices, chunk):
+        """See the docstring of :meth:`ChunkStore.put`."""
+        chunk_name = ChunkStore.chunk_name(array_name, slices)
+        bucket, key = ChunkStore.split(chunk_name, 1)
+        # Only copy the data buffer if array is discontiguous
+        if chunk.flags.contiguous:
+            data = io.BytesIO(chunk.data)
+        else:
+            data = chunk.tobytes()
+        self.client.put_object(Bucket=bucket, Key=key, Body=data)
+
+    get.__doc__ = ChunkStore.get.__doc__
+    put.__doc__ = ChunkStore.put.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -109,7 +109,7 @@ class S3ChunkStore(ChunkStore):
             response = self.client.get_object(Bucket=bucket, Key=key)
         with contextlib.closing(response['Body']) as stream:
             data_str = stream.read()
-        expected_bytes = np.prod(shape) * dtype.itemsize
+        expected_bytes = int(np.prod(shape)) * dtype.itemsize
         if len(data_str) != expected_bytes:
             raise BadChunk('Chunk {!r}: dtype {} and shape {} implies an '
                            'object size of {} bytes, got {} bytes instead'

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -84,9 +84,8 @@ class S3ChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
-        shape = tuple([s.stop - s.start for s in slices])
-        chunk_name = ChunkStore.chunk_name(array_name, slices)
-        bucket, key = ChunkStore.split(chunk_name, 1)
+        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
+        bucket, key = self.split(chunk_name, 1)
         with _convert_botocore_errors():
             response = self.client.get_object(Bucket=bucket, Key=key)
         with contextlib.closing(response['Body']) as stream:
@@ -95,8 +94,8 @@ class S3ChunkStore(ChunkStore):
 
     def put(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
-        chunk_name = ChunkStore.chunk_name(array_name, slices)
-        bucket, key = ChunkStore.split(chunk_name, 1)
+        chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
+        bucket, key = self.split(chunk_name, 1)
         data_str = chunk.tobytes()
         with _convert_botocore_errors():
             self.client.put_object(Bucket=bucket, Key=key, Body=data_str)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -103,6 +103,7 @@ class S3ChunkStore(ChunkStore):
 
     def get(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
+        dtype = np.dtype(dtype)
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         bucket, key = self.split(chunk_name, 1)
         with self._standard_errors(chunk_name):

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2017, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_categorical.py
+++ b/katdal/test/test_categorical.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_categorical.py
+++ b/katdal/test/test_categorical.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 """Tests for :py:mod:`katdal.categorical`."""
 
 import numpy as np

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -20,14 +20,14 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from nose.tools import assert_raises
 
-from katdal.chunkstore import ChunkStore, DictOfArraysChunkStore
+from katdal.chunkstore import ChunkStore, DictChunkStore
 
 
-class TestDictOfArraysChunkStore(object):
+class TestDictChunkStore(object):
     def setup(self):
         self.x = np.arange(10)
         self.y = np.arange(24.).reshape(4, 3, 2)
-        self.store = DictOfArraysChunkStore(x=self.x, y=self.y)
+        self.store = DictChunkStore(x=self.x, y=self.y)
 
     def test_store(self):
         store = ChunkStore()

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -33,6 +33,20 @@ class TestDictChunkStore(object):
         store = ChunkStore()
         assert_raises(NotImplementedError, store.get, 1, 2, 3)
         assert_raises(NotImplementedError, store.put, 1, 2, 3)
+        # Bad slice specifications
+        assert_raises(ValueError, store.chunk_metadata, "x", 3)
+        assert_raises(ValueError, store.chunk_metadata, "x", [3, 2])
+        assert_raises(ValueError, store.chunk_metadata, "x", slice(10))
+        assert_raises(ValueError, store.chunk_metadata, "x", [slice(10)])
+        assert_raises(ValueError, store.chunk_metadata, "x", [slice(0, 10, 2)])
+        # Chunk mismatch
+        assert_raises(ValueError, store.chunk_metadata, "x", [slice(0, 10, 1)],
+                      chunk=np.ones(11))
+        # Bad dtype
+        assert_raises(ValueError, store.chunk_metadata, "x", [slice(0, 10, 1)],
+                      chunk=np.array(10 * [{}]))
+        assert_raises(ValueError, store.chunk_metadata, "x", [slice(0, 2)],
+                      dtype=np.dtype(np.object))
 
     def test_get(self):
         s = (slice(3, 5),)
@@ -50,7 +64,7 @@ class TestDictChunkStore(object):
         actual = self.x[:5]
         desired = np.array([0, 1, 2, 0, 1])
         assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
-        s = (slice(0, 2), slice(0, 3))
+        s = (slice(0, 2), slice(0, 3), slice(0, 2))
         self.store.put('y', s, np.zeros((2, 3, 2), dtype=np.dtype(np.float)))
         actual = self.y[:2, :3, :]
         desired = np.zeros((2, 3, 2))

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -86,7 +86,7 @@ class ChunkStoreTestBase(object):
         self.store.put(name, s, desired)
         actual = self.store.get(name, s, desired.dtype)
         assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
-        # Try a different, larger dtype
+        # Stored object has fewer bytes than expected (and wrong dtype)
         assert_raises(BadChunk, self.store.get, name, s, self.y.dtype)
         # Check basic put + get on 3-D float
         s = (slice(3, 7), slice(2, 5), slice(1, 2))
@@ -95,5 +95,5 @@ class ChunkStoreTestBase(object):
         self.store.put(name, s, desired)
         actual = self.store.get(name, s, desired.dtype)
         assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))
-        # Try a different, smaller dtype
+        # Stored object has more bytes than expected (and wrong dtype)
         assert_raises(BadChunk, self.store.get, name, s, self.x.dtype)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -1,0 +1,61 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.chunkstore`."""
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_raises
+
+from katdal.chunkstore import ChunkStore, DictOfArraysChunkStore
+
+
+class TestDictOfArraysChunkStore(object):
+    def setup(self):
+        self.x = np.arange(10)
+        self.y = np.arange(24.).reshape(4, 3, 2)
+        self.store = DictOfArraysChunkStore(x=self.x, y=self.y)
+
+    def test_store(self):
+        store = ChunkStore()
+        assert_raises(NotImplementedError, store.get, 1, 2, 3)
+        assert_raises(NotImplementedError, store.put, 1, 2, 3)
+
+    def test_get(self):
+        s = (slice(3, 5),)
+        actual = self.store.get('x', s, np.dtype(np.int))
+        desired = self.x[s]
+        assert_array_equal(actual, desired, "Error getting x[%s]" % (s,))
+        s = (slice(1, 4), slice(1, 3), slice(1, 2))
+        actual = self.store.get('y', s, np.dtype(np.float))
+        desired = self.y[s]
+        assert_array_equal(actual, desired, "Error getting y[%s]" % (s,))
+        s = (slice(0, 2), slice(0, 3))
+        actual = self.store.get('y', s, np.dtype(np.complex))
+        desired = self.y.view(np.complex)[..., 0][s]
+        assert_array_equal(actual, desired, "Error getting complex y[%s]" % (s,))
+
+    def test_put(self):
+        s = (slice(3, 5),)
+        self.store.put('x', s, np.arange(2))
+        actual = self.x[:5]
+        desired = np.array([0, 1, 2, 0, 1])
+        assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
+        s = (slice(0, 2), slice(0, 3))
+        self.store.put('y', s, np.zeros((2, 3), dtype=np.complex))
+        actual = self.y[:2, :3, :]
+        desired = np.zeros((2, 3, 2))
+        assert_array_equal(actual, desired, "Error putting complex y[%s]" % (s,))

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -97,3 +97,15 @@ class ChunkStoreTestBase(object):
         assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))
         # Stored object has more bytes than expected (and wrong dtype)
         assert_raises(BadChunk, self.store.get, name, s, self.x.dtype)
+        # Try a chunk with zero size
+        s = (slice(4, 7), slice(3, 3), slice(0, 2))
+        desired = self.y[s]
+        name = self.array_name('y')
+        self.store.put(name, s, desired)
+        actual = self.store.get(name, s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))
+        # Try an empty slice (not allowed)
+        s = ()
+        desired = self.x[s]
+        name = self.array_name('x')
+        assert_raises(BadChunk, self.store.put, name, s, desired)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -43,10 +43,6 @@ class TestDictOfArraysChunkStore(object):
         actual = self.store.get('y', s, np.dtype(np.float))
         desired = self.y[s]
         assert_array_equal(actual, desired, "Error getting y[%s]" % (s,))
-        s = (slice(0, 2), slice(0, 3))
-        actual = self.store.get('y', s, np.dtype(np.complex))
-        desired = self.y.view(np.complex)[..., 0][s]
-        assert_array_equal(actual, desired, "Error getting complex y[%s]" % (s,))
 
     def test_put(self):
         s = (slice(3, 5),)
@@ -55,7 +51,7 @@ class TestDictOfArraysChunkStore(object):
         desired = np.array([0, 1, 2, 0, 1])
         assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
         s = (slice(0, 2), slice(0, 3))
-        self.store.put('y', s, np.zeros((2, 3), dtype=np.complex))
+        self.store.put('y', s, np.zeros((2, 3, 2), dtype=np.dtype(np.float)))
         actual = self.y[:2, :3, :]
         desired = np.zeros((2, 3, 2))
-        assert_array_equal(actual, desired, "Error putting complex y[%s]" % (s,))
+        assert_array_equal(actual, desired, "Error putting y[%s]" % (s,))

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -17,17 +17,12 @@
 """Tests for :py:mod:`katdal.chunkstore`."""
 
 import numpy as np
-from numpy.testing import assert_array_equal
 from nose.tools import assert_raises
 
-from katdal.chunkstore import ChunkStore, DictChunkStore
+from katdal.chunkstore import ChunkStore
 
 
-class TestDictChunkStore(object):
-    def setup(self):
-        self.x = np.arange(10)
-        self.y = np.arange(24.).reshape(4, 3, 2)
-        self.store = DictChunkStore(x=self.x, y=self.y)
+class TestChunkStore(object):
 
     def test_store(self):
         store = ChunkStore()
@@ -47,25 +42,3 @@ class TestDictChunkStore(object):
                       chunk=np.array(10 * [{}]))
         assert_raises(ValueError, store.chunk_metadata, "x", [slice(0, 2)],
                       dtype=np.dtype(np.object))
-
-    def test_get(self):
-        s = (slice(3, 5),)
-        actual = self.store.get('x', s, np.dtype(np.int))
-        desired = self.x[s]
-        assert_array_equal(actual, desired, "Error getting x[%s]" % (s,))
-        s = (slice(1, 4), slice(1, 3), slice(1, 2))
-        actual = self.store.get('y', s, np.dtype(np.float))
-        desired = self.y[s]
-        assert_array_equal(actual, desired, "Error getting y[%s]" % (s,))
-
-    def test_put(self):
-        s = (slice(3, 5),)
-        self.store.put('x', s, np.arange(2))
-        actual = self.x[:5]
-        desired = np.array([0, 1, 2, 0, 1])
-        assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
-        s = (slice(0, 2), slice(0, 3), slice(0, 2))
-        self.store.put('y', s, np.zeros((2, 3, 2), dtype=np.dtype(np.float)))
-        actual = self.y[:2, :3, :]
-        desired = np.zeros((2, 3, 2))
-        assert_array_equal(actual, desired, "Error putting y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -1,0 +1,51 @@
+################################################################################
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.chunkstore_dict`."""
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from katdal.chunkstore_dict import DictChunkStore
+
+
+class TestDictChunkStore(object):
+    def setup(self):
+        self.x = np.arange(10)
+        self.y = np.arange(24.).reshape(4, 3, 2)
+        self.store = DictChunkStore(x=self.x, y=self.y)
+
+    def test_get(self):
+        s = (slice(3, 5),)
+        actual = self.store.get('x', s, np.dtype(np.int))
+        desired = self.x[s]
+        assert_array_equal(actual, desired, "Error getting x[%s]" % (s,))
+        s = (slice(1, 4), slice(1, 3), slice(1, 2))
+        actual = self.store.get('y', s, np.dtype(np.float))
+        desired = self.y[s]
+        assert_array_equal(actual, desired, "Error getting y[%s]" % (s,))
+
+    def test_put(self):
+        s = (slice(3, 5),)
+        self.store.put('x', s, np.arange(2))
+        actual = self.x[:5]
+        desired = np.array([0, 1, 2, 0, 1])
+        assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
+        s = (slice(0, 2), slice(0, 3), slice(0, 2))
+        self.store.put('y', s, np.zeros((2, 3, 2), dtype=np.dtype(np.float)))
+        actual = self.y[:2, :3, :]
+        desired = np.zeros((2, 3, 2))
+        assert_array_equal(actual, desired, "Error putting y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -16,36 +16,10 @@
 
 """Tests for :py:mod:`katdal.chunkstore_dict`."""
 
-import numpy as np
-from numpy.testing import assert_array_equal
-
 from katdal.chunkstore_dict import DictChunkStore
+from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
-class TestDictChunkStore(object):
+class TestDictChunkStore(ChunkStoreTestBase):
     def setup(self):
-        self.x = np.arange(10)
-        self.y = np.arange(24.).reshape(4, 3, 2)
         self.store = DictChunkStore(x=self.x, y=self.y)
-
-    def test_get(self):
-        s = (slice(3, 5),)
-        actual = self.store.get('x', s, np.dtype(np.int))
-        desired = self.x[s]
-        assert_array_equal(actual, desired, "Error getting x[%s]" % (s,))
-        s = (slice(1, 4), slice(1, 3), slice(1, 2))
-        actual = self.store.get('y', s, np.dtype(np.float))
-        desired = self.y[s]
-        assert_array_equal(actual, desired, "Error getting y[%s]" % (s,))
-
-    def test_put(self):
-        s = (slice(3, 5),)
-        self.store.put('x', s, np.arange(2))
-        actual = self.x[:5]
-        desired = np.array([0, 1, 2, 0, 1])
-        assert_array_equal(actual, desired, "Error putting x[%s]" % (s,))
-        s = (slice(0, 2), slice(0, 3), slice(0, 2))
-        self.store.put('y', s, np.zeros((2, 3, 2), dtype=np.dtype(np.float)))
-        actual = self.y[:2, :3, :]
-        desired = np.zeros((2, 3, 2))
-        assert_array_equal(actual, desired, "Error putting y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -22,4 +22,4 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 class TestDictChunkStore(ChunkStoreTestBase):
     def setup(self):
-        self.store = DictChunkStore(x=self.x, y=self.y)
+        self.store = DictChunkStore(**vars(self))

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -38,7 +38,7 @@ class TestNpyFileChunkStore(object):
         shutil.rmtree(self.tempdir)
 
     def test_store(self):
-        assert_raises(IOError, NpyFileChunkStore, 'hahahahaha')
+        assert_raises(OSError, NpyFileChunkStore, 'hahahahaha')
 
     def test_put_and_get(self):
         s = (slice(3, 5),)

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -19,35 +19,27 @@
 import tempfile
 import shutil
 
-import numpy as np
-from numpy.testing import assert_array_equal
 from nose.tools import assert_raises
 
 from katdal.chunkstore_npy import NpyFileChunkStore
+from katdal.chunkstore import StoreUnavailable
+from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
-class TestNpyFileChunkStore(object):
+class TestNpyFileChunkStore(ChunkStoreTestBase):
+    """Tests interacting with an actual temp dir, implying a slower setup."""
+
     def setup(self):
         """Create temp dir to store NPY files and build ChunkStore on that."""
         self.tempdir = tempfile.mkdtemp()
-        self.x = np.arange(10)
-        self.y = np.arange(24.).reshape(4, 3, 2)
         self.store = NpyFileChunkStore(self.tempdir)
 
     def teardown(self):
         shutil.rmtree(self.tempdir)
 
-    def test_store(self):
-        assert_raises(OSError, NpyFileChunkStore, 'hahahahaha')
 
-    def test_put_and_get(self):
-        s = (slice(3, 5),)
-        desired = self.x[s]
-        self.store.put('x', s, desired)
-        actual = self.store.get('x', s, desired.dtype)
-        assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
-        s = (slice(1, 4), slice(1, 3), slice(1, 2))
-        desired = self.y[s]
-        self.store.put('y', s, desired)
-        actual = self.store.get('y', s, desired.dtype)
-        assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))
+class TestDudNpyFileChunkStore(object):
+    """Tests that don't need a temp dir, only a 'dud' store."""
+
+    def test_store_unavailable(self):
+        assert_raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -1,0 +1,53 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.chunkstore_npy`."""
+
+import tempfile
+import shutil
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_raises
+
+from katdal.chunkstore_npy import NpyFileChunkStore
+
+
+class TestNpyFileChunkStore(object):
+    def setup(self):
+        """Create temp dir to store NPY files and build ChunkStore on that."""
+        self.tempdir = tempfile.mkdtemp()
+        self.x = np.arange(10)
+        self.y = np.arange(24.).reshape(4, 3, 2)
+        self.store = NpyFileChunkStore(self.tempdir)
+
+    def teardown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_store(self):
+        assert_raises(IOError, NpyFileChunkStore, 'hahahahaha')
+
+    def test_put_and_get(self):
+        s = (slice(3, 5),)
+        desired = self.x[s]
+        self.store.put('x', s, desired)
+        actual = self.store.get('x', s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
+        s = (slice(1, 4), slice(1, 3), slice(1, 2))
+        desired = self.y[s]
+        self.store.put('y', s, desired)
+        actual = self.store.get('y', s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -38,6 +38,10 @@ class TestRadosChunkStore(object):
         except (ImportError, OSError, IOError):
             raise SkipTest('Rados not installed or cluster misconfigured / down')
 
+    def array_name(self, path):
+        namespace = 'katdal_test_chunkstore_rados'
+        return self.store.join(namespace, path)
+
     def test_store(self):
         # Pretend that rados is not installed
         real_rados = katdal.chunkstore_rados.rados
@@ -48,11 +52,13 @@ class TestRadosChunkStore(object):
     def test_put_and_get(self):
         s = (slice(3, 5),)
         desired = self.x[s]
-        self.store.put('x', s, desired)
-        actual = self.store.get('x', s, desired.dtype)
+        name = self.array_name('x')
+        self.store.put(name, s, desired)
+        actual = self.store.get(name, s, desired.dtype)
         assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
         s = (slice(1, 4), slice(1, 3), slice(1, 2))
         desired = self.y[s]
-        self.store.put('y', s, desired)
-        actual = self.store.get('y', s, desired.dtype)
+        name = self.array_name('y')
+        self.store.put(name, s, desired)
+        actual = self.store.get(name, s, desired.dtype)
         assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -30,12 +30,11 @@ class TestRadosChunkStore(object):
         self.x = np.arange(10)
         self.y = np.arange(24.).reshape(4, 3, 2)
         # Test configuration on seekat cluster (run this on appropriate machine!)
-        conf = '/etc/ceph/seekat.conf'
+        conf = '/etc/ceph/ceph.conf'
         pool = 'test_katdal'
-        keyring = '/home/kat/.ceph/seekat.client.admin.keyring'
         try:
-            self.store = RadosChunkStore(conf, pool, keyring)
-        except (ImportError, OSError, IOError):
+            self.store = RadosChunkStore(conf, pool)
+        except (ImportError, OSError):
             raise SkipTest('Rados not installed or cluster misconfigured / down')
 
     def array_name(self, path):

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -52,6 +52,8 @@ class TestDudRadosChunkStore(object):
     def test_store_unavailable(self):
         # Pretend that rados is not installed
         katdal.chunkstore_rados.rados = None
+        katdal.chunkstore_rados._rados_import_error = ImportError()
         assert_raises(ImportError, RadosChunkStore, None)
         katdal.chunkstore_rados.rados = rados
+        katdal.chunkstore_rados._rados_import_error = None
         assert_raises(StoreUnavailable, RadosChunkStore.from_config, 'x', 'y')

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -30,10 +30,10 @@ class TestRadosChunkStore(ChunkStoreTestBase):
 
     def setup(self):
         # Look for default Ceph installation but expect a special test pool
-        conf = '/etc/ceph/ceph.conf'
+        config = '/etc/ceph/ceph.conf'
         pool = 'test_katdal'
         try:
-            self.store = RadosChunkStore(conf, pool)
+            self.store = RadosChunkStore.from_config(config, pool)
         except (ImportError, StoreUnavailable):
             raise SkipTest('Rados not installed or cluster misconfigured / down')
 
@@ -52,6 +52,6 @@ class TestDudRadosChunkStore(object):
     def test_store_unavailable(self):
         # Pretend that rados is not installed
         katdal.chunkstore_rados.rados = None
-        assert_raises(ImportError, RadosChunkStore, 'blah', 'blah')
+        assert_raises(ImportError, RadosChunkStore, None)
         katdal.chunkstore_rados.rados = rados
-        assert_raises(StoreUnavailable, RadosChunkStore, 'blah', 'blah')
+        assert_raises(StoreUnavailable, RadosChunkStore.from_config, 'x', 'y')

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -1,0 +1,58 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.chunkstore_s3`."""
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose import SkipTest
+from nose.tools import assert_raises
+
+import katdal.chunkstore_rados
+from katdal.chunkstore_rados import RadosChunkStore
+
+
+class TestRadosChunkStore(object):
+    def setup(self):
+        self.x = np.arange(10)
+        self.y = np.arange(24.).reshape(4, 3, 2)
+        # Test configuration on seekat cluster (run this on appropriate machine!)
+        conf = '/etc/ceph/seekat.conf'
+        pool = 'test_katdal'
+        keyring = '/home/kat/.ceph/seekat.client.admin.keyring'
+        try:
+            self.store = RadosChunkStore(conf, pool, keyring)
+        except (ImportError, OSError, IOError):
+            raise SkipTest('Rados not installed or cluster misconfigured / down')
+
+    def test_store(self):
+        # Pretend that rados is not installed
+        real_rados = katdal.chunkstore_rados.rados
+        katdal.chunkstore_rados.rados = None
+        assert_raises(ImportError, RadosChunkStore, 'blah', 'blah')
+        katdal.chunkstore_rados.rados = real_rados
+
+    def test_put_and_get(self):
+        s = (slice(3, 5),)
+        desired = self.x[s]
+        self.store.put('x', s, desired)
+        actual = self.store.get('x', s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
+        s = (slice(1, 4), slice(1, 3), slice(1, 2))
+        desired = self.y[s]
+        self.store.put('y', s, desired)
+        actual = self.store.get('y', s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -19,13 +19,13 @@
 import tempfile
 import shutil
 import subprocess
-import requests
 import time
 
 import numpy as np
 from numpy.testing import assert_array_equal
 from nose import SkipTest
 from nose.tools import assert_raises
+import requests
 
 import katdal.chunkstore_s3
 from katdal.chunkstore_s3 import S3ChunkStore

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -1,0 +1,100 @@
+################################################################################
+# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.chunkstore_s3`."""
+
+import tempfile
+import shutil
+import subprocess
+import requests
+import time
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose import SkipTest
+from nose.tools import assert_raises
+
+import katdal.chunkstore_s3
+from katdal.chunkstore_s3 import S3ChunkStore
+
+
+class TestS3ChunkStore(object):
+    def setup(self):
+        """Start Fake S3 service running on temp dir, and ChunkStore on that."""
+        self.tempdir = tempfile.mkdtemp()
+        host = 'localhost'
+        # Choose a random port and hope it's available
+        port = np.random.randint(10000, 60000)
+        url = "http://%s:%d" % (host, port)
+        try:
+            self.fakes3 = subprocess.Popen(['fakes3', 'server', '-H', host,
+                                            '-p', str(port), '-r', self.tempdir])
+        except OSError:
+            self.fakes3 = None
+            self.teardown()
+            raise SkipTest('Could not start fakes3 server (is it installed?)')
+        start = time.time()
+        # Give up after waiting a few seconds for Fake S3
+        while time.time() - start <= 10:
+            try:
+                response = requests.get(url, timeout=0.5)
+            except requests.exceptions.ConnectionError:
+                time.sleep(0.3)
+            else:
+                # In case there is already another service on this port (even S3)
+                if response.reason == 'OK':
+                    break
+                else:
+                    self.teardown()
+                    raise SkipTest('Unexpected response from fakes3 server')
+        else:
+            self.teardown()
+            raise SkipTest('Could not connect to fakes3 server')
+        # Now start up store
+        self.x = np.arange(10)
+        self.y = np.arange(24.).reshape(4, 3, 2)
+        self.store = S3ChunkStore(url)
+
+    def teardown(self):
+        if self.fakes3:
+            self.fakes3.terminate()
+            self.fakes3.wait()
+        shutil.rmtree(self.tempdir)
+
+    def array_name(self, path):
+        bucket = 'katdal-unittest'
+        return self.store.join(bucket, path)
+
+    def test_store(self):
+        # Pretend that botocore is not installed
+        real_botocore = katdal.chunkstore_s3.botocore
+        katdal.chunkstore_s3.botocore = None
+        assert_raises(ImportError, S3ChunkStore, 'blah')
+        katdal.chunkstore_s3.botocore = real_botocore
+
+    def test_put_and_get(self):
+        s = (slice(3, 5),)
+        desired = self.x[s]
+        name = self.array_name('x')
+        self.store.put(name, s, desired)
+        actual = self.store.get(name, s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing x[%s]" % (s,))
+        s = (slice(1, 4), slice(1, 3), slice(1, 2))
+        desired = self.y[s]
+        name = self.array_name('y')
+        self.store.put(name, s, desired)
+        actual = self.store.get(name, s, desired.dtype)
+        assert_array_equal(actual, desired, "Error storing y[%s]" % (s,))

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -66,7 +66,10 @@ class TestS3ChunkStore(object):
         # Now start up store
         self.x = np.arange(10)
         self.y = np.arange(24.).reshape(4, 3, 2)
-        self.store = S3ChunkStore(url)
+        try:
+            self.store = S3ChunkStore(url)
+        except ImportError:
+            raise SkipTest('S3 botocore dependency not installed')
 
     def teardown(self):
         if self.fakes3:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -41,7 +41,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
                                             '-r', self.tempdir, '-p', '0',
                                             '-a', host, '-H', host],
                                            stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE, bufsize=1)
+                                           stderr=subprocess.PIPE)
         except OSError:
             raise SkipTest('Could not start fakes3 server (is it installed?)')
         start = time.time()
@@ -51,7 +51,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             line = self.fakes3.stderr.readline().strip()
             ports_found = re.search(r' port=(\d{4,5})$', line)
             if ports_found:
-                port = ports_found.groups()[0]
+                port = ports_found.group(1)
                 return 'http://%s:%s' % (host, port)
         raise SkipTest('Could not connect to fakes3 server')
 
@@ -97,4 +97,4 @@ class TestDudS3ChunkStore(object):
             raise SkipTest('S3 botocore dependency not installed')
 
     def test_store_unavailable(self):
-        assert_raises(StoreUnavailable, S3ChunkStore.from_url, 'hahahahahaha')
+        assert_raises(StoreUnavailable, S3ChunkStore.from_url, 'http://i.nvalid/')

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+botocore==1.8.9
 Cython
+docutils
 future
 h5py
+jmespath==0.9.3
 katversion
 numpy
 pkginfo

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ katversion
 numpy
 pkginfo
 pyephem
+python-dateutil
 six
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint

--- a/scripts/ff_holo_to_h5v1.py
+++ b/scripts/ff_holo_to_h5v1.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/fix_ant_positions.py
+++ b/scripts/fix_ant_positions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/h5list.py
+++ b/scripts/h5list.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -154,7 +154,7 @@ def corrprod_index_and_missing_mask(h5):
 
   # Identify missing correlator products
   missing_cp = np.logical_not([i is not None for i in cp_index])
-  
+
   # Now create ndarray containing all integers
   # missing_cp will be used to identify bad entries
   cp_index = np.asarray([i if i else 0 for i in cp_index])

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -250,7 +250,7 @@ if __name__ == '__main__':
         with open(args.ceph_conf, "r") as ceph_conf:
             ts_pbs.add("ceph_conf", ceph_conf.readlines(), immutable=True)
     else:
-        obj_store = S3ChunkStore(args.s3_url)
+        obj_store = S3ChunkStore.from_url(args.s3_url)
         ts_pbs.add("s3_endpoint", args.s3_url, immutable=True)
 
     target_object_size = args.obj_size * 2 ** 20

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -240,8 +240,8 @@ if __name__ == '__main__':
 
     use_rados = args.ceph_pool is not None
     if use_rados:
-        obj_store = RadosChunkStore(args.ceph_conf, args.ceph_pool,
-                                    args.ceph_keyring)
+        obj_store = RadosChunkStore.from_config(args.ceph_conf, args.ceph_pool,
+                                                args.ceph_keyring)
         pool_stats = obj_store.ioctx.get_stats()
         logger.info("Connected to pool %s. Currently holds %d objects "
                     "totalling %g GB", args.ceph_pool,

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -66,9 +66,11 @@ def parse_args():
                         help='Number of dumps to process. Default is all.')
     parser.add_argument('--ceph-conf', type=str, default="/etc/ceph/ceph.conf",
                         metavar='CEPHCONF',
-                        help='CEPH configuration file used for cluster connect')
+                        help='Ceph configuration file used for cluster connect')
     parser.add_argument('--ceph-pool', type=str, metavar='POOL',
-                        help='CEPH pool to use for object storage')
+                        help='Ceph pool to use for object storage')
+    parser.add_argument('--ceph-keyring',
+                        help='Ceph keyring to use for object storage')
     parser.add_argument('--s3-url', type=str,
                         help='S3 endpoint URL (includes leading "http")')
     parser.add_argument('--redis', type=str,
@@ -223,7 +225,8 @@ if __name__ == '__main__':
 
     use_rados = args.ceph_pool is not None
     if use_rados:
-        obj_store = RadosChunkStore(args.ceph_conf, args.ceph_pool)
+        obj_store = RadosChunkStore(args.ceph_conf, args.ceph_pool,
+                                    args.ceph_keyring)
         pool_stats = obj_store.ioctx.get_stats()
         logger.info("Connected to pool %s. Currently holds %d objects "
                     "totalling %g GB", args.ceph_pool,

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -33,31 +33,18 @@ import sys
 import time
 import shlex
 import subprocess
-import functools
 from itertools import product
-import io
 
 import numpy as np
 import katdal
+from katdal.chunkstore_rados import RadosChunkStore
+from katdal.chunkstore_s3 import S3ChunkStore
+from katdal.chunkstore import DictOfArraysChunkStore
 import katsdptelstate
 import katsdpservices
 import dask
 import dask.array as da
 from dask.diagnostics import ProgressBar
-
-try:
-    import rados
-except ImportError:
-    # librados (i.e. direct Ceph access) is only really available on Linux
-    rados = None
-
-try:
-    import botocore
-except ImportError:
-    botocore = None
-else:
-    import botocore.config
-    import botocore.session
 
 
 logging.basicConfig()
@@ -95,18 +82,11 @@ def parse_args():
     parser.add_argument('--obj-only', action='store_true',
                         help='Only populate object store - no Redis update')
     args = parser.parse_args()
-    if not rados and not botocore:
-        logger.warning("No Ceph or S3 installation found - storing Redis DB only")
-        args.redis_only = True
     if not args.redis_only:
         use_s3 = args.s3_url is not None
         use_rados = args.ceph_pool is not None
         if use_rados and use_s3:
             parser.error('Please specify either --ceph-pool or --s3-*')
-        if use_rados and not rados:
-            parser.error('Cannot use Ceph as rados Python library is not installed')
-        if use_s3 and not botocore:
-            parser.error('Cannot use S3 as botocore Python library is not installed')
     if args.base_name is None:
         args.base_name = args.file[0].split(".")[0]
     return args
@@ -130,43 +110,6 @@ def redis_bulk_str(r_str, host, port):
     logger.debug("Bulk insert r_str of len %d completed: %s", len(r_str), retout)
 
 
-def open_rados(ceph_conf, ceph_pool):
-    cluster = rados.Rados(conffile=ceph_conf)
-    cluster.connect()
-    available_pools = cluster.list_pools()
-    if ceph_pool not in available_pools:
-        logger.error("Specified pool %s not available in this cluster (%s)",
-                     ceph_pool, available_pools)
-        sys.exit()
-    ioctx = cluster.open_ioctx(ceph_pool)
-    pool_stats = ioctx.get_stats()
-    logger.info("Connected to pool %s. Currently holds %d objects totalling %g GB",
-                ceph_pool, pool_stats['num_objects'],
-                pool_stats['num_bytes'] / 2 ** 30)
-    return ioctx
-
-
-def write_chunk_rados(ioctx, name, chunk):
-    data_fp = io.BytesIO(chunk.data)
-    data_str = data_fp.read()
-    ioctx.write_full(name, data_str)
-
-
-def open_s3(url):
-    session = botocore.session.get_session()
-    config = botocore.config.Config(max_pool_connections=200,
-                                    s3={'addressing_style': 'path'})
-    client = session.create_client(service_name='s3', endpoint_url=url,
-                                   config=config)
-    return client
-
-
-def write_chunk_s3(client, name, chunk):
-    bucket, key = name.split('/', 1)
-    data_fp = io.BytesIO(chunk.data)
-    client.put_object(Bucket=bucket, Key=key, Body=data_fp)
-
-
 def generate_chunks(shape, dtype, target_object_size, dims_to_split=(0, 1)):
     """"""
     dataset_size = np.prod(shape) * dtype.itemsize
@@ -186,21 +129,11 @@ def generate_chunks(shape, dtype, target_object_size, dims_to_split=(0, 1)):
     return tuple(chunks)
 
 
-def dask_from_chunks(chunks, out_name, base_name):
-    single_chunk = all(len(c) == 1 for c in chunks)
-    last_index_per_dim = [np.r_[0, np.cumsum(c)[:-1]][-1] for c in chunks]
-    widths = [len(str(i)) for i in last_index_per_dim]
+def dsk_from_chunks(chunks, out_name):
     keys = list(product([out_name], *[range(len(bds)) for bds in chunks]))
     all_slices = da.core.slices_from_chunks(chunks)
     for key, slices in zip(keys, all_slices):
-        index = [s.start for s in slices]
-        if single_chunk:
-            obj_name = base_name
-        else:
-            index_str = '_'.join(["{:0{width}d}".format(i, width=w)
-                                  for (i, w) in zip(index, widths)])
-            obj_name = base_name + '/' + index_str
-        yield key, slices, obj_name
+        yield key, slices
 
 
 if __name__ == '__main__':
@@ -290,32 +223,35 @@ if __name__ == '__main__':
 
     use_rados = args.ceph_pool is not None
     if use_rados:
-        store = open_rados(args.ceph_conf, args.ceph_pool)
+        obj_store = RadosChunkStore(args.ceph_conf, args.ceph_pool)
+        pool_stats = obj_store.ioctx.get_stats()
+        logger.info("Connected to pool %s. Currently holds %d objects "
+                    "totalling %g GB", args.ceph_pool,
+                    pool_stats['num_objects'], pool_stats['num_bytes'] / 2**30)
         ts_pbs.add("ceph_pool", args.ceph_pool, immutable=True)
         with open(args.ceph_conf, "r") as ceph_conf:
             ts_pbs.add("ceph_conf", ceph_conf.readlines(), immutable=True)
-        save = functools.partial(write_chunk_rados, store)
     else:
-        store = open_s3(args.s3_url)
+        obj_store = S3ChunkStore(args.s3_url)
         ts_pbs.add("s3_endpoint", args.s3_url, immutable=True)
-        save = functools.partial(write_chunk_s3, store)
-    # Convert HDF5 visibilities to complex64 on the fly
-    vis_save = lambda obj, x: save(obj, x.view(np.complex64)[..., 0])
 
     target_object_size = args.obj_size * 2 ** 20
     dask_graph = {}
     schedule = dask.threaded.get
     output_keys = []
-    for dataset in ('timestamps', 'correlator_data', 'weights',
-                    'weights_channel', 'flags'):
-        arr = h5_file['Data'][dataset]
-        dask_graph[dataset] = arr
-        base_name = '/'.join((args.base_name, program_block, stream, dataset))
-        shape = (min(arr.shape[0], max_dumps),) + arr.shape[1:]
+    h5_store = DictOfArraysChunkStore(**h5_file['Data'])
+    for dataset in h5_store.arrays:
+        dataset = str(dataset)
+        arr = h5_store.arrays[dataset]
         dtype = arr.dtype
+        shape = arr.shape
         if dataset == 'correlator_data':
-            shape = shape[:-1]
             dtype = np.dtype(np.complex64)
+            shape = shape[:-1]
+        copy_dataset = 'copy_' + dataset
+        dask_graph[copy_dataset] = arr
+        base_name = obj_store.join(args.base_name, program_block, stream, dataset)
+        shape = (min(shape[0], max_dumps),) + shape[1:]
         chunks = generate_chunks(shape, dtype, target_object_size)
         num_chunks = np.prod([len(c) for c in chunks])
         chunk_size = np.prod([c[0] for c in chunks]) * dtype.itemsize
@@ -323,9 +259,8 @@ if __name__ == '__main__':
                     "~%d bytes each", base_name, shape, num_chunks, chunk_size)
         dask_info = {'dtype': dtype, 'shape': shape, 'chunks': chunks}
         ts_pbs.add(dataset, dask_info, immutable=True)
-        obj_save = vis_save if dataset == 'correlator_data' else save
-        dsk = {k: (obj_save, obj, (da.core.getter, dataset, s))
-               for k, s, obj in dask_from_chunks(chunks, dataset, base_name)}
+        dsk = {k: (obj_store.put, base_name, s, (h5_store.get, dataset, s, dtype))
+               for k, s in dsk_from_chunks(chunks, copy_dataset)}
         dask_graph.update(dsk)
         output_keys.extend(dsk.keys())
     with ProgressBar():

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -39,7 +39,7 @@ import numpy as np
 import katdal
 from katdal.chunkstore_rados import RadosChunkStore
 from katdal.chunkstore_s3 import S3ChunkStore
-from katdal.chunkstore import DictOfArraysChunkStore
+from katdal.chunkstore import DictChunkStore
 import katsdptelstate
 import katsdpservices
 import dask
@@ -242,7 +242,7 @@ if __name__ == '__main__':
     dask_graph = {}
     schedule = dask.threaded.get
     output_keys = []
-    h5_store = DictOfArraysChunkStore(**h5_file['Data'])
+    h5_store = DictChunkStore(**h5_file['Data'])
     for dataset in h5_store.arrays:
         dataset = str(dataset)
         arr = h5_store.arrays[dataset]

--- a/scripts/h5toobj.py
+++ b/scripts/h5toobj.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
 
+################################################################################
+# Copyright (c) 2017-2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 """Simple script to take an HDF5 file and chunk it into objects.
 
 This also populates a specified (or managed) Redis instance to hold

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2016, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2018, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(name="katdal",
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py'],
       extras_require={
-        'ms': ['python-casacore >= 2.2.1']
+        'ms': ['python-casacore >= 2.2.1'],
+        's3': ['botocore'],
+        # rados is not in PyPI but available as Debian package python-rados
+        'rados': ['rados']
       },
       tests_require=['nose'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 coverage
 nose
-requests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 coverage
 nose
+requests


### PR DESCRIPTION
A *chunk* is a simple (i.e. unit-stride) slice of an N-dimensional array known as its *parent array*. The array is identified by a string name, while the chunk within the array is identified by a sequence of slice objects which may be used to extract the chunk from the array. The array is a `numpy.ndarray` object with an associated *dtype*.

The basic idea is that the chunk store contains multiple arrays addressed by name. The list of available arrays and all array metadata (shape, chunks and dtype) are stored elsewhere. The metadata is used to identify chunks, while the chunk store takes care of storing and retrieving bytestrings of actual chunk data. These are packaged back into NumPy arrays for the user.

There are four incarnations:

  - `DictChunkStore`: works on dicts of NumPy arrays and even HDF5 files via `h5py` (chunk == slice)
  - `S3ChunkStore`: works via the S3 object storage API (chunk == object)
  - `RadosChunkStore`: works via the Ceph RADOS API (chunk == object)
  - `NpyFileChunkStore`: works on a directory of NPY files (chunk == file)
