### PR TITLE
Autodetect program block ID and stream name

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -524,10 +524,10 @@ class DataSet(object):
                max_freq < 1.6 * model.max_freq_MHz:
                 new_min_freq = min(min_freq, model.min_freq_MHz)
                 new_max_freq = max(max_freq, model.max_freq_MHz)
-                logger.warn('Extending flux density model frequency range of '
-                            '%r from %d-%d MHz to %d-%d MHz', target.name,
-                            model.min_freq_MHz, model.max_freq_MHz,
-                            new_min_freq, new_max_freq)
+                logger.warning('Extending flux density model frequency range '
+                               'of %r from %d-%d MHz to %d-%d MHz', target.name,
+                               model.min_freq_MHz, model.max_freq_MHz,
+                               new_min_freq, new_max_freq)
                 model.min_freq_MHz = new_min_freq
                 model.max_freq_MHz = new_max_freq
 


### PR DESCRIPTION
The default TelstateDataSource constructor now takes a telstate that
already has views associated with the capture block and stream. This
requires the reintroduction of `chunk_name` to figure out the chunk
store name of the dataset (as `capture_stream` is now implicit again).
This is the intended way to open pipeline data.

When constructing telstate from an URL with no prior views, detect
the capture block ID and stream name. Crash if there are none and warn
if there are more than one. Then prepare the telstate with the relevant
views before passing on to the usual constructor.