### PR TITLE
Decode binary pickles from HDF5 v3 files

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -30,7 +30,7 @@ except ImportError:
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray, SpectralWindow,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS, _robust_target)
 from .sensordata import (SensorCache, RecordSensorData,
-                         H5TelstateSensorData)
+                         H5TelstateSensorData, pickle_loads)
 from .categorical import CategoricalData
 from .lazy_indexer import LazyIndexer, LazyTransform
 
@@ -605,7 +605,7 @@ class H5DataV3(DataSet):
             if value in no_unpickle:
                 return value
             else:
-                return pickle.loads(value)
+                return pickle_loads(value)
         except (KeyError, pickle.UnpicklingError):
             # In some cases the value is placed in a sensor instead. Return
             # the most recent value.
@@ -753,7 +753,7 @@ class H5DataV3(DataSet):
         try:
             # If <stream_name>_bls_ordering is present, it should be used in preference
             # to cbf_bls_ordering.
-            corrprods = pickle.loads(f['TelescopeState'].attrs[stream_name + '_bls_ordering'])
+            corrprods = pickle_loads(f['TelescopeState'].attrs[stream_name + '_bls_ordering'])
         except KeyError:
             # Prior to about Nov 2016, ingest would rewrite cbf_bls_ordering in
             # place.
@@ -819,7 +819,7 @@ class H5DataV3(DataSet):
             attr_name = f.attrs['capture_block_id'] + '_obs_params'
             value = f['TelescopeState'].attrs.get(attr_name)
             if value is not None:
-                obs_params = pickle.loads(value)
+                obs_params = pickle_loads(value)
         # Fall back to old obs_params location
         else:
             tm_params = tm_group['obs/params']

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -171,11 +171,24 @@ class RecordSensorData(SensorData):
                 len(self._data), self.dtype, id(self))
 
 
+def pickle_loads(raw):
+    """Load a pickle that might be wrapped in np.void.
+
+    The np.void wrapping is needed to pass variable-length binary strings
+    through h5py. The pickle module handles it transparently, but cPickle does
+    not.
+    """
+    if isinstance(raw, np.void):
+        return pickle.loads(raw.tostring())
+    else:
+        return pickle.loads(raw)
+
+
 def _h5_telstate_unpack(s):
     """Unpack a telstate value from its string representation."""
     try:
         # Since 2016-05-09 the HDF5 TelescopeState contains pickled values
-        return pickle.loads(s)
+        return pickle_loads(s)
     except (pickle.UnpicklingError, ValueError, EOFError):
         try:
             # Before 2016-05-09 the telstate values were str() representations

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -35,6 +35,7 @@ import katpoint
 import katdal
 from katdal import averager
 from katdal import ms_extra
+from katdal.sensordata import pickle_loads
 
 tag_to_intent = {'gaincal': 'CALIBRATE_PHASE,CALIBRATE_AMPLI',
                  'bpcal': 'CALIBRATE_BANDPASS,CALIBRATE_FLUX',
@@ -588,7 +589,7 @@ for win in range(len(h5.spectral_windows)):
             #   newer h5 files have the cal antlist as a sensor
             if 'cal_antlist' in first_h5.file['TelescopeState'].keys():
                 a0 = first_h5.file['TelescopeState']['cal_antlist'].value
-                antlist = pickle.loads(a0[0][1])
+                antlist = pickle_loads(a0[0][1])
             #   older h5 files have the cal antlist as an attribute
             elif 'cal_antlist' in first_h5.file['TelescopeState'].attrs.keys():
                 antlist = np.safe_eval(first_h5.file['TelescopeState'].attrs['cal_antlist'])
@@ -610,7 +611,7 @@ for win in range(len(h5.spectral_windows)):
                     soltimes, solvals = [], []
                     for t, s in solutions:
                         soltimes.append(t)
-                        solvals.append(pickle.loads(s))
+                        solvals.append(pickle_loads(s))
                     solvals = np.array(solvals)
 
                     # convert averaged UTC timestamps to MJD seconds.

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -27,7 +27,6 @@ import shutil
 import tarfile
 import optparse
 import time
-import pickle
 
 import numpy as np
 

--- a/scripts/objtoms.py
+++ b/scripts/objtoms.py
@@ -36,6 +36,7 @@ import katpoint
 import katdal
 from katdal import averager
 from katdal import ms_extra
+from katdal.sensordata import pickle_loads
 
 tag_to_intent = {'gaincal': 'CALIBRATE_PHASE,CALIBRATE_AMPLI',
                  'bpcal': 'CALIBRATE_BANDPASS,CALIBRATE_FLUX',
@@ -589,7 +590,7 @@ for win in range(len(h5.spectral_windows)):
             #   newer h5 files have the cal antlist as a sensor
             if 'cal_antlist' in first_h5.file['TelescopeState'].keys():
                 a0 = first_h5.file['TelescopeState']['cal_antlist'].value
-                antlist = pickle.loads(a0[0][1])
+                antlist = pickle_loads(a0[0][1])
             #   older h5 files have the cal antlist as an attribute
             elif 'cal_antlist' in first_h5.file['TelescopeState'].attrs.keys():
                 antlist = np.safe_eval(first_h5.file['TelescopeState'].attrs['cal_antlist'])
@@ -611,7 +612,7 @@ for win in range(len(h5.spectral_windows)):
                     soltimes, solvals = [], []
                     for t, s in solutions:
                         soltimes.append(t)
-                        solvals.append(pickle.loads(s))
+                        solvals.append(pickle_loads(s))
                     solvals = np.array(solvals)
 
                     # convert averaged UTC timestamps to MJD seconds.

--- a/scripts/objtoms.py
+++ b/scripts/objtoms.py
@@ -28,7 +28,6 @@ import shutil
 import tarfile
 import optparse
 import time
-import pickle
 
 import numpy as np
 


### PR DESCRIPTION
This allows pickles containing binary (rather than ASCII) data to be
loaded. See SR-675.