### PR TITLE
Handle binary pickles in sensors encoded as array of uint8

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -602,10 +602,7 @@ class H5DataV3(DataSet):
         """
         try:
             value = self.file['TelescopeState'].attrs[key]
-            if value in no_unpickle:
-                return value
-            else:
-                return pickle_loads(value)
+            return pickle_loads(value, no_unpickle)
         except (KeyError, pickle.UnpicklingError):
             # In some cases the value is placed in a sensor instead. Return
             # the most recent value.

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -171,17 +171,23 @@ class RecordSensorData(SensorData):
                 len(self._data), self.dtype, id(self))
 
 
-def pickle_loads(raw):
-    """Load a pickle that might be wrapped in np.void.
+def pickle_loads(raw, no_unpickle=()):
+    """Load a pickle that might be wrapped in np.void or np.ndarray.
 
     The np.void wrapping is needed to pass variable-length binary strings
     through h5py. The pickle module handles it transparently, but cPickle does
     not.
+
+    If the value is a string and is in no_unpickle, it is returned verbatim.
+    This is for backwards compatibility with older files that didn't use
+    pickles.
     """
-    if isinstance(raw, np.void):
+    if isinstance(raw, (np.void, np.ndarray)):
         return pickle.loads(raw.tostring())
-    else:
+    elif raw not in no_unpickle:
         return pickle.loads(raw)
+    else:
+        return raw
 
 
 def _h5_telstate_unpack(s):


### PR DESCRIPTION
This is needed to put variable-length pickles into a sensor HDF5
dataset.

The no_unpickle functionality is moved into pickle_loads because the
test 'value in no_unpickle' spews a deprecation warning if value is an
ndarray - so we only want to do it on (legacy) strings.