### PR TITLE
Enforce timeout when constructing S3 chunk store

### DIFF
--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -23,9 +23,11 @@ import re
 import threading
 import Queue
 import os
+import time
 
 from nose import SkipTest
 from nose.tools import assert_raises, timed
+import mock
 
 from katdal.chunkstore_s3 import S3ChunkStore, botocore
 from katdal.chunkstore import StoreUnavailable
@@ -45,6 +47,12 @@ def consume_stderr_find_port(process, queue):
                 port_number = ports_found.group(1)
                 queue.put(port_number)
                 looking_for_port = False
+
+
+def gethostbyname_slow(host):
+    """Mock DNS lookup that is meant to be slow."""
+    time.sleep(30)
+    return '127.0.0.1'
 
 
 class TestS3ChunkStore(ChunkStoreTestBase):
@@ -120,14 +128,17 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         bucket = 'katdal-unittest'
         return self.store.join(bucket, path)
 
-    @timed(0.1 + 0.1 + 1 + 0.05)
-    def test_store_unavailable(self):
+    @timed(0.1 + 0.05)
+    def test_store_unavailable_invalid_url(self):
         # Drastically reduce the default botocore timeout of nearly 7 seconds
         assert_raises(StoreUnavailable, S3ChunkStore.from_url,
                       'http://apparently.invalid/',
                       timeout=0.1, extra_timeout=0)
-        # Some pathological DNS setups (sshuttle?) ignore the original timeout,
-        # preferring to wait 25-30 seconds instead... Check that it is fixed.
+
+    @timed(0.1 + 1 + 0.05)
+    @mock.patch('socket.gethostbyname', side_effect=gethostbyname_slow)
+    def test_store_unavailable_slow_dns(self, mock_dns_lookup):
+        # Some pathological DNS setups (sshuttle?) take forever to time out
         assert_raises(StoreUnavailable, S3ChunkStore.from_url,
                       'http://a-valid-domain-is-somehow-harder.kat.ac.za/',
                       timeout=0.1, extra_timeout=1)

--- a/setup.py
+++ b/setup.py
@@ -65,4 +65,4 @@ setup(name='katdal',
           # katsdpauth is currently only available via GitHub
           'auth': ['katsdpauth'],
       },
-      tests_require=['nose'])
+      tests_require=['mock', 'nose'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 coverage
+mock
 nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
 coverage
+funcsigs
 mock
 nose
+pbr


### PR DESCRIPTION
On initialisation of S3ChunkStore a connection is made to the S3
endpoint URL to check that it is up. While useful, this can lead to
interminable delays while doing DNS lookups for `archive-gw-1.kat.ac.za`
(at least from my admittedly pathological home setup via sshuttle).

The worst part is that DNS lookup via `socket.gethostbyname()` ignores
the usual timeout mechanisms. Therefore introduce a hard cutoff by
running the blocking initialisation code in a separate thread. The
constructed store (or an exception) is returned via a queue. This
smacks of `concurrent.futures` but avoids adding yet another dependency
on Python 2 just for this (revisit when Python 3 only...).

Test that the initialisation happens within the expected time period.