### PR TITLE
Robustify and add metadata fallback

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -222,12 +222,14 @@ a back door installed at `d.file` in the case of a single-file data set.
 import logging as _logging
 import urlparse
 
+from .datasources import open_data_source
 from .dataset import DataSet, WrongVersion
 from .lazy_indexer import LazyTransform
 from .concatdata import ConcatenatedDataSet
 from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2
 from .h5datav3 import H5DataV3
+from .visdatav4 import VisibilityDataV4
 from .sensordata import _sensor_completer
 
 
@@ -340,9 +342,7 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
     for f in filenames:
         # V4 RDB file with optional URL-style query string
         if urlparse.urlsplit(f).path.endswith('.rdb'):
-            from .datasources import open_data_source
-            from .visdatav4 import VisibilityDataV4
-            dataset = VisibilityDataV4(open_data_source(f),
+            dataset = VisibilityDataV4(open_data_source(f, **kwargs),
                                        ref_ant, time_offset, **kwargs)
         else:
             dataset = _file_action('__call__', f, ref_ant, time_offset, **kwargs)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -93,7 +93,7 @@ class S3ChunkStore(ChunkStore):
         if timeout is not None:
             config_kwargs['read_timeout'] = int(timeout)
             config_kwargs['connect_timeout'] = int(timeout)
-            config_kwargs['retries'] = {'max_attempts': 0}
+            config_kwargs['retries'] = {'max_attempts': 2}
         # Split keyword arguments into config settings and create_client args
         for k, v in kwargs.items():
             if k in botocore.config.Config.OPTION_DEFAULTS:

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -76,7 +76,7 @@ class S3ChunkStore(ChunkStore):
             raise _botocore_import_error
         error_map = {EndpointConnectionError: StoreUnavailable,
                      ConnectionError: StoreUnavailable,
-                     requests.exceptions.RequestsException: StoreUnavailable,
+                     requests.exceptions.RequestException: StoreUnavailable,
                      client.exceptions.NoSuchKey: ChunkNotFound,
                      client.exceptions.NoSuchBucket: ChunkNotFound}
         super(S3ChunkStore, self).__init__(error_map)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -76,7 +76,7 @@ class S3ChunkStore(ChunkStore):
             raise _botocore_import_error
         error_map = {EndpointConnectionError: StoreUnavailable,
                      ConnectionError: StoreUnavailable,
-                     requests.exceptions.ReadTimeout: StoreUnavailable,
+                     requests.exceptions.RequestsException: StoreUnavailable,
                      client.exceptions.NoSuchKey: ChunkNotFound,
                      client.exceptions.NoSuchBucket: ChunkNotFound}
         super(S3ChunkStore, self).__init__(error_map)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -36,6 +36,7 @@ except ImportError as e:
 else:
     import botocore.config
     import botocore.session
+    import botocore.vendored.requests as requests
     from botocore.exceptions import (ConnectionError, EndpointConnectionError,
                                      NoCredentialsError, ClientError)
 
@@ -75,6 +76,7 @@ class S3ChunkStore(ChunkStore):
             raise _botocore_import_error
         error_map = {EndpointConnectionError: StoreUnavailable,
                      ConnectionError: StoreUnavailable,
+                     requests.exceptions.ReadTimeout: StoreUnavailable,
                      client.exceptions.NoSuchKey: ChunkNotFound,
                      client.exceptions.NoSuchBucket: ChunkNotFound}
         super(S3ChunkStore, self).__init__(error_map)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -280,7 +280,7 @@ def _infer_chunk_store(url_parts, telstate, npy_store_path=None,
         If the chunk store could not be constructed
     """
     # Use overrides if provided, regardless of URL and telstate (NPY first)
-    if npy_store_path and os.path.isdir(npy_store_path):
+    if npy_store_path:
         return NpyFileChunkStore(npy_store_path)
     if s3_endpoint_url:
         return S3ChunkStore.from_url(s3_endpoint_url, **kwargs)
@@ -289,8 +289,6 @@ def _infer_chunk_store(url_parts, telstate, npy_store_path=None,
         # Look for adjacent data directory (presumably containing NPY files)
         rdb_path = os.path.abspath(url_parts.path)
         store_path = os.path.dirname(os.path.dirname(rdb_path))
-        if not store_path:
-            store_path = os.path.curdir
         data_path = os.path.join(store_path, telstate['chunk_name'])
         if os.path.isdir(data_path):
             return NpyFileChunkStore(store_path)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -396,6 +396,9 @@ class VisibilityDataV4(DataSet):
         electric field of :math:`e^{i(\omega t - jz)}` i.e. phase that
         increases with time.
         """
+        if self._vis is None:
+            raise ValueError('Visibilities are not available since dataset '
+                             'was opened with metadata only')
         return self._vis
 
     @property
@@ -413,6 +416,9 @@ class VisibilityDataV4(DataSet):
         indexing on it. Only then will data be loaded into memory.
 
         """
+        if self._weights is None:
+            raise ValueError('Weights are not available since dataset '
+                             'was opened with metadata only')
         return self._weights
 
     @property
@@ -430,6 +436,9 @@ class VisibilityDataV4(DataSet):
         indexing on it. Only then will data be loaded into memory.
 
         """
+        if self._flags is None:
+            raise ValueError('Flags are not available since dataset '
+                             'was opened with metadata only')
         return self._flags
 
     @property

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -347,7 +347,9 @@ class VisibilityDataV4(DataSet):
         DataSet._set_keep(self, time_keep, freq_keep, corrprod_keep, weights_keep, flags_keep)
         update_all = time_keep is not None or freq_keep is not None or corrprod_keep is not None
         update_flags = update_all or flags_keep is not None
-        if update_flags:
+        if not self.source.data:
+            self._vis = self._weights = self._flags = None
+        elif update_flags:
             # Create first-stage index from dataset selectors. Note: use
             # the member variables, not the parameters, because the parameters
             # can be None to indicate no change

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -220,8 +220,9 @@ def main():
         # Order as similarly to the input as possible, which gives better performance
         # in permute_baselines.
         bl_indices = zip(ant1_index, ant2_index)
-        bl_indices.sort(key=lambda a1, a2: _cp_index(dataset.ants[a1], dataset.ants[a2],
-                                                     pols_to_use[0]))
+        bl_indices.sort(key=lambda (a1, a2): _cp_index(dataset.ants[a1],
+                                                       dataset.ants[a2],
+                                                       pols_to_use[0]))
         # Undo the zip
         ant1_index[:] = [bl[0] for bl in bl_indices]
         ant2_index[:] = [bl[1] for bl in bl_indices]


### PR DESCRIPTION
This is a small platter of fixes to make katdal more robust:

- Fix a fatal bug in mvftoms (see [COMM-318](https://skaafrica.atlassian.net/browse/COMM-318))
- Map a requests ReadTimeout to StoreUnavailable
- Retry S3 connections twice, to cater for network glitches
- Open the RDB metadata even if the chunk store is missing or inaccessible
- Warn when timestamps and/or data is missing (but continue opening what you have)
- Allow simple overrides of key parameters via kwargs to `katdal.open` as well as query strings in the original URL
