### PR TITLE
Remove botocore, using requests directly

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -27,6 +27,8 @@ import Queue
 import sys
 import urlparse
 import urllib
+import hashlib
+import base64
 import warnings
 import xml.etree.cElementTree
 
@@ -203,9 +205,13 @@ class S3ChunkStore(ChunkStore):
         url = self._chunk_url(chunk_name)
         fp = io.BytesIO()
         np.lib.format.write_array(fp, chunk, allow_pickle=False)
+        md5 = base64.b64encode(hashlib.md5(fp.getvalue()).digest())
         fp.seek(0)
         with self._standard_errors(chunk_name):
-            response = self._session.put(url, data=fp)
+            response = self._session.put(
+                url,
+                headers={'Content-MD5': md5},
+                data=fp)
 
     def has_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.has_chunk`."""

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -254,7 +254,7 @@ class S3ChunkStore(ChunkStore):
         url = self._chunk_url(chunk_name)
         try:
             with self._standard_errors(chunk_name), self._session_pool() as session:
-                with session.head(url) as response:
+                with contextlib.closing(session.head(url)) as response:
                     _raise_for_status(response)
         except ChunkNotFound:
             return False

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -31,8 +31,9 @@ import hashlib
 import base64
 import warnings
 import contextlib
-import xml.etree.cElementTree
 
+import defusedxml.ElementTree
+import defusedxml.cElementTree
 import numpy as np
 try:
     import requests
@@ -138,7 +139,7 @@ class S3ChunkStore(ChunkStore):
             raise StoreUnavailable(str(error))
 
         error_map = {requests.exceptions.RequestException: StoreUnavailable,
-                     xml.etree.cElementTree.ParseError: StoreUnavailable}
+                     defusedxml.ElementTree.ParseError: StoreUnavailable}
         super(S3ChunkStore, self).__init__(error_map)
         self._session_pool = _Pool(session_factory)
         self._url = url
@@ -276,7 +277,7 @@ class S3ChunkStore(ChunkStore):
             with self._standard_errors(), self._session_pool() as session:
                 with session.get(url, params=params) as response:
                     _raise_for_status(response)
-                    root = xml.etree.cElementTree.fromstring(response.content)
+                    root = defusedxml.cElementTree.fromstring(response.content)
                 keys.extend(child.text for child in root.iter(NS + 'Key'))
                 truncated = root.find(NS + 'IsTruncated')
                 more = (truncated is not None and truncated.text == 'true')

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -227,7 +227,7 @@ class S3ChunkStore(ChunkStore):
         else:
             return True
 
-    list_max_keys = 10000
+    list_max_keys = 100000
 
     def list_chunk_ids(self, array_name):
         """See the docstring of :meth:`ChunkStore.list_chunk_ids`."""

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -29,7 +29,7 @@ from nose import SkipTest
 from nose.tools import assert_raises, timed
 import mock
 
-from katdal.chunkstore_s3 import S3ChunkStore, botocore
+from katdal.chunkstore_s3 import S3ChunkStore
 from katdal.chunkstore import StoreUnavailable
 from katdal.test.test_chunkstore import ChunkStoreTestBase
 
@@ -100,16 +100,9 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             try:
                 cls.store = S3ChunkStore.from_url(url, timeout=1)
             except ImportError:
-                raise SkipTest('S3 botocore dependency not installed')
-            except StoreUnavailable:
-                # Simplified client setup with dummy authentication keys,
-                # useful for Jenkins that doesn't have any S3 credentials
-                session = botocore.session.get_session()
-                client = session.create_client(service_name='s3',
-                                               endpoint_url=url,
-                                               aws_access_key_id='blah',
-                                               aws_secret_access_key='blah')
-                cls.store = S3ChunkStore(client)
+                raise SkipTest('S3 requests dependency not installed')
+            # Ensure that pagination is tested
+            cls.store.list_max_keys = 2
         except Exception:
             cls.teardown_class()
             raise
@@ -130,7 +123,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
 
     @timed(0.1 + 0.05)
     def test_store_unavailable_invalid_url(self):
-        # Drastically reduce the default botocore timeout of nearly 7 seconds
+        # Ensure that timeouts work
         assert_raises(StoreUnavailable, S3ChunkStore.from_url,
                       'http://apparently.invalid/',
                       timeout=0.1, extra_timeout=0)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -102,7 +102,9 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             except ImportError:
                 raise SkipTest('S3 requests dependency not installed')
             # Ensure that pagination is tested
-            cls.store.list_max_keys = 2
+            # Disabled for now because FakeS3 doesn't implement it correctly
+            # (see for example https://github.com/jubos/fake-s3/pull/163).
+            # cls.store.list_max_keys = 3
         except Exception:
             cls.teardown_class()
             raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-botocore==1.10.16
 dask
 docutils
 fakeredis
@@ -14,6 +13,7 @@ python-dateutil
 python-lzf
 rdbtools
 redis
+requests
 six
 toolz
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask
+defusedxml==0.5.0
 docutils
 fakeredis
 future

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='katdal',
                         'katsdptelstate[rdb]', 'dask[array]'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1', 'numba'],
-          's3': ['botocore'],
+          's3': ['requests'],
           # rados is not in PyPI but available as Debian package python-rados
           'rados': ['rados'],
           # katsdpauth is currently only available via GitHub

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='katdal',
                         'katsdptelstate[rdb]', 'dask[array]'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1', 'numba'],
-          's3': ['requests'],
+          's3': ['requests', 'defusedxml'],
           # rados is not in PyPI but available as Debian package python-rados
           'rados': ['rados'],
           # katsdpauth is currently only available via GitHub


### PR DESCRIPTION
botocore is incredibly slow at parsing the list_buckets output. It also needlessly insists on an access key, and will be difficult to patch to deal with OAuth. Ripped it out and replaced with direct calls to the requests library.

Should not be merged yet, as it lacks the integrations with katsdpauth to authenticate.

The put_chunks will also not work, unless the server allows anonymous uploads, since it does not do S3 authentication. Fortunately we're not using S3 put_chunks for anything.