### PR TITLE
Be more specific when comparing numpy dtypes

### DIFF
--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -189,7 +189,7 @@ class ConcatenatedLazyIndexer(LazyIndexer):
         dtypes = set([indexer.dtype for indexer in self.indexers])
         if len(dtypes) == 1:
             return dtypes.pop()
-        elif np.all([np.issubdtype(dtype, np.str) for dtype in dtypes]):
+        elif np.all([np.issubdtype(dtype, np.string_) for dtype in dtypes]):
             # Strings of different lengths have different dtypes (e.g. '|S1' vs '|S10') but can be safely concatenated
             return np.dtype('|S%d' % (max([dt.itemsize for dt in dtypes]),))
         else:

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -389,15 +389,15 @@ def dummy_sensor_data(name, value=None, dtype=np.float64, timestamp=0.0):
 
     """
     if value is None:
-        if np.issubdtype(dtype, np.float):
-            value = np.nan
-        elif np.issubdtype(dtype, np.int):
-            value = -1
-        elif np.issubdtype(dtype, np.str):
+        if np.issubdtype(dtype, np.floating):
+            value = np.dtype(dtype).type(np.nan)
+        elif np.issubdtype(dtype, np.integer):
+            value = np.dtype(dtype).type(-1)
+        elif np.issubdtype(dtype, np.string_):
             # Order is important here, because np.str is a subtype of np.bool,
             # but not the other way around...
             value = ''
-        elif np.issubdtype(dtype, np.bool):
+        elif np.issubdtype(dtype, np.bool_):
             value = False
     else:
         dtype = infer_dtype([value])
@@ -719,7 +719,7 @@ class SensorCache(dict):
             # If this is the first time any sensor is accessed, obtain all data timestamps via indexer
             self.timestamps = self.timestamps[:] if not isinstance(self.timestamps, np.ndarray) else self.timestamps
             # Determine if sensor produces categorical or numerical data (by default, float data are non-categorical)
-            categ = props.get('categorical', not np.issubdtype(sensor_data.dtype, np.float))
+            categ = props.get('categorical', not np.issubdtype(sensor_data.dtype, np.floating))
             props['categorical'] = categ
             if categ:
                 sensor_data = sensor_to_categorical(sensor_data['timestamp'], sensor_data['value'],


### PR DESCRIPTION
This removes a FutureWarning issued by numpy 1.14 and later. It is
no longer cool to be vague about the second argument to `np.issubdtype`.
It currently does some unexpected type conversions internally that
will go away eventually. If we are checking for a general floating-point
type, use np.floating instead of np.float (which is np.float64).
The same goes for np.integer, np.string_ and np.bool_ (which also have
sub-types). In those cases, also convert the default value to the
correct type (i.e. np.nan != np.float32(np.nan)).