### PR TITLE
Make writing an NPY file atomic

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -139,7 +139,7 @@ def view_capture_stream(telstate, capture_block_id=None, stream_name=None):
     """Create telstate view based on capture block ID and stream name.
 
     This figures out the appropriate capture block ID and L0 stream name from
-    a capture-stream specific telstate, or use the provided ones. It then
+    a capture-stream specific telstate, or uses the provided ones. It then
     constructs a view on `telstate` with at least the prefixes
 
       - <capture_block_id>_<stream_name>


### PR DESCRIPTION
This writes to a temporary filename first (ending in '.writing.npy')
before renaming it to the final '.npy' file after the file has been
closed. This ensures that other processes waiting for the file (like
the vis trawler) knows when it is safe to pick it up.

Also fix a grammar bug.