### PR TITLE
Flag and zero missing chunks

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -22,7 +22,7 @@ import io
 import numpy as np
 try:
     try:
-        import katsdpauth.auth_botocore
+        import katsdpauth.auth_botocore   # noqa: F401
     except ImportError:
         import botocore
     _botocore_import_error = None

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -84,17 +84,17 @@ class VisFlagsWeights(object):
         return self.vis.shape
 
 
-def _has_chunk_to_flags(has_chunk, block_id=None, full_chunks=None):
+def _has_chunk_to_flags(has_chunk, block_id, full_chunks):
     """Turn a has_chunk bool into chunk of flags with correct data_lost bit."""
     shape = tuple(chk[idx] for chk, idx in zip(full_chunks, block_id))
     return np.full(shape, 0 if has_chunk else 8, dtype=np.uint8)
 
 
 def _multi_or_3d(*args):
-    """Do bitwise 'or' of more than two 3-D arrays."""
+    """Do bitwise 'or' of two or more 3-D arrays (without modifying them)."""
     args = np.atleast_3d(*args)
-    out = args[0]
-    for arg in args[1:]:
+    out = args[0] | args[1]
+    for arg in args[2:]:
         out |= arg
     return out
 

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -97,15 +97,15 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
     """
     def __init__(self, store, base_name, chunk_info):
         self.store = store
-        da = {}
+        darray = {}
         for array, info in chunk_info.iteritems():
             array_name = store.join(base_name, array)
-            da[array] = store.get_dask_array(array_name, info['chunks'],
-                                             info['dtype'])
-        vis = da['correlator_data']
-        flags = da['flags']
+            darray[array] = store.get_dask_array(array_name, info['chunks'],
+                                                 info['dtype'])
+        vis = darray['correlator_data']
+        flags = darray['flags']
         # Combine low-resolution weights and high-resolution weights_channel
-        weights = da['weights'] * da['weights_channel'][..., np.newaxis]
+        weights = darray['weights'] * darray['weights_channel'][..., np.newaxis]
         VisFlagsWeights.__init__(self, vis, flags, weights, base_name)
 
 

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -125,11 +125,8 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
                                         token='missing-chunks-' + array_name,
                                         chunks=info['chunks'], dtype=np.uint8,
                                         full_chunks=info['chunks'])
-            # If a flag chunk is missing but not the corresponding vis/weights,
-            # the data_lost bit will *not* be set (all flags cleared, actually)
-            if array != 'flags':
-                extra_flags.append(chunks_lost)
-                extra_flags.append('ijk'[:chunks_lost.ndim])
+            extra_flags.append(chunks_lost)
+            extra_flags.append('ijk'[:chunks_lost.ndim])
         vis = darray['correlator_data']
         # Combine original L0 flags with extras (missing chunks per array)
         flags = da.atop(_multi_or_3d, 'ijk', darray['flags'], 'ijk',

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -23,3 +23,5 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 class TestDictChunkStore(ChunkStoreTestBase):
     def setup(self):
         self.store = DictChunkStore(**vars(self))
+        # This store is prepopulated so missing chunks can't be checked
+        self.preloaded_chunks = True

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -1,0 +1,83 @@
+################################################################################
+# Copyright (c) 2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.datasources`."""
+
+import tempfile
+import shutil
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_equal
+import dask.array as da
+
+from katdal.chunkstore import generate_chunks
+from katdal.chunkstore_npy import NpyFileChunkStore
+from katdal.datasources import ChunkStoreVisFlagsWeights
+
+
+def ramp(shape, offset=0.0, slope=1.0, dtype=np.float_):
+    """Generate a multidimensional ramp of values of the given dtype."""
+    x = offset + slope * np.arange(np.prod(shape), dtype=np.float_)
+    return x.astype(dtype).reshape(shape)
+
+
+def to_dask_array(x):
+    """Turn ndarray `x` into a dask array with the standard vis chunking."""
+    n_corrprods = x.shape[2] if x.ndim >= 3 else x.shape[1] / 8
+    chunk_size = 4 * n_corrprods * 8
+    chunks = generate_chunks(x.shape, x.dtype, chunk_size,
+                             dims_to_split=(0, 1), power_of_two=True)
+    return da.from_array(x, chunks)
+
+
+def put_fake_dataset(store, base_name, shape):
+    """Write a fake dataset into the chunk store."""
+    data = {'correlator_data': ramp(shape, dtype=np.float32) * (1 - 1j),
+            'flags': np.zeros(shape, dtype=np.uint8),
+            'weights': ramp(shape, slope=256. / np.prod(shape), dtype=np.uint8),
+            'weights_channel': ramp(shape[:-1], dtype=np.float32)}
+    ddata = {k: to_dask_array(array) for k, array in data.items()}
+    chunk_info = {k: {'chunks': darray.chunks, 'dtype': darray.dtype,
+                      'shape': darray.shape} for k, darray in ddata.items()}
+    push = [store.put_dask_array(store.join(base_name, k), darray)
+            for k, darray in ddata.items()]
+    da.compute(push)
+    return data, chunk_info
+
+
+class TestChunkStoreVisFlagsWeights(object):
+    """Test the :class:`ChunkStoreVisFlagsWeights` dataset store."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.tempdir = tempfile.mkdtemp()
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tempdir)
+
+    def test_construction(self):
+        store = NpyFileChunkStore(self.tempdir)
+        base_name = 'cb1'
+        shape = (10, 64, 30)
+        data, chunk_info = put_fake_dataset(store, base_name, shape)
+        vfw = ChunkStoreVisFlagsWeights(store, base_name, chunk_info)
+        weights = data['weights'] * data['weights_channel'][..., np.newaxis]
+        assert_equal(vfw.shape, data['correlator_data'].shape)
+        assert_array_equal(vfw.vis.compute(), data['correlator_data'])
+        assert_array_equal(vfw.flags.compute(), data['flags'])
+        assert_array_equal(vfw.weights.compute(), weights)

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -103,6 +103,11 @@ class TestChunkStoreVisFlagsWeights(object):
         vfw = ChunkStoreVisFlagsWeights(store, base_name, chunk_info)
         # Check that missing chunks have been replaced by zeroes
         assert_array_equal(vfw.vis[missing_chunks['correlator_data']], 0.)
-        assert_array_equal(vfw.flags[missing_chunks['flags']], 0.)
         assert_array_equal(vfw.weights[missing_chunks['weights']], 0.)
         assert_array_equal(vfw.weights[missing_chunks['weights_channel']], 0.)
+        # Check that (only) missing chunks have been flagged as 'data lost'
+        expected = np.zeros_like(vfw.flags)
+        expected[missing_chunks['correlator_data']] |= 8
+        expected[missing_chunks['weights']] |= 8
+        expected[missing_chunks['weights_channel']] |= 8
+        assert_array_equal(vfw.flags & 8, expected)

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -17,7 +17,6 @@
 """Tests for :py:mod:`katdal.lazy_indexer`."""
 
 import numpy as np
-import dask.array as da
 
 from nose.tools import assert_raises
 


### PR DESCRIPTION
All missing chunks (i.e. chunks raising `ChunkNotFound` in the chunk store) are now replaced by zeros of the appropriate shape and dtype. In addition, missing chunks in the `correlator_data`, `weights` and `weights_channel` (but not `flags`...) arrays will get flagged as `data_lost`.

In the process, add unit tests for `ChunkStoreVisFlagsWeights`, including the ability to make fake datasets in the chunk store.

The last niggle is to replace the explicit flag value of 8 with `data_lost` but that will come in a separate PR that will rearrange all the flag info.