### PR TITLE
fix typo in sensor name for the revciever serial number

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -451,7 +451,7 @@ class H5DataV3(DataSet):
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
             # Try sanitised version of RX serial number first
-            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
+            rx_sensor = 'TelescopeState/%s_rsc_rx%s_serial_number' % (ant, band)
             rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
             if rx_serial == 0:
                 rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -211,7 +211,7 @@ class VisibilityDataV4(DataSet):
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
             # Try sanitised version of RX serial number first
-            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
+            rx_sensor = 'TelescopeState/%s_rsc_rx%s_serial_number' % (ant, band)
             rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
             if rx_serial == 0:
                 rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)


### PR DESCRIPTION
. The sensor name now includes the band



The h5 file has the sensors :
In [13]: print h5.sensor['TelescopeState/m005_ap_indexer_position']
['l' 'l' 'l' ..., 'l' 'l' 'l']
In [14]: print h5.sensor['TelescopeState/m005_rsc_rxl_serial_number']
[4029 4029 4029 ..., 4029 4029 4029]

But the code wants : 
            # Try sanitised version of RX serial number first
            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
            rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0


Should it rather be :
rx_sensor = 'TelescopeState/%s_rsc_rx%s_serial_number' % (ant, band) 
