### PR TITLE
Improve stream attribute search

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -113,7 +113,7 @@ def dummy_dataset(name, shape, dtype, value):
                                      dtype=dtype, fillvalue=value, compression='gzip')
 
 
-class AttributeFound(Exception):
+class _AttributeFound(Exception):
     """This indicates that an attribute has been found and contains its value."""
 
 # -------------------------------------------------------------------------------------------------
@@ -614,7 +614,7 @@ class H5DataV3(DataSet):
 
         Raises
         ------
-        AttributeFound(value)
+        _AttributeFound(value)
             If attribute is found, return value via exception (else do nothing)
         """
         attr_name = '_'.join(attr_name_parts)
@@ -628,13 +628,13 @@ class H5DataV3(DataSet):
             else:
                 logger.debug("Found %s=%s in h5.file[%r].attrs[%r]",
                              key, value, h5_group.name, attr_name)
-                raise AttributeFound(value)
+                raise _AttributeFound(value)
         else:
             NOTFOUND = object()     # Dummy to distinguish "not found" from None
             value = self._get_telstate_attr(attr_name, NOTFOUND)
             if value is not NOTFOUND:
                 logger.debug('Found %s=%s in telstate[%r]', key, value, attr_name)
-                raise AttributeFound(value)
+                raise _AttributeFound(value)
 
     def _get_cbf_attr(self, key, cbf_group=None, required=True, default=None):
         """Retrieve attribute associated with the CBF stream.
@@ -682,7 +682,7 @@ class H5DataV3(DataSet):
             if cbf_group is not None:
                 self._raise_if_attr_found('cbf', key)
                 self._raise_if_attr_found(key, h5_group=cbf_group)
-        except AttributeFound as exc:
+        except _AttributeFound as exc:
             return exc.args[0]
         if required:
             raise BrokenFile('File does not contain {!r}'.format(key))
@@ -716,7 +716,7 @@ class H5DataV3(DataSet):
             self._raise_if_attr_found(self.stream_name, key)
             if sdp_group is not None:
                 self._raise_if_attr_found('l0', key, h5_group=sdp_group)
-        except AttributeFound as exc:
+        except _AttributeFound as exc:
             return exc.args[0]
         return self._get_cbf_attr(key, cbf_group, required, default)
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -495,7 +495,7 @@ class H5DataV3(DataSet):
             spw_params['centre_freq'] = 428e6
             spw_params['sideband'] = -1
         stream_centre_freq = self._get_telstate_stream_attr(
-            'center_freq', cbf_group=cbf_group, sdp_group=sdp_group, required=False)
+            'center_freq', sdp_group=sdp_group, required=False)
         if stream_centre_freq is not None:
             spw_params['centre_freq'] = stream_centre_freq
         # Get channel width from original CBF / SDP parameters
@@ -656,10 +656,10 @@ class H5DataV3(DataSet):
                     'cbf_' + instrument + '_' + key, NOTFOUND, no_unpickle)
                 if value is not NOTFOUND:
                     return value
-        value = self._get_telstate_attr('cbf_' + key, NOTFOUND, no_unpickle)
-        if value is not NOTFOUND:
-            return value
         if cbf_group is not None:
+            value = self._get_telstate_attr('cbf_' + key, NOTFOUND, no_unpickle)
+            if value is not NOTFOUND:
+                return value
             try:
                 return cbf_group.attrs[key]
             except KeyError:


### PR DESCRIPTION
The main fix is to avoid looking into the CBF stream for the L0 centre frequency as it is unreliable for this purpose.

Refactor the attribute search by introducing a helper method which raises an exception if the attribute was found (and not vice versa!). This makes it easy to chain a series of search locations with decreasing priority. It also logs the results of the search, for debug purposes.

This closes #108 and should enhance the debugging of similar issues in the future.

Tested on a very small menagerie of files.