### PR TITLE
Fix NumPy 1.14 support by simplifying has_chunk

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.10.1 (2018-05-18)
+-------------------
+* Restore NumPy 1.14 support (all data flagged otherwise)
+
 0.10 (2018-05-17)
 -----------------
 * Rally around the MeerKAT Visibility Format (MVF)

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -42,10 +42,11 @@ class DictChunkStore(ChunkStore):
             array = self.arrays[array_name]
             # Ensure that chunk is array (otherwise 0-dim array becomes number)
             chunk = array[slices] if slices != () else array
-        if dtype != chunk.dtype:
-            raise BadChunk('Chunk {!r}: requested dtype {} differs from '
-                           'actual dtype {}'
-                           .format(chunk_name, dtype, chunk.dtype))
+        if chunk.shape != shape or chunk.dtype != dtype:
+            raise BadChunk('Chunk {!r}: requested dtype {} and/or shape {} '
+                           'differs from expected dtype {} and shape {}'
+                           .format(chunk_name, chunk.dtype, chunk.shape,
+                                   dtype, shape))
         return chunk
 
     def put_chunk(self, array_name, slices, chunk):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -63,9 +63,11 @@ class NpyFileChunkStore(ChunkStore):
         filename = os.path.join(self.path, chunk_name) + '.npy'
         with self._standard_errors(chunk_name):
             chunk = np.load(filename, allow_pickle=False)
-        if dtype != chunk.dtype:
-            raise BadChunk('Requested dtype {} differs from NPY file dtype {}'
-                           .format(dtype, chunk.dtype))
+        if chunk.shape != shape or chunk.dtype != dtype:
+            raise BadChunk('Chunk {!r}: NPY file dtype {} and/or shape {} '
+                           'differs from expected dtype {} and shape {}'
+                           .format(chunk_name, chunk.dtype, chunk.shape,
+                                   dtype, shape))
         return chunk
 
     def put_chunk(self, array_name, slices, chunk):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -23,15 +23,6 @@ import numpy as np
 from .chunkstore import ChunkStore, StoreUnavailable, ChunkNotFound, BadChunk
 
 
-def load_npy_header(filename):
-    """Load NPY file header only to obtain shape and dtype information."""
-    with open(filename, 'r') as fp:
-        # Header version: either (1, 0) or (2, 0)
-        ver = np.lib.format.read_magic(fp)
-        shape, fortran_order, dtype = np.lib.format._read_array_header(fp, ver)
-    return shape, fortran_order, dtype
-
-
 class NpyFileChunkStore(ChunkStore):
     """A store of chunks (i.e. N-dimensional arrays) based on NPY files.
 
@@ -79,7 +70,7 @@ class NpyFileChunkStore(ChunkStore):
 
     def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put_chunk`."""
-        chunk_name, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
+        chunk_name, _ = self.chunk_metadata(array_name, slices, chunk=chunk)
         base_filename = os.path.join(self.path, chunk_name)
         # Ensure any subdirectories are in place
         try:
@@ -96,15 +87,9 @@ class NpyFileChunkStore(ChunkStore):
 
     def has_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.has_chunk`."""
-        chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
+        chunk_name, _ = self.chunk_metadata(array_name, slices, dtype=dtype)
         filename = os.path.join(self.path, chunk_name) + '.npy'
-        try:
-            with self._standard_errors(chunk_name):
-                npy_shape, _, npy_dtype = load_npy_header(filename)
-        except ChunkNotFound:
-            return False
-        else:
-            return npy_dtype == dtype and npy_shape == shape
+        return os.path.exists(filename)
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -121,7 +121,7 @@ class RadosChunkStore(ChunkStore):
 
     def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put_chunk`."""
-        key, shape = self.chunk_metadata(array_name, slices, chunk=chunk)
+        key, _ = self.chunk_metadata(array_name, slices, chunk=chunk)
         data_str = chunk.tobytes()
         with self._standard_errors(key):
             self.ioctx.write_full(key, data_str)
@@ -129,15 +129,14 @@ class RadosChunkStore(ChunkStore):
     def has_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.has_chunk`."""
         dtype = np.dtype(dtype)
-        key, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
-        expected_bytes = int(np.prod(shape)) * dtype.itemsize
+        key, _ = self.chunk_metadata(array_name, slices, dtype=dtype)
         try:
             with self._standard_errors(key):
-                actual_bytes, _ = self.ioctx.stat(key)
+                self.ioctx.stat(key)
         except ChunkNotFound:
             return False
         else:
-            return actual_bytes == expected_bytes
+            return True
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__


### PR DESCRIPTION
Make `has_chunk` as lightweight as possible. It now only checks the
presence or absence of a chunk based on its name (i.e. it checks
whether an NPY file or S3 object exists). The chunk dtype and shape
will still be checked by `get_chunk` and result in a `BadChunk`
exception if wrong. There is no need to anticipate this in `has_chunk`.

This fixes NumPy 1.14 support, which modified the size of the NPY file
header by changing its padding (see numpy/numpy#8598). This made it
harder to predict the expected S3 object size (which was still being
produced by an older NumPy), so get rid of the check.