### PR TITLE
Fix multiple boolean indexing in dask indexer

### DIFF
--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -434,6 +434,7 @@ class DaskLazyIndexer(object):
                     dataset = self._orig_dataset[self.keep]
                 except NotImplementedError:
                     # Dask does not like multiple boolean indices: go one dim at a time
+                    dataset = self._orig_dataset
                     for dim, keep_per_dim in enumerate(self.keep):
                         dataset = da.take(dataset, keep_per_dim, axis=dim)
                 for transform in self.transforms:


### PR DESCRIPTION
This never worked due to a missing initialisation and was only tested now by @lmagnus...