### PR TITLE
Various v4 mop-up operations

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -219,18 +219,16 @@ def _shorten_key(telstate, key):
 
     Returns
     -------
-    short_key : string or None
-        Suffix of `key` after subtracting first matching prefix, or None if
-        `key` does not start with any of the prefixes
+    short_key : string
+        Suffix of `key` after subtracting first matching prefix, or empty
+        string if `key` does not start with any of the prefixes (or exactly
+        matches a prefix, which is also considered pathological)
 
     """
     for prefix in telstate.prefixes:
-        if not prefix:
-            return key
-        head, sep, tail = key.partition(prefix)
-        if not head and sep == prefix:
-            return tail
-    return None
+        if key.startswith(prefix):
+            return key[len(prefix):]
+    return ''
 
 
 class TelstateDataSource(DataSource):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -158,7 +158,7 @@ class VisibilityDataV4(DataSet):
         ants = []
         for resource in attrs['sub_pool_resources'].split(','):
             try:
-                ant_description = self.sensor.get(resource + '_observer')[0]
+                ant_description = attrs[resource + '_observer']
                 ants.append(katpoint.Antenna(ant_description))
             except (KeyError, ValueError):
                 continue


### PR DESCRIPTION
- Allow chunk store to be overridden (opens NPY files during testing instead of S3)
- Fix mxxx_observer which is now an attribute
- Shorten sensor names by discarding the most relevant prefix from the telstate key