### PR TITLE
SR-1052: katdal.open() a V4 file

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -212,6 +212,7 @@ a back door installed at `d.file` in the case of a single-file data set.
 """
 
 import logging as _logging
+import urlparse
 
 from .dataset import DataSet, WrongVersion
 from .lazy_indexer import LazyTransform
@@ -330,7 +331,7 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
     datasets = []
     for f in filenames:
         # V4 RDB file with optional URL-style query string
-        if f.split('?')[0].endswith('.rdb'):
+        if urlparse.urlsplit(f).path.endswith('.rdb'):
             from .datasources import open_data_source
             from .visdatav4 import VisibilityDataV4
             dataset = VisibilityDataV4(open_data_source(f),

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -329,7 +329,14 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
     filenames = [filename] if isinstance(filename, basestring) else filename
     datasets = []
     for f in filenames:
-        dataset = _file_action('__call__', f, ref_ant, time_offset, **kwargs)
+        # V4 RDB file with optional URL-style query string
+        if f.split('?')[0].endswith('.rdb'):
+            from .datasources import open_data_source
+            from .visdatav4 import VisibilityDataV4
+            dataset = VisibilityDataV4(open_data_source(f),
+                                       ref_ant, time_offset, **kwargs)
+        else:
+            dataset = _file_action('__call__', f, ref_ant, time_offset, **kwargs)
         datasets.append(dataset)
     return datasets[0] if isinstance(filename, basestring) else \
         ConcatenatedDataSet(datasets)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -171,7 +171,7 @@ def view_capture_stream(telstate, capture_block_id=None, stream_name=None):
         capture_blocks = []
         if 'sdp_capture_block_id' in telstate:
             for value_time in telstate.get_range('sdp_capture_block_id', st=0):
-                cbid = value_time[0]
+                cbid = str(value_time[0])
                 if 'obs_params' in telstate.view(cbid, exclusive=True):
                     capture_blocks.append(cbid)
         if not capture_blocks:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -132,16 +132,7 @@ class VisibilityDataV4(DataSet):
 
         # ------ Extract observation parameters and script log ------
 
-        self.obs_params = {}
-        # Replay obs_params sensor if available and update obs_params dict accordingly
-        try:
-            obs_params = self.sensor.get('obs_params', extract=False)['value']
-        except KeyError:
-            obs_params = []
-        for obs_param in obs_params:
-            if obs_param:
-                key, val = obs_param.split(' ', 1)
-                self.obs_params[key] = np.lib.utils.safe_eval(val)
+        self.obs_params = attrs['obs_params']
         # Get observation script parameters, with defaults
         self.observer = self.obs_params.get('observer', '')
         self.description = self.obs_params.get('description', '')


### PR DESCRIPTION
Synchronise v4 format with new `CaptureSession` as we now have `obs_params` as an attribute and `sdp_capture_block_id` needs to lose its unicodeness.

Then plumb all the goodness straight into `katdal.open()` and declare success!