### PR TITLE
Require python-casacore 2.2.1 when importing

### DIFF
--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -53,9 +53,11 @@ except:
         req_ver = parse_version("2.2.1")
 
         if not pyc_ver >= req_ver:
-            raise ImportError("python-casacore '%s' is required, "
-                              "but the current version is '%s'."
-                                              % (req_ver, pyc_ver))
+            raise ImportError("python-casacore %s is required, "
+                              "but the current version is %s. "
+                              "Note that python-casacore %s "
+                              "requires at least casacore 2.3.0."
+                                      % (req_ver, pyc_ver,req_ver))
 
 
 def std_scalar(comment, valueType='integer', option=0, **kwargs):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -46,14 +46,15 @@ except:
         casacore_binding = ''
     else:
         # Perform python-casacore version checks
-        import pkg_resources
-        pyc_dist = pkg_resources.get_distribution('python-casacore')
-        pyc_ver = pkg_resources.parse_version(pyc_dist.version)
-        req_ver = pkg_resources.parse_version("2.2.1")
+        from pkg_resources import parse_version
+        import casacore
+
+        pyc_ver = parse_version(casacore.__version__)
+        req_ver = parse_version("2.2.1")
 
         if not pyc_ver >= req_ver:
             raise ImportError("python-casacore '%s' is required, "
-                              "but the current version is '%s'"
+                              "but the current version is '%s'."
                                               % (req_ver, pyc_ver))
 
 

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -57,7 +57,7 @@ except:
                               "but the current version is %s. "
                               "Note that python-casacore %s "
                               "requires at least casacore 2.3.0."
-                                      % (req_ver, pyc_ver,req_ver))
+                                      % (req_ver, pyc_ver, req_ver))
 
 
 def std_scalar(comment, valueType='integer', option=0, **kwargs):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -44,6 +44,18 @@ except:
         casacore_binding = 'pyrap'
     except ImportError:
         casacore_binding = ''
+    else:
+        # Perform python-casacore version checks
+        import pkg_resources
+        pyc_dist = pkg_resources.get_distribution('python-casacore')
+        pyc_ver = pkg_resources.parse_version(pyc_dist.version)
+        req_ver = pkg_resources.parse_version("2.2.1")
+
+        if not pyc_ver >= req_ver:
+            raise ImportError("python-casacore '%s' is required, "
+                              "but the current version is '%s'"
+                                              % (req_ver, pyc_ver))
+
 
 
 def std_scalar(comment, valueType='integer', option=0, **kwargs):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -57,7 +57,6 @@ except:
                                               % (req_ver, pyc_ver))
 
 
-
 def std_scalar(comment, valueType='integer', option=0, **kwargs):
     """Description for standard scalar column."""
     return dict(comment=comment, valueType=valueType, dataManagerType='StandardStMan',

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,7 @@ setup(name="katdal",
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py'],
+      extras_require={
+        'ms': ['python-casacore >= 2.2.1']
+      },
       tests_require=['nose'])


### PR DESCRIPTION
python-casacore 2.2.1 is required for creating Measurement Sets. Raise an informative ImportError if the required version is not installed, rather than failing due to missing functionality.