### PR TITLE
Optimise has_dask_array

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -287,6 +287,13 @@ class ChunkStore(object):
         return name.split(cls.NAME_SEP, maxsplit)
 
     @classmethod
+    def chunk_id_str(cls, slices):
+        """Chunk identifier in string form (e.g. '00012_01024_00000')."""
+        index = [s.start for s in slices]
+        return '_'.join(["{:0{width}d}".format(i, width=cls.NAME_INDEX_WIDTH)
+                         for i in index])
+
+    @classmethod
     def chunk_metadata(cls, array_name, slices, chunk=None, dtype=None):
         """Turn array name and chunk identifier into chunk name and shape.
 
@@ -330,10 +337,7 @@ class ChunkStore(object):
             raise BadChunk('Array {!r}: chunk ID {} contains non-unit strides'
                            .format(array_name, slices))
         # Construct chunk name from array_name + slices
-        index = [s.start for s in slices]
-        idxstr = '_'.join(["{:0{width}d}".format(i, width=cls.NAME_INDEX_WIDTH)
-                           for i in index])
-        chunk_name = cls.join(array_name, idxstr)
+        chunk_name = cls.join(array_name, cls.chunk_id_str(slices))
         if chunk is not None and chunk.shape != shape:
             raise BadChunk('Chunk {!r}: shape {} implied by slices does not '
                            'match actual shape {}'
@@ -437,6 +441,54 @@ class ChunkStore(object):
         out_chunks = tuple(len(c) * (1,) for c in array.chunks)
         return da.Array(dask_graph, out_name, out_chunks, np.object)
 
+    def list_chunk_ids(self, array_name):
+        """List all chunk ID strings associated with given array in chunk store.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of array in chunk store
+
+        Returns
+        -------
+        chunk_ids : list of string
+            List of chunk identifier strings (e.g. '00012_01024_00000')
+        """
+        raise NotImplementedError
+
+    def _has_array_via_list_chunk_ids(self, array_name, chunks, offset):
+        """See :meth:`ChunkStore.has_dask_array` (list_chunk_ids version)."""
+        # Obtain ID strings of all chunks in store associated with array_name
+        # This might not be implemented by underlying store
+        store_ids = set(self.list_chunk_ids(array_name))
+        # Turn chunks + offset into list of expected chunk ID strings
+        slices = da.core.slices_from_chunks(chunks)
+        if offset:
+            offset_slices = tuple(slice(start, None) for start in offset)
+            slices = [da.core.fuse_slice(offset_slices, s) for s in slices]
+        chunk_ids = [self.chunk_id_str(s) for s in slices]
+        # Look up expected IDs in set of actual IDs in store
+        has_array = np.array([cid in store_ids for cid in chunk_ids])
+        # Turn 1-D array of checks into dask array of required shape
+        has_array = has_array.reshape(tuple(len(c) for c in chunks))
+        # Make out_name unique to avoid clashes and caches
+        out_name = 'check-{}-{}-{}'.format(array_name, offset, uuid.uuid4().hex)
+        return da.from_array(has_array, chunks=1, name=out_name)
+
+    def _has_array_via_has_chunk(self, array_name, chunks, dtype, offset):
+        """See :meth:`ChunkStore.has_dask_array` (has_chunk version)."""
+        # Embellish has_chunk to set dtype and add offset
+        has = _scalar_to_chunk(functools.partial(self.has_chunk, dtype=dtype))
+        if offset:
+            has = _add_offset_to_slices(has, offset)
+        # Make out_name unique to avoid clashes and caches
+        out_name = 'check-{}-{}-{}'.format(array_name, offset, uuid.uuid4().hex)
+        # Use dask utility function that forms the core of da.from_array
+        dask_graph = da.core.getem(array_name, chunks, has, out_name=out_name)
+        # The success array has one element per chunk in the input array
+        out_chunks = tuple(len(c) * (1,) for c in chunks)
+        return da.Array(dask_graph, out_name, out_chunks, np.bool_)
+
     def has_dask_array(self, array_name, chunks, dtype, offset=()):
         """Check if dask array is in the store.
 
@@ -455,14 +507,15 @@ class ChunkStore(object):
         -------
         success : :class:`dask.array.Array` object
             Dask array of bools indicating presence of each chunk
+
+        Notes
+        -----
+        If the underlying store implements :meth:`list_chunk_ids`, that is
+        preferred; otherwise :meth:`has_chunk` is called for each chunk.
         """
-        has = _scalar_to_chunk(functools.partial(self.has_chunk, dtype=dtype))
-        if offset:
-            has = _add_offset_to_slices(has, offset)
-        # Make out_name unique to avoid clashes and caches
-        out_name = 'check-{}-{}-{}'.format(array_name, offset, uuid.uuid4().hex)
-        # Use dask utility function that forms the core of da.from_array
-        dask_graph = da.core.getem(array_name, chunks, has, out_name=out_name)
-        # The success array has one element per chunk in the input array
-        out_chunks = tuple(len(c) * (1,) for c in chunks)
-        return da.Array(dask_graph, out_name, out_chunks, np.bool_)
+        try:
+            return self._has_array_via_list_chunk_ids(array_name, chunks,
+                                                      offset)
+        except NotImplementedError:
+            return self._has_array_via_has_chunk(array_name, chunks,
+                                                 dtype, offset)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -289,9 +289,8 @@ class ChunkStore(object):
     @classmethod
     def chunk_id_str(cls, slices):
         """Chunk identifier in string form (e.g. '00012_01024_00000')."""
-        index = [s.start for s in slices]
-        return '_'.join(["{:0{width}d}".format(i, width=cls.NAME_INDEX_WIDTH)
-                         for i in index])
+        return '_'.join("{:0{w}d}".format(s.start, w=cls.NAME_INDEX_WIDTH)
+                        for s in slices)
 
     @classmethod
     def chunk_metadata(cls, array_name, slices, chunk=None, dtype=None):
@@ -453,6 +452,11 @@ class ChunkStore(object):
         -------
         chunk_ids : list of string
             List of chunk identifier strings (e.g. '00012_01024_00000')
+
+        Raises
+        ------
+        NotImplementedError
+            If the underlying store does not have an efficient implementation
         """
         raise NotImplementedError
 

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -97,7 +97,7 @@ class NpyFileChunkStore(ChunkStore):
         """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""
         array_dir = os.path.join(self.path, array_name)
         # Strip the .npy extension to get the chunk ID string
-        return [fn[:-4] for fn in os.listdir(array_dir)]
+        return [fn[:-4] for fn in os.listdir(array_dir) if fn.endswith('.npy')]
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -93,6 +93,12 @@ class NpyFileChunkStore(ChunkStore):
         filename = os.path.join(self.path, chunk_name) + '.npy'
         return os.path.exists(filename)
 
+    def list_chunk_ids(self, array_name):
+        """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""
+        array_dir = os.path.join(self.path, array_name)
+        return [fn[:-4] for fn in os.listdir(array_dir)]
+
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__
     has_chunk.__doc__ = ChunkStore.has_chunk.__doc__
+    list_chunk_ids.__doc__ = ChunkStore.list_chunk_ids.__doc__

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -96,6 +96,7 @@ class NpyFileChunkStore(ChunkStore):
     def list_chunk_ids(self, array_name):
         """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""
         array_dir = os.path.join(self.path, array_name)
+        # Strip the .npy extension to get the chunk ID string
         return [fn[:-4] for fn in os.listdir(array_dir)]
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -179,6 +179,7 @@ class S3ChunkStore(ChunkStore):
         page_iter = paginator.paginate(Bucket=bucket, Prefix=prefix,
                                        PaginationConfig={'PageSize': 10000})
         keys = [item['Key'] for page in page_iter for item in page['Contents']]
+        # Strip the array name and .npy extension to get the chunk ID string
         return [key[len(prefix) + 1:-4] for key in keys]
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -180,7 +180,7 @@ class S3ChunkStore(ChunkStore):
                                        PaginationConfig={'PageSize': 10000})
         keys = [item['Key'] for page in page_iter for item in page['Contents']]
         # Strip the array name and .npy extension to get the chunk ID string
-        return [key[len(prefix) + 1:-4] for key in keys]
+        return [key[len(prefix) + 1:-4] for key in keys if key.endswith('.npy')]
 
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -175,7 +175,7 @@ class S3ChunkStore(ChunkStore):
     def list_chunk_ids(self, array_name):
         """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""
         bucket, prefix = self.split(array_name, 1)
-        paginator = self.client.get_paginator('list_objects_v2')
+        paginator = self.client.get_paginator('list_objects')
         page_iter = paginator.paginate(Bucket=bucket, Prefix=prefix,
                                        PaginationConfig={'PageSize': 10000})
         keys = [item['Key'] for page in page_iter for item in page['Contents']]

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -172,6 +172,16 @@ class S3ChunkStore(ChunkStore):
             else:
                 return True
 
+    def list_chunk_ids(self, array_name):
+        """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""
+        bucket, prefix = self.split(array_name, 1)
+        paginator = self.client.get_paginator('list_objects_v2')
+        page_iter = paginator.paginate(Bucket=bucket, Prefix=prefix,
+                                       PaginationConfig={'PageSize': 10000})
+        keys = [item['Key'] for page in page_iter for item in page['Contents']]
+        return [key[len(prefix) + 1:-4] for key in keys]
+
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__
     has_chunk.__doc__ = ChunkStore.has_chunk.__doc__
+    list_chunk_ids.__doc__ = ChunkStore.list_chunk_ids.__doc__

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -178,15 +178,13 @@ class ChunkStoreTestBase(object):
         results = pull.compute()
         divisions_per_dim = [len(c) for c in dask_array.chunks]
         assert_array_equal(results, np.full(divisions_per_dim, True))
+        # Also check has_array if available
         try:
-            pull = self.store._has_array_via_list_chunk_ids(array_name,
-                                                            dask_array.chunks,
-                                                            offset)
+            arr = self.store.has_array(array_name, dask_array.chunks, offset)
         except NotImplementedError:
             pass
         else:
-            results = pull.compute()
-            assert_array_equal(results, np.full(divisions_per_dim, True))
+            assert_array_equal(arr, np.full(divisions_per_dim, True))
 
     def test_chunk_non_existent(self):
         slices = (slice(0, 1),)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -250,7 +250,7 @@ class ChunkStoreTestBase(object):
         self.put_dask_array('big_y2', np.s_[3:8, 30:60, 0:2])
         self.get_dask_array('big_y2')
 
-    def test_list_of_chunk_ids(self):
+    def test_list_chunk_ids(self):
         array_name, dask_array, offset = self.make_dask_array('big_y2')
         try:
             chunk_ids = self.store.list_chunk_ids(array_name)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -77,10 +77,11 @@ class TestGenerateChunks(object):
 class TestChunkStore(object):
     """This tests the base class functionality."""
 
-    def test_put_and_get_chunk(self):
+    def test_put_get_list_chunks(self):
         store = ChunkStore()
         assert_raises(NotImplementedError, store.get_chunk, 1, 2, 3)
         assert_raises(NotImplementedError, store.put_chunk, 1, 2, 3)
+        assert_raises(NotImplementedError, store.list_chunk_ids, 1)
 
     def test_metadata_validation(self):
         store = ChunkStore()
@@ -177,6 +178,15 @@ class ChunkStoreTestBase(object):
         results = pull.compute()
         divisions_per_dim = [len(c) for c in dask_array.chunks]
         assert_array_equal(results, np.full(divisions_per_dim, True))
+        try:
+            pull = self.store._has_array_via_list_chunk_ids(array_name,
+                                                            dask_array.chunks,
+                                                            offset)
+        except NotImplementedError:
+            pass
+        else:
+            results = pull.compute()
+            assert_array_equal(results, np.full(divisions_per_dim, True))
 
     def test_chunk_non_existent(self):
         slices = (slice(0, 1),)
@@ -241,3 +251,14 @@ class ChunkStoreTestBase(object):
         # Now store the last quarter and check that complete array is correct
         self.put_dask_array('big_y2', np.s_[3:8, 30:60, 0:2])
         self.get_dask_array('big_y2')
+
+    def test_list_of_chunk_ids(self):
+        array_name, dask_array, offset = self.make_dask_array('big_y2')
+        try:
+            chunk_ids = self.store.list_chunk_ids(array_name)
+        except NotImplementedError:
+            pass
+        else:
+            slices = da.core.slices_from_chunks(dask_array.chunks)
+            ref_chunk_ids = [self.store.chunk_id_str(s) for s in slices]
+            assert_equal(set(chunk_ids), set(ref_chunk_ids))


### PR DESCRIPTION
Since the flags now call `has_dask_array` on the rest of the arrays
in the dataset, it is time to optimise it. This feature can also be
used to check which chunks are present upon opening a dataset.

Some chunk store implementations allow an efficient enumeration of
all chunks associated with an array. We are only interested in the
presence or absence of a chunk and nothing more. For example, the
`NpyFileChunkStore` can `os.listdir` the array subdirectory to get
a list of all the relevant NPY files, while the `S3ChunkStore` can
send a `list_objects_v2` request with the appropriate bucket and prefix
to get a list of associated keys (via pagination).

If this efficient `list_chunk_ids` method is available, use it within
`has_dask_array`, otherwise fall back to a series of `has_chunk` calls.
Introduce the `chunk_id_str` method to simplify generation of chunk
identifier strings.

On a 2-hour dataset (1523731706) of size 250 GB served via S3 the vis
`has_dask_array` call duration drops from 90 seconds to about 13 seconds
(or 6 seconds if `has_array` is used).
