### PR TITLE
Look for unrenamed RX serial number sensor first

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -450,12 +450,18 @@ class H5DataV3(DataSet):
                            'please provide it via band parameter')
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
-            # Try sanitised version of RX serial number first
-            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
-            rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
-            if rx_serial == 0:
-                rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
-                rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
+            rx_sensor_options = (
+                # Since 2018-01-16 MKAT / ARx only has this version
+                'TelescopeState/%s_rsc_rx%s_serial_number' % (ant, band),
+                # RTS since 2017-11-15
+                'TelescopeState/%s_rx_serial_number' % (ant,),
+                # Original TelescopeModel version
+                'Antennas/%s/rsc_rx%s_serial_number' % (ant, band))
+            rx_serial = 0
+            for rx_sensor in rx_sensor_options:
+                if rx_sensor in self.sensor:
+                    rx_serial = self.sensor[rx_sensor][0]
+                    break
             if band:
                 self.receivers[ant] = '%s.%d' % (band, rx_serial)
             nd_sensor = 'TelescopeState/%s_dig_%s_band_noise_diode' % (ant, band)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -211,11 +211,8 @@ class VisibilityDataV4(DataSet):
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
             # Try sanitised version of RX serial number first
-            rx_sensor = 'TelescopeState/%s_rx_serial_number' % (ant,)
+            rx_sensor = 'TelescopeState/%s_rsc_rx%s_serial_number' % (ant, band)
             rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
-            if rx_serial == 0:
-                rx_sensor = 'Antennas/%s/rsc_rx%s_serial_number' % (ant, band)
-                rx_serial = self.sensor[rx_sensor][0] if rx_sensor in self.sensor else 0
             if band:
                 self.receivers[ant] = '%s.%d' % (band, rx_serial)
             nd_sensor = 'TelescopeState/%s_dig_%s_band_noise_diode' % (ant, band)


### PR DESCRIPTION
Since 2017-11-15 RTS renamed the `rsc_rxl_serial_number` sensor to
`rx_serial_number` (i.e. dropping the band label). AR1 / MKAT would
have done this too, but stopped short at the last minute (see
katsdpingest PR #189). Since 2018-01-16 the MKAT files no longer have
the corresponding TelescopeModel sensor to fall back on. To fix this,
first look for the original sensor name in TelescopeState.

The `dig_l_band_noise_diode` sensor (renamed as `dig_noise_diode`)
luckily don't suffer from the same issue, as there the renamed sensor
matches the old name and the full name is already looked up first in
TelescopeState.

This closes issue #114.