### PR TITLE
Check presence of chunks in store

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -218,6 +218,37 @@ class ChunkStore(object):
         except ChunkStoreError as err:
             return np.full(singleton_shape, err, object)
 
+    def has_chunk(self, array_name, slices, dtype):
+        """Check if chunk is in the store.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of parent array `x` of chunk
+        slices : sequence of unit-stride slice objects
+            Identifier of individual chunk, to be extracted as `x[slices]`
+        dtype : :class:`numpy.dtype` object or equivalent
+            Data type of array `x`
+
+        Returns
+        -------
+        success : bool
+            True if chunk was found in the store, with appropriate size / dtype
+
+        Raises
+        ------
+        :exc:`chunkstore.BadChunk`
+            If `slices` has wrong specification
+        :exc:`chunkstore.StoreUnavailable`
+            If interaction with chunk store failed (offline, bad auth, bad config)
+        """
+        try:
+            self.get_chunk(array_name, slices, dtype)
+        except ChunkNotFound:
+            return False
+        else:
+            return True
+
     NAME_SEP = '/'
     # Width sufficient to store any dump / channel / corrprod index for MeerKAT
     NAME_INDEX_WIDTH = 5

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -381,13 +381,6 @@ class ChunkStore(object):
         -------
         array : :class:`dask.array.Array` object
             Dask array of given dtype
-
-        Raises
-        ------
-        :exc:`chunkstore.StoreUnavailable`
-            If interaction with chunk store failed (offline, bad auth, bad config)
-        :exc:`chunkstore.ChunkNotFound`
-            If requested chunk was not found in store
         """
         getter = functools.partial(self.get_chunk, dtype=dtype)
         if offset:
@@ -451,11 +444,6 @@ class ChunkStore(object):
         -------
         success : :class:`dask.array.Array` object
             Dask array of bools indicating presence of each chunk
-
-        Raises
-        ------
-        :exc:`chunkstore.StoreUnavailable`
-            If interaction with chunk store failed (offline, bad auth, bad config)
         """
         has = _scalar_to_chunk(functools.partial(self.has_chunk, dtype=dtype))
         if offset:

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -103,7 +103,7 @@ def generate_chunks(shape, dtype, max_chunk_size, dims_to_split=None,
 
 
 def _add_offset_to_slices(func, offset):
-    """Modify chunk getter/putter to add an offset to its `slices` parameter."""
+    """Modify chunk get/put/has to add an offset to its `slices` parameter."""
     offset_slices = tuple(slice(start, None) for start in offset)
 
     def func_with_offset(array_name, slices, *args, **kwargs):
@@ -112,6 +112,23 @@ def _add_offset_to_slices(func, offset):
         return func(array_name, slices, *args, **kwargs)
 
     return func_with_offset
+
+
+def _scalar_to_chunk(func):
+    """Modify chunk get/put/has to turn a scalar return value into a chunk.
+
+    This modifies the given function so that it returns its result as an
+    ndarray with the same number of (singleton) dimensions as the corresponding
+    chunk to enable assembly into a dask array.
+    """
+
+    def func_returning_chunk(array_name, slices, *args, **kwargs):
+        """Turn scalar return value into chunk of appropriate dimension."""
+        value = func(array_name, slices, *args, **kwargs)
+        singleton_shape = len(slices) * (1,)
+        return np.full(singleton_shape, value)
+
+    return func_returning_chunk
 
 
 class ChunkStore(object):
@@ -209,14 +226,12 @@ class ChunkStore(object):
 
     def put_chunk_noraise(self, array_name, slices, chunk):
         """Put chunk into store but return any exceptions instead of raising."""
-        singleton_shape = len(slices) * (1,)
         try:
             self.put_chunk(array_name, slices, chunk)
-            # Return result as ndarray with same number of (singleton)
-            # dimensions as chunk to enable assembly into a dask array
-            return np.empty(singleton_shape, object)
         except ChunkStoreError as err:
-            return np.full(singleton_shape, err, object)
+            return err
+        else:
+            return None
 
     def has_chunk(self, array_name, slices, dtype):
         """Check if chunk is in the store.
@@ -365,7 +380,7 @@ class ChunkStore(object):
         Returns
         -------
         array : :class:`dask.array.Array` object
-            Dask array
+            Dask array of given dtype
 
         Raises
         ------
@@ -396,7 +411,7 @@ class ChunkStore(object):
         Returns
         -------
         success : :class:`dask.array.Array` object
-            Dask array indicating success of the transfer of each chunk
+            Dask array of objects indicating success of transfer of each chunk
             (None indicates success, otherwise there is an exception object)
         """
         dask_graph = dask.sharedict.ShareDict()
@@ -406,7 +421,7 @@ class ChunkStore(object):
         out_name = array_name
         # Make out_name unique to avoid clashes and caches
         out_name = 'store-{}-{}-{}'.format(out_name, offset, uuid.uuid4().hex)
-        put = self.put_chunk_noraise
+        put = _scalar_to_chunk(self.put_chunk_noraise)
         if offset:
             put = _add_offset_to_slices(put, offset)
         # Construct output graph on same chunks as input, but with new name
@@ -417,3 +432,38 @@ class ChunkStore(object):
         # The success array has one element per chunk in the input array
         out_chunks = tuple(len(c) * (1,) for c in array.chunks)
         return da.Array(dask_graph, out_name, out_chunks, np.object)
+
+    def has_dask_array(self, array_name, chunks, dtype, offset=()):
+        """Check if dask array is in the store.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of array in chunk store
+        chunks : tuple of tuples of ints
+            Chunk specification
+        dtype : :class:`numpy.dtype` object or equivalent
+            Data type of array
+        offset : tuple of int, optional
+            Offset to add to each dimension when addressing chunks in store
+
+        Returns
+        -------
+        success : :class:`dask.array.Array` object
+            Dask array of bools indicating presence of each chunk
+
+        Raises
+        ------
+        :exc:`chunkstore.StoreUnavailable`
+            If interaction with chunk store failed (offline, bad auth, bad config)
+        """
+        has = _scalar_to_chunk(functools.partial(self.has_chunk, dtype=dtype))
+        if offset:
+            has = _add_offset_to_slices(has, offset)
+        # Make out_name unique to avoid clashes and caches
+        out_name = 'check-{}-{}-{}'.format(array_name, offset, uuid.uuid4().hex)
+        # Use dask utility function that forms the core of da.from_array
+        dask_graph = da.core.getem(array_name, chunks, has, out_name=out_name)
+        # The success array has one element per chunk in the input array
+        out_chunks = tuple(len(c) * (1,) for c in chunks)
+        return da.Array(dask_graph, out_name, out_chunks, np.bool_)

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -36,7 +36,7 @@ class DictChunkStore(ChunkStore):
         self.arrays = kwargs
 
     def get_chunk(self, array_name, slices, dtype):
-        """See the docstring of :meth:`ChunkStore.get`."""
+        """See the docstring of :meth:`ChunkStore.get_chunk`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         with self._standard_errors(chunk_name):
             array = self.arrays[array_name]
@@ -49,7 +49,7 @@ class DictChunkStore(ChunkStore):
         return chunk
 
     def put_chunk(self, array_name, slices, chunk):
-        """See the docstring of :meth:`ChunkStore.put`."""
+        """See the docstring of :meth:`ChunkStore.put_chunk`."""
         self.chunk_metadata(array_name, slices, chunk=chunk)
         self.get_chunk(array_name, slices, chunk.dtype)[()] = chunk
 

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -67,7 +67,7 @@ class NpyFileChunkStore(ChunkStore):
         self.path = path
 
     def get_chunk(self, array_name, slices, dtype):
-        """See the docstring of :meth:`ChunkStore.get`."""
+        """See the docstring of :meth:`ChunkStore.get_chunk`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         filename = os.path.join(self.path, chunk_name) + '.npy'
         with self._standard_errors(chunk_name):
@@ -78,7 +78,7 @@ class NpyFileChunkStore(ChunkStore):
         return chunk
 
     def put_chunk(self, array_name, slices, chunk):
-        """See the docstring of :meth:`ChunkStore.put`."""
+        """See the docstring of :meth:`ChunkStore.put_chunk`."""
         chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         filename = os.path.join(self.path, chunk_name) + '.npy'
         # Ensure any subdirectories are in place

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -100,7 +100,7 @@ class RadosChunkStore(ChunkStore):
         return cls(ioctx)
 
     def get_chunk(self, array_name, slices, dtype):
-        """See the docstring of :meth:`ChunkStore.get`."""
+        """See the docstring of :meth:`ChunkStore.get_chunk`."""
         dtype = np.dtype(dtype)
         key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         expected_bytes = int(np.prod(shape)) * dtype.itemsize
@@ -120,7 +120,7 @@ class RadosChunkStore(ChunkStore):
         return np.ndarray(shape, dtype, data_str)
 
     def put_chunk(self, array_name, slices, chunk):
-        """See the docstring of :meth:`ChunkStore.put`."""
+        """See the docstring of :meth:`ChunkStore.put_chunk`."""
         key, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
         data_str = chunk.tobytes()
         with self._standard_errors(key):

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -126,5 +126,19 @@ class RadosChunkStore(ChunkStore):
         with self._standard_errors(key):
             self.ioctx.write_full(key, data_str)
 
+    def has_chunk(self, array_name, slices, dtype):
+        """See the docstring of :meth:`ChunkStore.has_chunk`."""
+        dtype = np.dtype(dtype)
+        key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
+        expected_bytes = int(np.prod(shape)) * dtype.itemsize
+        try:
+            with self._standard_errors(key):
+                actual_bytes, _ = self.ioctx.stat(key)
+        except ChunkNotFound:
+            return False
+        else:
+            return actual_bytes == expected_bytes
+
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__
+    has_chunk.__doc__ = ChunkStore.has_chunk.__doc__


### PR DESCRIPTION
This does a basic check to see if a given chunk (or array) is present in the store, with the appropriate size (and dtype if supported), using the new `has_chunk` and `has_dask_array` methods. The idea is that it should be (much) faster than the default `get_chunk`, otherwise there is very little point...

I'm really adding this as a debugging tool, so it is not very optimised. Especially multi-chunk checking on e.g. S3 can still be sped up a lot.
