### PR TITLE
Clear up v4 niggles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ Open any data set through a single function to obtain a data set object:
 This automatically determines the version and storage location of the data set.
 The versions roughly map to the various instruments::
 
-  - v1 : Fringe Finder / FF (HDF5 file)
+  - v1 : Fringe Finder (HDF5 file)
   - v2 : KAT-7 (HDF5 file)
-  - v3 : RTS / AR1 (HDF5 file)
+  - v3 : MeerKAT (HDF5 file)
   - v4 : MeerKAT (chunk store based on objects in Ceph)
 
 Multiple data sets (even of different versions) may also be concatenated

--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,39 @@
 katdal
 ======
 
-This package serves as a data access library to the HDF5 files produced by
-the Fringe Finder, KAT-7 and MeerKAT data capturing systems. It uses memory
-carefully, allowing files to be inspected and partially loaded into memory.
-Data sets may be concatenated and split via a flexible selection mechanism.
-In addition, it provides a script to convert these HDF5 files to CASA
-MeasurementSets.
+This package serves as a data access library to interact with the chunk stores
+and HDF5 files produced by the MeerKAT radio telescope and its predecessors
+(KAT-7 and Fringe Finder). It uses memory carefully, allowing data sets to be
+inspected and partially loaded into memory. Data sets may be concatenated and
+split via a flexible selection mechanism. In addition, it provides a script to
+convert these data sets to CASA MeasurementSets.
 
 Quick Tutorial
 --------------
 
-Open any HDF5 file through a single function to obtain a data set object:
+Open any data set through a single function to obtain a data set object:
 
 .. code:: python
 
   import katdal
   d = katdal.open('1234567890.h5')
 
-This automatically determines whether it is a version 1 (FF), version 2
-(KAT-7) or version 3 (MeerKAT) file. Multiple files (even of different
-versions) may also be concatenated together (as long as they have the
-same dump rate):
+This automatically determines the version and storage location of the data set.
+The versions roughly map to the various instruments::
+
+  - v1 : Fringe Finder / FF (HDF5 file)
+  - v2 : KAT-7 (HDF5 file)
+  - v3 : RTS / AR1 (HDF5 file)
+  - v4 : MeerKAT (chunk store based on objects in Ceph)
+
+Multiple data sets (even of different versions) may also be concatenated
+together (as long as they have the same dump rate):
 
 .. code:: python
 
   d = katdal.open(['1234567890.h5', '1234567891.h5'])
 
-Inspect the contents of the file by printing the object:
+Inspect the contents of the data set by printing the object:
 
 .. code:: python
 
@@ -170,11 +176,11 @@ frequency dimension by ``d.channel_freqs`` and the correlation product dimension
 by ``d.corr_products``.
 
 Another key concept in the data set object is that of *sensors*. These are named
-time series of arbritrary data that are either loaded from the file (*actual*
-sensors) or calculated on the fly (*virtual* sensors). Both variants are
-accessed through the *sensor cache* (available as ``d.sensor``) and cached there
-after the first access. The data set object also provides convenient properties
-to expose commonly-used sensors, as shown in the plot example below:
+time series of arbritrary data that are either loaded from the data set
+(*actual* sensors) or calculated on the fly (*virtual* sensors). Both variants
+are accessed through the *sensor cache* (available as ``d.sensor``) and cached
+there after the first access. The data set object also provides convenient
+properties to expose commonly-used sensors, as shown in the plot example below:
 
 .. code:: python
 

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -14,32 +14,40 @@
 # limitations under the License.
 ################################################################################
 
-"""KAT data access library to interact with HDF5 and MeasurementSet files.
+"""KAT data access library for HDF5 files, MeasurementSets and chunk stores.
 
 Overview
 --------
 
-This module serves as a data access library to the HDF5 files produced by the
-Fringe Finder and KAT-7 data capturing systems. It uses memory carefully,
-allowing files to be inspected and partially loaded into memory. Data sets may
-be concatenated and split via a flexible selection mechanism. In addition, it
-provides a script to convert these HDF5 files to CASA MeasurementSets.
+This module serves as a data access library to interact with the chunk stores
+and HDF5 files produced by the MeerKAT radio telescope and its predecessors
+(KAT-7 and Fringe Finder). It uses memory carefully, allowing data sets to be
+inspected and partially loaded into memory. Data sets may be concatenated and
+split via a flexible selection mechanism. In addition, it provides a script to
+convert these data sets to CASA MeasurementSets.
 
 Quick Tutorial
 --------------
 
-Open any HDF5 file through a single function to obtain a data set object::
+Open any data set through a single function to obtain a data set object::
 
   import katdal
   d = katdal.open('1234567890.h5')
 
-This automatically determines whether it is a version 1 (FF) or version 2
-(KAT-7) file. Multiple files (even of different versions) may also be
-concatenated together (as long as they have the same dump rate)::
+This automatically determines the version and storage location of the data set.
+The versions roughly map to the various instruments::
+
+  - v1 : Fringe Finder / FF (HDF5 file)
+  - v2 : KAT-7 (HDF5 file)
+  - v3 : RTS / AR1 (HDF5 file)
+  - v4 : MeerKAT (chunk store based on objects in Ceph)
+
+Multiple data sets (even of different versions) may also be concatenated
+together (as long as they have the same dump rate)::
 
   d = katdal.open(['1234567890.h5', '1234567891.h5'])
 
-Inspect the contents of the file by printing the object::
+Inspect the contents of the data set by printing the object::
 
   print d
 
@@ -172,11 +180,11 @@ frequency dimension by `d.channel_freqs` and the correlation product dimension
 by `d.corr_products`.
 
 Another key concept in the data set object is that of *sensors*. These are named
-time series of arbritrary data that are either loaded from the file (*actual*
-sensors) or calculated on the fly (*virtual* sensors). Both variants are
-accessed through the *sensor cache* (available as `d.sensor`) and cached there
-after the first access. The data set object also provides convenient properties
-to expose commonly-used sensors, as shown in the plot example below::
+time series of arbritrary data that are either loaded from the data set
+(*actual* sensors) or calculated on the fly (*virtual* sensors). Both variants
+are accessed through the *sensor cache* (available as `d.sensor`) and cached
+there after the first access. The data set object also provides convenient
+properties to expose commonly-used sensors, as shown in the plot example below::
 
   import matplotlib.pyplot as plt
   plt.plot(d.az, d.el, 'o')

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-"""KAT data access library for HDF5 files, MeasurementSets and chunk stores.
+"""Data access library for data sets in the MeerKAT Visibility Format (MVF).
 
 Overview
 --------
@@ -37,9 +37,9 @@ Open any data set through a single function to obtain a data set object::
 This automatically determines the version and storage location of the data set.
 The versions roughly map to the various instruments::
 
-  - v1 : Fringe Finder / FF (HDF5 file)
+  - v1 : Fringe Finder (HDF5 file)
   - v2 : KAT-7 (HDF5 file)
-  - v3 : RTS / AR1 (HDF5 file)
+  - v3 : MeerKAT (HDF5 file)
   - v4 : MeerKAT (chunk store based on objects in Ceph)
 
 Multiple data sets (even of different versions) may also be concatenated

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -77,7 +77,7 @@ class S3ChunkStore(ChunkStore):
         self.client = client
 
     @classmethod
-    def from_url(cls, url, timeout=5, **kwargs):
+    def from_url(cls, url, timeout=10, **kwargs):
         """Construct S3 chunk store from endpoint URL.
 
         S3 authentication (i.e. the access + secret keys) is handled externally

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -285,7 +285,8 @@ class TelstateDataSource(DataSource):
             telstate = view_capture_stream(telstate, **kwargs)
             # Look for adjacent data directory (presumably containing NPY files)
             if chunk_store == 'auto':
-                store_path = os.path.dirname(os.path.dirname(url_parts.path))
+                rdb_path = os.path.abspath(url_parts.path)
+                store_path = os.path.dirname(os.path.dirname(rdb_path))
                 if not store_path:
                     store_path = os.path.curdir
                 try:

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -286,6 +286,8 @@ class TelstateDataSource(DataSource):
             # Look for adjacent data directory (presumably containing NPY files)
             if chunk_store == 'auto':
                 store_path = os.path.dirname(os.path.dirname(url_parts.path))
+                if not store_path:
+                    store_path = os.path.curdir
                 try:
                     data_path = os.path.join(store_path, telstate['chunk_name'])
                 except KeyError:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -117,7 +117,7 @@ class VisibilityDataV4(DataSet):
         half_dump = 0.5 * self.dump_period
         self.start_time = katpoint.Timestamp(source.timestamps[0] - half_dump)
         self.end_time = katpoint.Timestamp(source.timestamps[-1] + half_dump)
-        self._time_keep = np.full(num_dumps, True, dtype=bool)
+        self._time_keep = np.full(num_dumps, True, dtype=np.bool_)
         all_dumps = [0, num_dumps]
 
         # Assemble sensor cache

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -116,7 +116,7 @@ class VisibilityDataV4(DataSet):
         half_dump = 0.5 * self.dump_period
         self.start_time = katpoint.Timestamp(source.timestamps[0] - half_dump)
         self.end_time = katpoint.Timestamp(source.timestamps[-1] + half_dump)
-        self._time_keep = np.full(num_dumps, True)
+        self._time_keep = np.full(num_dumps, True, dtype=bool)
         all_dumps = [0, num_dumps]
 
         # Assemble sensor cache

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -20,6 +20,7 @@ import logging
 
 import numpy as np
 import katpoint
+import dask.array as da
 
 from .dataset import (DataSet, BrokenFile, Subarray, SpectralWindow,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
@@ -387,7 +388,7 @@ class VisibilityDataV4(DataSet):
         """
         stage1 = (self._time_keep, self._freq_keep, self._corrprod_keep)
         flags = self.source.data.flags
-        flags = np.bitwise_and(self._flags_select, flags).view(np.bool_)
+        flags = da.bitwise_and(self._flags_select, flags).view(np.bool_)
         return DaskLazyIndexer(flags, stage1)
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ python-dateutil
 six
 toolz==0.9.0
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint
-git+ssh://git@github.com/ska-sa/katsdpauth

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -89,6 +89,8 @@ def main():
                       help="If a single element in an averaging bin is flagged, flag the averaged bin.")
     parser.add_option("--caltables", action="store_true", default=False,
                       help="Create calibration tables from gain solutions in the dataset (if present).")
+    parser.add_option("--quack", type=int, default=2, metavar='N',
+                      help="Discard the first N dumps (which are frequently incomplete).")
 
     (options, args) = parser.parse_args()
 
@@ -164,7 +166,7 @@ def main():
 
       return CPInfo(ant1_index, ant2_index, ant1, ant2, cp_index, missing_cp)
 
-    # Open dataset 
+    # Open dataset
     # if len(args) == 1: args = args[0]
     # katdal can handle a list of files, which get virtually concatenated internally
     dataset = katdal.open(args, ref_ant=options.ref_ant)
@@ -214,7 +216,8 @@ def main():
         # otherwise use the ms name
         caltable_basename = ms_name[:-3] if ms_name.lower().endswith('.ms') else ms_name
 
-        dataset.select(spw=win, scans='track', flags=options.flags)
+        # XXX Discard first N dumps which are frequently incomplete (fix this in ChunkStore eventually)
+        dataset.select(spw=win, scans='track', flags=options.flags, dumps=slice(options.quack, None))
 
         # The first step is to copy the blank template MS to our desired output (making sure it's not already there)
         if os.path.exists(ms_name):

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ news = open(os.path.join(here, 'NEWS.rst')).read()
 long_description = readme + '\n\n' + news
 
 setup(name="katdal",
-      description="Karoo Array Telescope data access library "
-                  "to interact with HDF5 and MS files",
+      description="Karoo Array Telescope data access library to interact "
+                  "with HDF5 files, MeasurementSets and chunk stores",
       long_description=long_description,
       author="Ludwig Schwardt",
       author_email="ludwig@ska.ac.za",
@@ -63,6 +63,6 @@ setup(name="katdal",
         # rados is not in PyPI but available as Debian package python-rados
         'rados': ['rados'],
         # Only available throught github currently
-        'auth': ['katsdpauth'], 
+        'auth': ['katsdpauth'],
       },
       tests_require=['nose', 'dask[array]'])

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ news = open(os.path.join(here, 'NEWS.rst')).read()
 long_description = readme + '\n\n' + news
 
 setup(name="katdal",
-      description="Karoo Array Telescope data access library to interact "
-                  "with HDF5 files, MeasurementSets and chunk stores",
+      description="Karoo Array Telescope data access library for interacting "
+                  "with data sets in the MeerKAT Visibility Format (MVF)",
       long_description=long_description,
       author="Ludwig Schwardt",
       author_email="ludwig@ska.ac.za",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name="katdal",
       zip_safe=False,
       setup_requires=['katversion'],
       use_katversion=True,
-      install_requires=['numpy', 'katpoint', 'h5py'],
+      install_requires=['numpy', 'katpoint', 'h5py>=2.3'],
       extras_require={
         'ms': ['python-casacore >= 2.2.1'],
         's3': ['botocore'],


### PR DESCRIPTION
This is a first pass to prepare for release:

  - Improve timeouts and errors for S3
  - Restore support for NumPy 1.11 / Ubuntu 16.04
  - Speed up flag access
  - Fix relative NPY store paths
  - Update docs to refer to datasets and not files (MVF still has to happen)
  - Quack by default in mvftoms
  - Remove katsdpauth from requirements.txt for now