### PR TITLE
SR919: Prepare for dask

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -74,7 +74,7 @@ class ChunkStore(object):
                          ValueError: BadChunk}
         self._error_map = error_map
 
-    def get(self, array_name, slices, dtype):
+    def get_chunk(self, array_name, slices, dtype):
         """Get chunk from the store.
 
         Parameters
@@ -103,7 +103,7 @@ class ChunkStore(object):
         """
         raise NotImplementedError
 
-    def put(self, array_name, slices, chunk):
+    def put_chunk(self, array_name, slices, chunk):
         """Put chunk into the store.
 
         Parameters

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -35,7 +35,7 @@ class DictChunkStore(ChunkStore):
         super(DictChunkStore, self).__init__(error_map)
         self.arrays = kwargs
 
-    def get(self, array_name, slices, dtype):
+    def get_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         with self._standard_errors(chunk_name):
@@ -48,10 +48,10 @@ class DictChunkStore(ChunkStore):
                            .format(chunk_name, dtype, chunk.dtype))
         return chunk
 
-    def put(self, array_name, slices, chunk):
+    def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
         self.chunk_metadata(array_name, slices, chunk=chunk)
-        self.get(array_name, slices, chunk.dtype)[()] = chunk
+        self.get_chunk(array_name, slices, chunk.dtype)[()] = chunk
 
-    get.__doc__ = ChunkStore.get.__doc__
-    put.__doc__ = ChunkStore.put.__doc__
+    get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
+    put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -56,7 +56,7 @@ class NpyFileChunkStore(ChunkStore):
             raise StoreUnavailable('Directory {!r} does not exist'.format(path))
         self.path = path
 
-    def get(self, array_name, slices, dtype):
+    def get_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         filename = os.path.join(self.path, chunk_name) + '.npy'
@@ -67,7 +67,7 @@ class NpyFileChunkStore(ChunkStore):
                            .format(dtype, chunk.dtype))
         return chunk
 
-    def put(self, array_name, slices, chunk):
+    def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         filename = os.path.join(self.path, chunk_name) + '.npy'
@@ -81,5 +81,5 @@ class NpyFileChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             np.save(filename, chunk, allow_pickle=False)
 
-    get.__doc__ = ChunkStore.get.__doc__
-    put.__doc__ = ChunkStore.put.__doc__
+    get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
+    put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -111,7 +111,8 @@ class RadosChunkStore(ChunkStore):
         if actual_bytes != expected_bytes:
             # Get the actual value via stat() to improve error reporting
             if actual_bytes > expected_bytes:
-                actual_bytes, _ = self.ioctx.stat(key)
+                with self._standard_errors(key):
+                    actual_bytes, _ = self.ioctx.stat(key)
             raise BadChunk('Chunk {!r}: dtype {} and shape {} implies an '
                            'object size of {} bytes, got {} bytes instead'
                            .format(key, dtype, shape, expected_bytes,

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -103,14 +103,19 @@ class RadosChunkStore(ChunkStore):
         """See the docstring of :meth:`ChunkStore.get`."""
         dtype = np.dtype(dtype)
         key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
-        num_bytes = int(np.prod(shape)) * dtype.itemsize
+        expected_bytes = int(np.prod(shape)) * dtype.itemsize
         with self._standard_errors(key):
             # Try to read an extra byte to see if data is more than expected
-            data_str = self.ioctx.read(key, num_bytes + 1)
-        if len(data_str) != num_bytes:
+            data_str = self.ioctx.read(key, expected_bytes + 1)
+        actual_bytes = len(data_str)
+        if actual_bytes != expected_bytes:
+            # Get the actual value via stat() to improve error reporting
+            if actual_bytes > expected_bytes:
+                actual_bytes, _ = self.ioctx.stat(key)
             raise BadChunk('Chunk {!r}: dtype {} and shape {} implies an '
                            'object size of {} bytes, got {} bytes instead'
-                           .format(key, dtype, shape, num_bytes, len(data_str)))
+                           .format(key, dtype, shape, expected_bytes,
+                                   actual_bytes))
         return np.ndarray(shape, dtype, data_str)
 
     def put(self, array_name, slices, chunk):

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -99,7 +99,7 @@ class RadosChunkStore(ChunkStore):
             raise StoreUnavailable(str(e))
         return cls(ioctx)
 
-    def get(self, array_name, slices, dtype):
+    def get_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         dtype = np.dtype(dtype)
         key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
@@ -118,12 +118,12 @@ class RadosChunkStore(ChunkStore):
                                    actual_bytes))
         return np.ndarray(shape, dtype, data_str)
 
-    def put(self, array_name, slices, chunk):
+    def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
         key, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         data_str = chunk.tobytes()
         with self._standard_errors(key):
             self.ioctx.write_full(key, data_str)
 
-    get.__doc__ = ChunkStore.get.__doc__
-    put.__doc__ = ChunkStore.put.__doc__
+    get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
+    put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -70,16 +70,22 @@ class S3ChunkStore(ChunkStore):
         self.client = client
 
     @classmethod
-    def from_url(cls, url):
+    def from_url(cls, url, **kwargs):
         """Construct S3 chunk store from endpoint URL.
 
         S3 authentication (i.e. the access + secret keys) is handled externally
-        via the botocore config file or environment variables.
+        via the botocore config file or environment variables. Extra keyword
+        arguments are interpreted as botocore config settings (see
+        :class:`botocore.config.Config`) or arguments to the client creation
+        method (see :meth:`botocore.session.Session.create_client`), in that
+        order, overriding the defaults.
 
         Parameters
         ----------
         url : string
             Endpoint of S3 service, e.g. 'http://127.0.0.1:9000'
+        kwargs : dict
+            Extra keyword arguments: config settings or create_client arguments
 
         Raises
         ------
@@ -90,12 +96,21 @@ class S3ChunkStore(ChunkStore):
         """
         if not botocore:
             raise ImportError('Please install botocore for katdal S3 support')
+        config_kwargs = dict(max_pool_connections=200,
+                             s3={'addressing_style': 'path'})
+        client_kwargs = {}
+        # Split keyword arguments into config settings and create_client args
+        for k, v in kwargs.items():
+            if k in botocore.config.Config.OPTION_DEFAULTS:
+                config_kwargs[k] = v
+            else:
+                client_kwargs[k] = v
         session = botocore.session.get_session()
-        config = botocore.config.Config(max_pool_connections=200,
-                                        s3={'addressing_style': 'path'})
+        config = botocore.config.Config(**config_kwargs)
         try:
             client = session.create_client(service_name='s3',
-                                           endpoint_url=url, config=config)
+                                           endpoint_url=url, config=config,
+                                           **client_kwargs)
             # Quick smoke test to see if the S3 server is available
             client.list_buckets()
         except (EndpointConnectionError, NoCredentialsError, ValueError) as e:

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -102,7 +102,7 @@ class S3ChunkStore(ChunkStore):
             raise StoreUnavailable(str(e))
         return cls(client)
 
-    def get(self, array_name, slices, dtype):
+    def get_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get`."""
         dtype = np.dtype(dtype)
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
@@ -119,7 +119,7 @@ class S3ChunkStore(ChunkStore):
                                    len(data_str)))
         return np.ndarray(shape, dtype, data_str)
 
-    def put(self, array_name, slices, chunk):
+    def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         bucket, key = self.split(chunk_name, 1)
@@ -127,5 +127,5 @@ class S3ChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             self.client.put_object(Bucket=bucket, Key=key, Body=data_str)
 
-    get.__doc__ = ChunkStore.get.__doc__
-    put.__doc__ = ChunkStore.put.__doc__
+    get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
+    put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -63,10 +63,10 @@ class TestChunkStore(object):
 
 
 class ChunkStoreTestBase(object):
-    """Standard test performed on all types of ChunkStore.
+    """Standard tests performed on all types of ChunkStore."""
 
-    Put everything in a single test as setup and teardown can be quite costly.
-    """
+    # Instance of store instantiated once per class via class-level fixture
+    store = None
 
     def __init__(self):
         # Pick arrays with differently sized dtypes and dimensions

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -27,10 +27,10 @@ from katdal.chunkstore import (ChunkStore, StoreUnavailable,
 class TestChunkStore(object):
     """This tests the base class functionality."""
 
-    def test_put_and_get(self):
+    def test_put_and_get_chunk(self):
         store = ChunkStore()
-        assert_raises(NotImplementedError, store.get, 1, 2, 3)
-        assert_raises(NotImplementedError, store.put, 1, 2, 3)
+        assert_raises(NotImplementedError, store.get_chunk, 1, 2, 3)
+        assert_raises(NotImplementedError, store.put_chunk, 1, 2, 3)
 
     def test_metadata_validation(self):
         store = ChunkStore()
@@ -77,31 +77,31 @@ class ChunkStoreTestBase(object):
     def array_name(self, name):
         return name
 
-    def put_and_get(self, var_name, slices):
+    def put_and_get_chunk(self, var_name, slices):
         array_name = self.array_name(var_name)
         chunk = getattr(self, var_name)[slices]
-        self.store.put(array_name, slices, chunk)
-        chunk_retrieved = self.store.get(array_name, slices, chunk.dtype)
+        self.store.put_chunk(array_name, slices, chunk)
+        chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
         assert_array_equal(chunk_retrieved, chunk,
                            "Error storing {}[{}]".format(var_name, slices))
 
-    def test_put_and_get(self):
+    def test_put_and_get_chunk(self):
         # Look for non-existent chunk
-        assert_raises(ChunkNotFound, self.store.get, 'haha',
+        assert_raises(ChunkNotFound, self.store.get_chunk, 'haha',
                       (slice(0, 1),), np.dtype(np.float))
         # Check basic put + get on 1-D bool
         name = self.array_name('x')
         s = (slice(3, 5),)
-        self.put_and_get('x', s)
+        self.put_and_get_chunk('x', s)
         # Stored object has fewer bytes than expected (and wrong dtype)
-        assert_raises(BadChunk, self.store.get, name, s, self.y.dtype)
+        assert_raises(BadChunk, self.store.get_chunk, name, s, self.y.dtype)
         # Check basic put + get on 3-D float
         name = self.array_name('y')
         s = (slice(3, 7), slice(2, 5), slice(1, 2))
-        self.put_and_get('y', s)
+        self.put_and_get_chunk('y', s)
         # Stored object has more bytes than expected (and wrong dtype)
-        assert_raises(BadChunk, self.store.get, name, s, self.x.dtype)
+        assert_raises(BadChunk, self.store.get_chunk, name, s, self.x.dtype)
         # Try a chunk with zero size
-        self.put_and_get('y', (slice(4, 7), slice(3, 3), slice(0, 2)))
+        self.put_and_get_chunk('y', (slice(4, 7), slice(3, 3), slice(0, 2)))
         # Try an empty slice on a zero-dimensional array (but why?)
-        self.put_and_get('z', ())
+        self.put_and_get_chunk('z', ())

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -85,22 +85,27 @@ class ChunkStoreTestBase(object):
         assert_array_equal(chunk_retrieved, chunk,
                            "Error storing {}[{}]".format(var_name, slices))
 
-    def test_put_and_get_chunk(self):
-        # Look for non-existent chunk
+    def test_chunk_non_existent(self):
         assert_raises(ChunkNotFound, self.store.get_chunk, 'haha',
                       (slice(0, 1),), np.dtype(np.float))
+
+    def test_chunk_bool_1dim_and_too_small(self):
         # Check basic put + get on 1-D bool
         name = self.array_name('x')
         s = (slice(3, 5),)
         self.put_and_get_chunk('x', s)
         # Stored object has fewer bytes than expected (and wrong dtype)
         assert_raises(BadChunk, self.store.get_chunk, name, s, self.y.dtype)
+
+    def test_chunk_float_3dim_and_too_large(self):
         # Check basic put + get on 3-D float
         name = self.array_name('y')
         s = (slice(3, 7), slice(2, 5), slice(1, 2))
         self.put_and_get_chunk('y', s)
         # Stored object has more bytes than expected (and wrong dtype)
         assert_raises(BadChunk, self.store.get_chunk, name, s, self.x.dtype)
+
+    def test_chunk_zero_size(self):
         # Try a chunk with zero size
         self.put_and_get_chunk('y', (slice(4, 7), slice(3, 3), slice(0, 2)))
         # Try an empty slice on a zero-dimensional array (but why?)

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -27,19 +27,17 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
 class TestNpyFileChunkStore(ChunkStoreTestBase):
-    """Tests interacting with an actual temp dir, implying a slower setup."""
+    """Test NPY file functionality using a temporary directory."""
 
-    def setup(self):
+    @classmethod
+    def setup_class(cls):
         """Create temp dir to store NPY files and build ChunkStore on that."""
-        self.tempdir = tempfile.mkdtemp()
-        self.store = NpyFileChunkStore(self.tempdir)
+        cls.tempdir = tempfile.mkdtemp()
+        cls.store = NpyFileChunkStore(cls.tempdir)
 
-    def teardown(self):
-        shutil.rmtree(self.tempdir)
-
-
-class TestDudNpyFileChunkStore(object):
-    """Tests that don't need a temp dir, only a 'dud' store."""
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tempdir)
 
     def test_store_unavailable(self):
         assert_raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')

--- a/katdal/test/test_chunkstore_rados.py
+++ b/katdal/test/test_chunkstore_rados.py
@@ -26,28 +26,21 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
 class TestRadosChunkStore(ChunkStoreTestBase):
-    """Tests connecting to an actual RADOS service, implying a slower setup."""
+    """Test Ceph functionality by connecting to an actual RADOS service."""
 
-    def setup(self):
+    @classmethod
+    def setup_class(cls):
         # Look for default Ceph installation but expect a special test pool
         config = '/etc/ceph/ceph.conf'
         pool = 'test_katdal'
         try:
-            self.store = RadosChunkStore.from_config(config, pool)
+            cls.store = RadosChunkStore.from_config(config, pool)
         except (ImportError, StoreUnavailable):
             raise SkipTest('Rados not installed or cluster misconfigured / down')
 
     def array_name(self, path):
         namespace = 'katdal_test_chunkstore_rados'
         return self.store.join(namespace, path)
-
-
-class TestDudRadosChunkStore(object):
-    """Tests that don't need a RADOS connection, only a 'dud' store."""
-
-    def setup(self):
-        if not rados:
-            raise SkipTest('Rados not installed')
 
     def test_store_unavailable(self):
         # Pretend that rados is not installed

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -31,38 +31,40 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
 class TestS3ChunkStore(ChunkStoreTestBase):
-    """Tests connecting to an actual (fake) S3 service, implying a slower setup."""
+    """Test S3 functionality against an actual (fake) S3 service."""
 
-    def start_fakes3(self, host):
+    @classmethod
+    def start_fakes3(cls, host):
         """Start Fake S3 service as `host` and return its URL."""
         try:
             # Port number is automatically assigned
-            self.fakes3 = subprocess.Popen(['fakes3', 'server',
-                                            '-r', self.tempdir, '-p', '0',
-                                            '-a', host, '-H', host],
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
+            cls.fakes3 = subprocess.Popen(['fakes3', 'server',
+                                           '-r', cls.tempdir, '-p', '0',
+                                           '-a', host, '-H', host],
+                                          stdout=subprocess.PIPE,
+                                          stderr=subprocess.PIPE)
         except OSError:
             raise SkipTest('Could not start fakes3 server (is it installed?)')
         start = time.time()
         # Give up after waiting a few seconds for Fake S3
         while time.time() - start <= 5:
             # Look for assigned port number in fakes3 stderr output
-            line = self.fakes3.stderr.readline().strip()
+            line = cls.fakes3.stderr.readline().strip()
             ports_found = re.search(r' port=(\d{4,5})$', line)
             if ports_found:
                 port = ports_found.group(1)
                 return 'http://%s:%s' % (host, port)
         raise SkipTest('Could not connect to fakes3 server')
 
-    def setup(self):
+    @classmethod
+    def setup_class(cls):
         """Start Fake S3 service running on temp dir, and ChunkStore on that."""
-        self.tempdir = tempfile.mkdtemp()
-        self.fakes3 = None
+        cls.tempdir = tempfile.mkdtemp()
+        cls.fakes3 = None
         try:
-            url = self.start_fakes3('localhost')
+            url = cls.start_fakes3('localhost')
             try:
-                self.store = S3ChunkStore.from_url(url)
+                cls.store = S3ChunkStore.from_url(url)
             except ImportError:
                 raise SkipTest('S3 botocore dependency not installed')
             except StoreUnavailable:
@@ -73,28 +75,22 @@ class TestS3ChunkStore(ChunkStoreTestBase):
                                                endpoint_url=url,
                                                aws_access_key_id='blah',
                                                aws_secret_access_key='blah')
-                self.store = S3ChunkStore(client)
+                cls.store = S3ChunkStore(client)
         except Exception:
-            self.teardown()
+            cls.teardown_class()
             raise
 
-    def teardown(self):
-        if self.fakes3:
-            self.fakes3.terminate()
-            self.fakes3.wait()
-        shutil.rmtree(self.tempdir)
+    @classmethod
+    def teardown_class(cls):
+        if cls.fakes3:
+            cls.fakes3.terminate()
+            cls.fakes3.wait()
+        shutil.rmtree(cls.tempdir)
 
     def array_name(self, path):
         bucket = 'katdal-unittest'
         return self.store.join(bucket, path)
 
-
-class TestDudS3ChunkStore(object):
-    """Tests that don't need an S3 connection, only a 'dud' store."""
-
-    def setup(self):
-        if not botocore:
-            raise SkipTest('S3 botocore dependency not installed')
-
     def test_store_unavailable(self):
-        assert_raises(StoreUnavailable, S3ChunkStore.from_url, 'http://i.nvalid/')
+        assert_raises(StoreUnavailable, S3ChunkStore.from_url,
+                      'http://i.nvalid/')

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -92,5 +92,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         return self.store.join(bucket, path)
 
     def test_store_unavailable(self):
+        # Drastically reduce the default botocore timeout of nearly 7 seconds
         assert_raises(StoreUnavailable, S3ChunkStore.from_url,
-                      'http://i.nvalid/')
+                      'http://i.nvalid/',
+                      connect_timeout=0.1, retries={'max_attempts': 0})

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -94,5 +94,5 @@ class TestS3ChunkStore(ChunkStoreTestBase):
     def test_store_unavailable(self):
         # Drastically reduce the default botocore timeout of nearly 7 seconds
         assert_raises(StoreUnavailable, S3ChunkStore.from_url,
-                      'http://i.nvalid/',
+                      'http://apparently.invalid/',
                       connect_timeout=0.1, retries={'max_attempts': 0})


### PR DESCRIPTION
These smaller changes pave the way for dask:

- Improve RADOS error report if chunk is too big (unrelated)
- Rename `get` to `get_chunk` etc (there will soon be a `get_dask_array`)
- Switch to class-level fixtures in the tests (we need to add `test_put_and_get_dask_array`)
- Override botocore settings (unrelated, speeds up tests a lot)
