### PR TITLE
Add dask support to ChunkStore

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -20,6 +20,7 @@ from __future__ import division
 
 import contextlib
 import functools
+import uuid
 
 import numpy as np
 import dask
@@ -354,9 +355,8 @@ class ChunkStore(object):
         # Give better names to these two very similar variables
         in_name = array.name
         out_name = array_name
-        # Make out_name reasonably unique to avoid clashes and caches
-        token = da.core.tokenize(object())[:8]
-        out_name = 'store-{}-{}'.format(out_name, token)
+        # Make out_name unique to avoid clashes and caches
+        out_name = 'store-{}-{}'.format(out_name, uuid.uuid4().hex)
         # Construct output graph on same chunks as input, but with new name
         graph = da.core.getem(array_name, array.chunks, self.put_chunk_noraise,
                               out_name=out_name)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -29,24 +29,39 @@ def test_generate_chunks():
     shape = (10, 8192, 144)
     dtype = np.complex64
     nbytes = np.prod(shape) * np.dtype(dtype).itemsize
+    # Basic check
     chunks = generate_chunks(shape, dtype, 3e6)
     assert_equal(chunks, (10 * (1,), 4 * (2048,), (144,)))
+    # Check that bad dims_to_split are ignored
     chunks = generate_chunks(shape, dtype, 3e6, (0, 10))
     assert_equal(chunks, (10 * (1,), (8192,), (144,)))
+    # Uneven chunks in the final split
     chunks = generate_chunks(shape, dtype, 1e6)
     assert_equal(chunks, (10 * (1,), 2 * (820,) + 8 * (819,), (144,)))
+    # Corner case: don't select any dimensions to split -> one chunk
     chunks = generate_chunks(shape, dtype, 1e6, ())
     assert_equal(chunks, ((10,), (8192,), (144,)))
+    # Corner case: all bytes results in one chunk
     chunks = generate_chunks(shape, dtype, nbytes)
     assert_equal(chunks, ((10,), (8192,), (144,)))
+    # Corner case: one byte less than the full size results in a split
     chunks = generate_chunks(shape, dtype, nbytes - 1)
     assert_equal(chunks, ((5, 5), (8192,), (144,)))
+    # Check power_of_two
     chunks = generate_chunks(shape, dtype, 1e6,
                              dims_to_split=[1], power_of_two=True)
     assert_equal(chunks, ((10,), 128 * (64,), (144,)))
     chunks = generate_chunks(shape, dtype, nbytes / 16,
                              dims_to_split=[1], power_of_two=True)
     assert_equal(chunks, ((10,), 16 * (512,), (144,)))
+    # Check power_of_two when dimension is not a power-of-two itself
+    chunks = generate_chunks((10, 32768 - 2048, 144), dtype, nbytes / 10,
+                             dims_to_split=(0, 1), power_of_two=True)
+    assert_equal(chunks, (10 * (1,), 3 * (8192,) + (6144,), (144,)))
+    # Check swapping the order of dims_to_split
+    chunks = generate_chunks((10, 32768 - 2048, 144), dtype, nbytes / 10,
+                             dims_to_split=(1, 0), power_of_two=True)
+    assert_equal(chunks, ((10,), 60 * (512,), (144,)))
 
 
 class TestChunkStore(object):

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -98,7 +98,7 @@ class ChunkStoreTestBase(object):
         self.x = np.ones(10, dtype=np.bool)
         self.y = np.arange(96.).reshape(8, 6, 2)
         self.z = np.array(2.)
-        self.dask_x = np.arange(960.).reshape(8, 60, 2)
+        self.big_y = np.arange(960.).reshape(8, 60, 2)
 
     def array_name(self, name):
         return name
@@ -157,4 +157,4 @@ class ChunkStoreTestBase(object):
         assert_is_instance(result[0, 0], BadChunk)
 
     def test_dask_array(self):
-        self.put_and_get_dask_array('dask_x')
+        self.put_and_get_dask_array('big_y')

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -56,9 +56,6 @@ class TestChunkStore(object):
         store = ChunkStore()
         assert_raises(NotImplementedError, store.get_chunk, 1, 2, 3)
         assert_raises(NotImplementedError, store.put_chunk, 1, 2, 3)
-        result = store.put_chunk_noraise("x", (slice(1, 2), slice(10, 20)), [])
-        assert_array_equal(result.shape, (1, 1))
-        assert_is_instance(result[0, 0], NotImplementedError)
 
     def test_metadata_validation(self):
         store = ChunkStore()
@@ -153,6 +150,11 @@ class ChunkStoreTestBase(object):
         self.put_and_get_chunk('y', (slice(4, 7), slice(3, 3), slice(0, 2)))
         # Try an empty slice on a zero-dimensional array (but why?)
         self.put_and_get_chunk('z', ())
+
+    def test_put_chunk_noraise(self):
+        result = self.store.put_chunk_noraise("x", (1, 2), [])
+        assert_array_equal(result.shape, (1, 1))
+        assert_is_instance(result[0, 0], BadChunk)
 
     def test_dask_array(self):
         self.put_and_get_dask_array('dask_x')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 botocore==1.8.9
 Cython
+dask==0.16.1
 docutils
 future
 h5py
@@ -10,4 +11,5 @@ pkginfo
 pyephem
 python-dateutil
 six
+toolz==0.9.0
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,4 @@ setup(name="katdal",
         # rados is not in PyPI but available as Debian package python-rados
         'rados': ['rados']
       },
-      tests_require=['nose'])
+      tests_require=['nose', 'dask[array]'])


### PR DESCRIPTION
Add `get_dask_array` method that combines all the chunks associated with an array into a single dask Array and loads the associated data only on compute(). The corresponding `put_dask_array` method stores the chunks of a dask array in the store and returns a results array that also suppresses any exceptions (for inspection by the caller).

The supporting `generate_chunks` function provides a standard way to split an array into roughly equal-sized chunks. Dask is only a test requirement for now - wait until we have a fully integrated v4 loader to make it a main requirement.
