### PR TITLE
Improve autodetection of chunk store

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -49,7 +49,8 @@ class S3ChunkStore(ChunkStore):
     where "<bucket>" refers to the relevant S3 bucket, "<bucket>/<path>" is
     the name of the parent array of the chunk and "<idx>" is the index string
     of each chunk (e.g. "00001_00512"). The corresponding S3 key string of
-    a chunk is therefore "<path>/<idx>".
+    a chunk is "<path>/<idx>.npy" which reflects the fact that the chunk is
+    stored as a string representation of an NPY file (complete with header).
 
     Parameters
     ----------

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -26,6 +26,8 @@ import numpy as np
 
 from .sensordata import TelstateSensorData
 from .chunkstore_s3 import S3ChunkStore
+from .chunkstore_npy import NpyFileChunkStore
+from .chunkstore import StoreUnavailable
 
 
 logger = logging.getLogger(__name__)
@@ -235,7 +237,7 @@ class TelstateDataSource(DataSource):
     telstate : :class:`katsdptelstate.TelescopeState` object
         Telescope state with appropriate views
     chunk_store : :class:`katdal.ChunkStore` object, optional
-        Alternative chunk store (defaults to S3 store specified in telstate)
+        Chunk store for visibility data (the default is no data - metadata only)
     source_name : string, optional
         Name of telstate source (used for metadata name)
     """
@@ -254,22 +256,19 @@ class TelstateDataSource(DataSource):
             int_time = telstate['int_time']
             chunk_name = telstate['chunk_name']
             chunk_info = telstate['chunk_info']
-            if chunk_store is None:
-                s3_endpoint_url = telstate['s3_endpoint_url']
         except KeyError:
             # Metadata without data
             DataSource.__init__(self, metadata, None)
         else:
-            # Extract VisFlagsWeights and timestamps from telstate
+            # Extract timestamps from telstate
             n_dumps = chunk_info['correlator_data']['shape'][0]
             timestamps = t0 + np.arange(n_dumps) * int_time
-            if chunk_store is None:
-                chunk_store = S3ChunkStore.from_url(s3_endpoint_url)
-            data = ChunkStoreVisFlagsWeights(chunk_store, chunk_name, chunk_info)
+            data = ChunkStoreVisFlagsWeights(
+                chunk_store, chunk_name, chunk_info) if chunk_store else None
             DataSource.__init__(self, metadata, timestamps, data)
 
     @classmethod
-    def from_url(cls, url, chunk_store=None):
+    def from_url(cls, url, chunk_store='auto'):
         """Construct TelstateDataSource from URL (RDB file / REDIS server)."""
         url_parts = urlparse.urlparse(url, scheme='file')
         kwargs = dict(urlparse.parse_qsl(url_parts.query))
@@ -283,16 +282,27 @@ class TelstateDataSource(DataSource):
                 telstate.load_from_file(url_parts.path)
             except OSError as err:
                 raise DataSourceNotFound(str(err))
-            return cls(view_capture_stream(telstate, **kwargs), chunk_store,
-                       source_name)
+            telstate = view_capture_stream(telstate, **kwargs)
+            capture_stream = telstate.prefixes[0][:-1]
+            # Look for adjacent data directory (presumably containing NPY files)
+            capture_block_path = os.path.dirname(url_parts.path)
+            data_path = os.path.join(capture_block_path, '..', capture_stream)
+            if chunk_store == 'auto':
+                try:
+                    chunk_store = NpyFileChunkStore(os.path.normpath(data_path))
+                except StoreUnavailable:
+                    chunk_store = S3ChunkStore(telstate['s3_endpoint_url'])
+            return cls(telstate, chunk_store, source_name)
         elif url_parts.scheme == 'redis':
             # Redis server
             try:
                 telstate = katsdptelstate.TelescopeState(url_parts.netloc, db)
             except (redis.ConnectionError, redis.TimeoutError) as e:
                 raise DataSourceNotFound(str(e))
-            return cls(view_capture_stream(telstate, **kwargs), chunk_store,
-                       source_name)
+            telstate = view_capture_stream(telstate, **kwargs)
+            if chunk_store == 'auto':
+                chunk_store = S3ChunkStore(telstate['s3_endpoint_url'])
+            return cls(telstate, chunk_store, source_name)
 
 
 def open_data_source(url, *args, **kwargs):

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -27,7 +27,6 @@ import numpy as np
 from .sensordata import TelstateSensorData
 from .chunkstore_s3 import S3ChunkStore
 from .chunkstore_npy import NpyFileChunkStore
-from .chunkstore import StoreUnavailable
 
 
 logger = logging.getLogger(__name__)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -292,7 +292,7 @@ class TelstateDataSource(DataSource):
                 except KeyError:
                     chunk_store = None
             if chunk_store == 'auto' and os.path.isdir(data_path):
-                chunk_store = NpyFileChunkStore(os.path.normpath(store_path))
+                chunk_store = NpyFileChunkStore(store_path)
             else:
                 chunk_store = S3ChunkStore.from_url(telstate['s3_endpoint_url'])
             return cls(telstate, chunk_store, source_name)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -285,8 +285,7 @@ class TelstateDataSource(DataSource):
             telstate = view_capture_stream(telstate, **kwargs)
             # Look for adjacent data directory (presumably containing NPY files)
             if chunk_store == 'auto':
-                capture_block_path = os.path.dirname(url_parts.path)
-                store_path = os.path.join(capture_block_path, '..')
+                store_path = os.path.dirname(os.path.dirname(url_parts.path))
                 try:
                     data_path = os.path.join(store_path, telstate['chunk_name'])
                 except KeyError:

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -295,7 +295,7 @@ class TelstateDataSource(DataSource):
             if chunk_store == 'auto' and os.path.isdir(data_path):
                 chunk_store = NpyFileChunkStore(os.path.normpath(store_path))
             else:
-                chunk_store = S3ChunkStore(telstate['s3_endpoint_url'])
+                chunk_store = S3ChunkStore.from_url(telstate['s3_endpoint_url'])
             return cls(telstate, chunk_store, source_name)
         elif url_parts.scheme == 'redis':
             # Redis server
@@ -305,7 +305,7 @@ class TelstateDataSource(DataSource):
                 raise DataSourceNotFound(str(e))
             telstate = view_capture_stream(telstate, **kwargs)
             if chunk_store == 'auto':
-                chunk_store = S3ChunkStore(telstate['s3_endpoint_url'])
+                chunk_store = S3ChunkStore.from_url(telstate['s3_endpoint_url'])
             return cls(telstate, chunk_store, source_name)
 
 


### PR DESCRIPTION
For RDB files this first attempts to locate an `NpyFileChunkStore` in an adjacent directory named after the capture stream, as is typically produced by `vis_writer` and other tools. Failing this, it falls back to the S3 gateway suggested by telstate. Another fail here is treated as an error (as this is typically due to authentication or network connection errors that the user wants to know about). The redis server option only attempts the S3 option, since there is no file access.

If the user really wants no chunk store it can be specified as `None`, which is useful for metadata extraction.

This allows the dream of `katdal.open('whatever')`, at least for RDB files :-)