### PR TITLE
Fix opening of older v3 files

### DIFF
--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -580,7 +580,7 @@ class ConcatenatedDataSet(DataSet):
             for n, d in enumerate(self.datasets):
                 d._set_keep(time_keep=self._time_keep[self._segments[n]:self._segments[n + 1]])
             # Ensure that sensor cache gets updated time selection
-            if self.sensor is not None:
+            if not self.sensor:
                 self.sensor._set_keep(self._time_keep)
         if freq_keep is not None:
             self._freq_keep = freq_keep

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -580,7 +580,7 @@ class ConcatenatedDataSet(DataSet):
             for n, d in enumerate(self.datasets):
                 d._set_keep(time_keep=self._time_keep[self._segments[n]:self._segments[n + 1]])
             # Ensure that sensor cache gets updated time selection
-            if not self.sensor:
+            if self.sensor:
                 self.sensor._set_keep(self._time_keep)
         if freq_keep is not None:
             self._freq_keep = freq_keep

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -445,7 +445,7 @@ class DataSet(object):
         self.channels = np.empty(0, dtype=np.int)
 
         self.dump_period = 0.0
-        self.sensor = None
+        self.sensor = {}
         self.catalogue = katpoint.Catalogue()
         self.start_time = katpoint.Timestamp(0.0)
         self.end_time = katpoint.Timestamp(0.0)
@@ -603,7 +603,7 @@ class DataSet(object):
         if time_keep is not None:
             self._time_keep = time_keep
             # Ensure that sensor cache gets updated time selection
-            if self.sensor is not None:
+            if not self.sensor:
                 self.sensor._set_keep(self._time_keep)
         if freq_keep is not None:
             self._freq_keep = freq_keep

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -603,7 +603,7 @@ class DataSet(object):
         if time_keep is not None:
             self._time_keep = time_keep
             # Ensure that sensor cache gets updated time selection
-            if not self.sensor:
+            if self.sensor:
                 self.sensor._set_keep(self._time_keep)
         if freq_keep is not None:
             self._freq_keep = freq_keep

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -596,7 +596,7 @@ class H5DataV3(DataSet):
             # the most recent value.
             try:
                 return self.sensor['TelescopeState/' + key][-1]
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, TypeError):
                 return default
 
     def _get_telstate_stream_attr(self, key, default=None, no_unpickle=()):

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -596,7 +596,7 @@ class H5DataV3(DataSet):
             # the most recent value.
             try:
                 return self.sensor['TelescopeState/' + key][-1]
-            except (KeyError, IndexError, TypeError):
+            except (KeyError, IndexError):
                 return default
 
     def _get_telstate_stream_attr(self, key, default=None, no_unpickle=()):


### PR DESCRIPTION
On pre-telstate v3 files, the `_get_telstate_attr()` helper function crashes when it looks for improved versions of the dump period attribute in the sensor cache. The problem is that the sensor cache
does not exist this early on in the metadata parsing... Fall back to the default obtained from the TelescopeModel on this exception.
