### PR TITLE
SR919: V4 formatter update

### DIFF
--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -16,9 +16,6 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on the Ceph RADOS API."""
 
-import os
-import tempfile
-
 import numpy as np
 try:
     import rados
@@ -69,7 +66,7 @@ class RadosChunkStore(ChunkStore):
         Parameters
         ----------
         config : string or dict
-            Path to Ceph config file or contents of that file or config dict
+            Path to Ceph config file or config dict
         pool : string
             Name of the Ceph pool
         keyring : string, optional
@@ -89,13 +86,8 @@ class RadosChunkStore(ChunkStore):
         try:
             if isinstance(config, dict):
                 cluster = rados.Rados(conf=config)
-            elif os.path.isfile(config):
-                cluster = rados.Rados(conffile=config)
             else:
-                with tempfile.NamedTemporaryFile() as f:
-                    f.write(config)
-                    f.seek(0)
-                    cluster = rados.Rados(conffile=f.name)
+                cluster = rados.Rados(conffile=config)
             if keyring:
                 cluster.conf_set('keyring', keyring)
             if timeout is not None:

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -54,54 +54,6 @@ def array_equal(a1, a2):
         return (a1.shape == a2.shape) and np.all(a1 == a2)
 
 
-class AttrsSensors(object):
-    """Metadata in the form of attributes and sensors.
-
-    Parameters
-    ----------
-    attrs : mapping from string to object
-        Metadata attributes
-    sensors : mapping from string to :class:`SensorData` objects
-        Metadata sensor cache mapping sensor names to raw sensor data
-    name : string, optional
-        Identifier that describes the origin of the metadata (backend-specific)
-
-    """
-    def __init__(self, attrs, sensors, name='custom'):
-        self.attrs = attrs
-        self.sensors = sensors
-        self.name = name
-
-
-class VisFlagsWeights(object):
-    """Correlator data in the form of visibilities, flags and weights.
-
-    Parameters
-    ----------
-    vis : array-like of complex64, shape (*T*, *F*, *B*)
-        Complex visibility data as a function of time, frequency and baseline
-    flags : array-like of uint8, shape (*T*, *F*, *B*)
-        Flags as a function of time, frequency and baseline
-    weights : array-like of float32, shape (*T*, *F*, *B*)
-        Visibility weights as a function of time, frequency and baseline
-    name : string, optional
-        Identifier that describes the origin of the data (backend-specific)
-
-    """
-    def __init__(self, vis, flags, weights, name='custom'):
-        if not (vis.shape == flags.shape == weights.shape):
-            raise ValueError("Shapes of vis %s, flags %s and weights %s differ"
-                             % (vis.shape, flags.shape, weights.shape))
-        self.vis = vis
-        self.flags = flags
-        self.weights = weights
-        self.name = name
-
-    @property
-    def shape(self):
-        return self.vis.shape
-
-
 class Subarray(object):
     """Subarray specification.
 

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -22,12 +22,59 @@ import os
 import katsdptelstate
 import redis
 
-from .dataset import AttrsSensors
 from .sensordata import TelstateSensorData
 
 
 class DataSourceNotFound(Exception):
     """File associated with DataSource not found or server not responding."""
+
+
+class AttrsSensors(object):
+    """Metadata in the form of attributes and sensors.
+
+    Parameters
+    ----------
+    attrs : mapping from string to object
+        Metadata attributes
+    sensors : mapping from string to :class:`SensorData` objects
+        Metadata sensor cache mapping sensor names to raw sensor data
+    name : string, optional
+        Identifier that describes the origin of the metadata (backend-specific)
+
+    """
+    def __init__(self, attrs, sensors, name='custom'):
+        self.attrs = attrs
+        self.sensors = sensors
+        self.name = name
+
+
+class VisFlagsWeights(object):
+    """Correlator data in the form of visibilities, flags and weights.
+
+    Parameters
+    ----------
+    vis : array-like of complex64, shape (*T*, *F*, *B*)
+        Complex visibility data as a function of time, frequency and baseline
+    flags : array-like of uint8, shape (*T*, *F*, *B*)
+        Flags as a function of time, frequency and baseline
+    weights : array-like of float32, shape (*T*, *F*, *B*)
+        Visibility weights as a function of time, frequency and baseline
+    name : string, optional
+        Identifier that describes the origin of the data (backend-specific)
+
+    """
+    def __init__(self, vis, flags, weights, name='custom'):
+        if not (vis.shape == flags.shape == weights.shape):
+            raise ValueError("Shapes of vis %s, flags %s and weights %s differ"
+                             % (vis.shape, flags.shape, weights.shape))
+        self.vis = vis
+        self.flags = flags
+        self.weights = weights
+        self.name = name
+
+    @property
+    def shape(self):
+        return self.vis.shape
 
 
 class DataSource(object):

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -193,7 +193,7 @@ class TelstateDataSource(DataSource):
             # Redis server
             try:
                 telstate = katsdptelstate.TelescopeState(url_parts.netloc, db)
-            except (redis.ConnectionError, redis.exceptions.TimeoutError) as e:
+            except (redis.ConnectionError, redis.TimeoutError) as e:
                 raise DataSourceNotFound(str(e))
             return cls(telstate, **kwargs)
 

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -18,6 +18,7 @@
 
 import urlparse
 import os
+import tempfile
 
 import katsdptelstate
 import redis
@@ -158,8 +159,11 @@ class TelstateDataSource(DataSource):
             DataSource.__init__(self, metadata, None)
         else:
             # Extract VisFlagsWeights and timestamps from telstate
-            store = RadosChunkStore.from_config(telstate['ceph_conf'],
-                                                telstate['ceph_pool'])
+            with tempfile.NamedTemporaryFile() as f:
+                f.write(telstate['ceph_conf'])
+                f.flush()
+                pool = telstate['ceph_pool']
+                store = RadosChunkStore.from_config(f.name, pool)
             ts_name = store.join(base_name, 'timestamps')
             ts_chunks = chunk_info['timestamps']['chunks']
             ts_dtype = chunk_info['timestamps']['dtype']

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -341,11 +341,12 @@ class DaskLazyIndexer(object):
         except NotImplementedError:
             # Dask does not like multiple boolean indices: go one dim at a time
             for dim, keep_per_dim in enumerate(keep):
+                # Use da.take(dataset, index, axis=dim) once dask is required
                 index = dataset.ndim * [slice(None)]
                 index[dim] = keep_per_dim
                 dataset = dataset[tuple(index)]
         self.dataset = dataset
-        self.transforms = [] if transforms is None else transforms
+        self.transforms = []
 
     def __getitem__(self, keep):
         return self.dataset[keep].compute()

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -334,17 +334,16 @@ class LazyIndexer(object):
 
 class DaskLazyIndexer(object):
     """Turn a dask Array into a LazyIndexer by computing it upon indexing."""
-    def __init__(self, dataset, keep=(), transforms=None):
+    def __init__(self, dataset, keep=()):
         self.name = getattr(dataset, 'name', '')
         try:
             dataset = dataset[keep]
         except NotImplementedError:
+            # XXX Once dask is a katdal install requirement this can move out
+            import dask.array as da
             # Dask does not like multiple boolean indices: go one dim at a time
             for dim, keep_per_dim in enumerate(keep):
-                # Use da.take(dataset, index, axis=dim) once dask is required
-                index = dataset.ndim * [slice(None)]
-                index[dim] = keep_per_dim
-                dataset = dataset[tuple(index)]
+                dataset = da.take(dataset, keep_per_dim, axis=dim)
         self.dataset = dataset
         self.transforms = []
 

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -330,3 +330,20 @@ class LazyIndexer(object):
         """Type of data array after transformation, i.e. `self[:].dtype`."""
         return reduce(lambda dtype, transform: transform.dtype if transform.dtype is not None else dtype,
                       self.transforms, self._initial_dtype)
+
+
+class DaskLazyIndexer(object):
+    """Turn a dask Array into a LazyIndexer by computing it upon indexing."""
+    def __init__(self, dataset, keep=slice(None), transforms=None):
+        self.da = dataset[keep]
+
+    def __getitem__(self, keep):
+        return self.da[keep].compute()
+
+    @property
+    def shape(self):
+        return self.da.shape
+
+    @property
+    def dtype(self):
+        return self.da.dtype

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -334,7 +334,7 @@ class LazyIndexer(object):
 
 class DaskLazyIndexer(object):
     """Turn a dask Array into a LazyIndexer by computing it upon indexing."""
-    def __init__(self, dataset, keep=slice(None), transforms=None):
+    def __init__(self, dataset, keep=(), transforms=None):
         self.da = dataset[keep]
 
     def __getitem__(self, keep):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -54,7 +54,7 @@ SENSOR_ALIASES = {
 
 def _calc_azel(cache, name, ant):
     """Calculate virtual (az, el) sensors from actual ones in sensor cache."""
-    real_sensor = 'Antennas/%s/pos_actual_scan_%s' % \
+    real_sensor = '%s_pos_actual_scan_%s' % \
                   (ant, 'azim' if name.endswith('az') else 'elev')
     cache[name] = sensor_data = katpoint.deg2rad(cache.get(real_sensor))
     return sensor_data
@@ -353,29 +353,29 @@ class VisibilityDataV4(DataSet):
     @property
     def temperature(self):
         """Air temperature in degrees Celsius."""
-        names = ['anc_weather_temperature']
+        names = ['anc_air_temperature']
         return self.sensor.get_with_fallback('temperature', names)
 
     @property
     def pressure(self):
         """Barometric pressure in millibars."""
-        names = ['anc_weather_pressure']
+        names = ['anc_air_pressure']
         return self.sensor.get_with_fallback('pressure', names)
 
     @property
     def humidity(self):
         """Relative humidity as a percentage."""
-        names = ['anc_weather_humidity']
+        names = ['anc_air_relative_humidity']
         return self.sensor.get_with_fallback('humidity', names)
 
     @property
     def wind_speed(self):
         """Wind speed in metres per second."""
-        names = ['anc_weather_wind_speed']
+        names = ['anc_mean_wind_speed']
         return self.sensor.get_with_fallback('wind_speed', names)
 
     @property
     def wind_direction(self):
         """Wind direction as an azimuth angle in degrees."""
-        names = ['anc_weather_wind_direction']
+        names = ['anc_wind_direction']
         return self.sensor.get_with_fallback('wind_direction', names)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -126,7 +126,8 @@ class VisibilityDataV4(DataSet):
 
         # ------ Extract flags ------
 
-        self._flags_select = np.array([0], dtype=np.uint8)
+        # Internal flag mask overridden whenever _flags_keep is set via select()
+        self._flags_select = np.array([255], dtype=np.uint8)
         self._flags_keep = 'all'
 
         # ------ Extract observation parameters and script log ------

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -109,24 +109,6 @@ class VisibilityDataV4(DataSet):
         self.version = '4.0'
         self.dump_period = attrs['int_time']
 
-        # Check dimensions of timestamps vs those of visibility data
-        num_dumps = len(source.timestamps)
-        if source.data and (num_dumps != source.data.shape[0]):
-            raise BrokenFile('Number of timestamps received from ingest '
-                             '(%d) differs from number of dumps in data (%d)' %
-                             (num_dumps, source.data.shape[0]))
-        # The expected_dumps should always be an integer (like num_dumps),
-        # unless the timestamps and/or dump period are messed up in the file,
-        # so threshold of this test is a bit arbitrary (e.g. could use > 0.5).
-        # The last dump might only be partially filled by ingest, so ignore it.
-        if num_dumps > 1:
-            expected_dumps = 2 + (source.timestamps[-2] -
-                                  source.timestamps[0]) / self.dump_period
-            if abs(expected_dumps - num_dumps) >= 0.01:
-                # Warn the user, as this is anomalous
-                logger.warning("Irregular timestamps detected: expected %.3f "
-                               "dumps based on dump period and start/end times, "
-                               "got %d instead", expected_dumps, num_dumps)
         source.timestamps += self.time_offset
         if source.timestamps[0] < 1e9:
             logger.warning("Data set has invalid first correlator timestamp "

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -108,7 +108,7 @@ class VisibilityDataV4(DataSet):
         self.file = {}
         self.version = '4.0'
         self.dump_period = attrs['int_time']
-
+        num_dumps = len(source.timestamps)
         source.timestamps += self.time_offset
         if source.timestamps[0] < 1e9:
             logger.warning("Data set has invalid first correlator timestamp "


### PR DESCRIPTION
This brings the V4 formatter up to speed (note that this PR piggy-backs on #118). The main improvements are:

- Use telstate views
- Add vis / flags / weights indexers

An RDB file can currently be opened like this:

```Python
from katdal.datasources import open_data_source
from katdal.visdatav4 import VisibilityDataV4
ds = open_data_source('dump.20180207-0002.rdb?capture_block_id=20180207-0002-1517994195&stream_name=sdp_l0')
f = VisibilityDataV4(ds)
f.select(dumps=slice(0,10), ants='m003,m000,m017', channels=slice(0,1000))
f.vis[:].shape
(10, 1000, 24)
```

Output:

```
===============================================================================
Name: file:///dump.20180207-0002.rdb?capture_block_id=20180207-0002-1517994195&stream_name=sdp_l0 | test_vis_writer/20180207-0002-1517994195/sdp_l0 (version 4.0)
===============================================================================
Observer: sarah  Experiment ID: 20180207-0007
Description: 'MKAIV-387: CBF J1939+2134'
Observed from 2018-02-07 11:03:41.430 SAST to 2018-02-07 11:07:01.346 SAST
Dump rate / period: 0.12505 Hz / 7.997 s
Subarrays: 1
  ID  Antennas                            Inputs  Corrprods
   0  m000,m003,m015,m016,m017,m018,m019,m020,m021,m024,m027,m029,m031,m034,m035,m040  32      544
Spectral Windows: 1
  ID Band Product  CentreFreq(MHz)  Bandwidth(MHz)  Channels  ChannelWidth(kHz)
   0 L    bc856M4k   1284.000         856.000           4096       208.984
-------------------------------------------------------------------------------
Data selected according to the following criteria:
  subarray=0
  ants=['m018', 'm019', 'm040', 'm003', 'm000', 'm015', 'm016', 'm017', 'm021', 'm020', 'm034', 'm035', 'm024', 'm027', 'm031', 'm029']
  spw=0
-------------------------------------------------------------------------------
Shape: (25 dumps, 4096 channels, 544 correlation products) => Size: 445.645 MB
Antennas: m000,m003,m015,m016,m017,*m018,m019,m020,m021,m024,m027,m029,m031,m034,m035,m040  Inputs: 32  Autocorr: yes  Crosscorr: yes
Channels: 4096 (index 0 - 4095,  856.000 MHz - 1711.791 MHz), each 208.984 kHz wide
Targets: 1 selected out of 1 in catalogue
  ID  Name        Type      RA(J2000)     DEC(J2000)  Tags     Dumps  ModelFlux(Jy)
   0  J1939+2134  radec     19:39:38.56   21:34:59.1  Pulsars     25  
Scans: 1 selected out of 1 total       Compscans: 1 selected out of 1 total
  Date        Timerange(UTC)       ScanState  CompScanLabel  Dumps  Target
  07-Feb-2018/09:03:45 - 09:06:57    0:track    0:track         25    0:J1939+2134
```

Next steps are S3 support and better capture block / stream detection.