### PR TITLE
Fix mvftoms for v3 files

### DIFF
--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -38,6 +38,7 @@ import katdal
 from katdal import averager
 from katdal import ms_extra
 from katdal.sensordata import pickle_loads
+from katdal.lazy_indexer import DaskLazyIndexer
 
 
 def load(dataset, indices, vis, weights, flags):
@@ -56,7 +57,7 @@ def load(dataset, indices, vis, weights, flags):
     vis, weights, flags : array-like
         Outputs, which must have the correct shape and type
     """
-    if hasattr(dataset.vis, 'dataset'):
+    if isinstance(dataset.vis, DaskLazyIndexer):
         da.store([dataset.vis.dataset[indices],
                   dataset.weights.dataset[indices],
                   dataset.flags.dataset[indices]],


### PR DESCRIPTION
My detection of the dataset being dask-like was flawed and was
incorrectly trying to use da.store on HDF5 data.