### PR TITLE
Authenticated katdal

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -20,7 +20,10 @@ import contextlib
 
 import numpy as np
 try:
-    import katsdpauth.auth_botocore
+    try:
+        import katsdpauth.auth_botocore
+    except:
+        import botocore
     _botocore_import_error = None
 except ImportError as e:
     botocore = None

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -20,7 +20,7 @@ import contextlib
 
 import numpy as np
 try:
-    import botocore
+    import katsdpauth.auth_botocore
     _botocore_import_error = None
 except ImportError as e:
     botocore = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-dateutil
 six
 toolz==0.9.0
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint
+git+ssh://git@github.com/ska-sa/katsdpauth#egg=katsdpauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ python-dateutil
 six
 toolz==0.9.0
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint
-git+ssh://git@github.com/ska-sa/katsdpauth#egg=katsdpauth
+git+ssh://git@github.com/ska-sa/katsdpauth

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(name="katdal",
         # rados is not in PyPI but available as Debian package python-rados
         'rados': ['rados'],
         # Only available throught github currently
-        'auth' : ['katsdpauth'], 
+        'auth': ['katsdpauth'], 
       },
       tests_require=['nose', 'dask[array]'])

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(name="katdal",
         's3': ['botocore'],
         # rados is not in PyPI but available as Debian package python-rados
         'rados': ['rados'],
-        #Only available throught github currently
-        'authed':['katsdpauth'], 
+        # Only available throught github currently
+        'auth' : ['katsdpauth'], 
       },
       tests_require=['nose', 'dask[array]'])

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(name="katdal",
         'ms': ['python-casacore >= 2.2.1'],
         's3': ['botocore'],
         # rados is not in PyPI but available as Debian package python-rados
-        'rados': ['rados']
+        'rados': ['rados'],
+        #Only available throught github currently
+        'authed':['katsdpauth'], 
       },
       tests_require=['nose', 'dask[array]'])


### PR DESCRIPTION
My authenticated katdal version. It is not really necessary to include the import as part of katdal itself. Technically simply importing katadpauth.auth_botocore in any script will patch anything in it using botocore to use my authentication. I think it may be a good idea to create a small script (auth_katdal or something) which simply imports katdal and katsdpauth.auth_botocore which will allow us to not perform the pull in your code.

This current version will not ask you to log in unless you are trying to access a protected resource. If you are on a whitelisted machine, katdal will simply run as it currently does, otherwise you will be prompted to log in.