### PR TITLE
Fix sensor props for v4 observation labels

### DIFF
--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -46,6 +46,7 @@ SENSOR_PROPS.update({
                      'initial_value': 0.0, 'transform': lambda x: x > 0.0},
     '*serial_number': {'initial_value': 0},
     '*target': {'initial_value': '', 'transform': _robust_target},
+    'obs_label': {'initial_value': '', 'allow_repeats': True},
 })
 
 SENSOR_ALIASES = {


### PR DESCRIPTION
The compscan labels have always been exposed via the 'Observation/label'
sensor, which crucially allows repeats. In v4 land this sensor is
initialised from the 'obs_label' telstate sensor, but that sensor is
extracted without the same sensor props. Add the relevant props.

I've toyed with the idea of getting obs_label props directly from the
existing Observation/label props, but I think there is no more need for
the `transform=str` bit, for one, so rather be explicit.