### PR TITLE
Speed up flagging of lost data

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -116,7 +116,8 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             chunk_args = (array_name, info['chunks'], info['dtype'])
             darray[array] = store.get_dask_array(*chunk_args)
             # Find all missing chunks in array and convert to 'data_lost' flags
-            has_arrays.append((store.has_array(array_name, info['chunks']), info['chunks']))
+            has_arrays.append((store.has_array(array_name, info['chunks'], info['dtype']),
+                               info['chunks']))
         vis = darray['correlator_data']
         base_name = chunk_info['correlator_data']['prefix']
         flags_raw_name = store.join(chunk_info['flags']['prefix'], 'flags_raw')

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -170,21 +170,12 @@ class ChunkStoreTestBase(object):
                            "Error retrieving {} / {} / {}"
                            .format(array_name, offset, dask_array.chunks))
 
-    def has_dask_array(self, var_name, slices=()):
+    def has_array(self, var_name, slices=()):
         """Get (part of) an array from store via dask and compare."""
         array_name, dask_array, offset = self.make_dask_array(var_name, slices)
-        pull = self.store.has_dask_array(array_name, dask_array.chunks,
-                                         dask_array.dtype, offset)
-        results = pull.compute()
+        results = self.store.has_array(array_name, dask_array.chunks, dask_array.dtype, offset)
         divisions_per_dim = [len(c) for c in dask_array.chunks]
         assert_array_equal(results, np.full(divisions_per_dim, True))
-        # Also check has_array if available
-        try:
-            arr = self.store.has_array(array_name, dask_array.chunks, offset)
-        except NotImplementedError:
-            pass
-        else:
-            assert_array_equal(arr, np.full(divisions_per_dim, True))
 
     def test_chunk_non_existent(self):
         slices = (slice(0, 1),)
@@ -226,9 +217,9 @@ class ChunkStoreTestBase(object):
     def test_dask_array_basic(self):
         self.put_dask_array('big_y')
         self.get_dask_array('big_y')
-        self.has_dask_array('big_y')
+        self.has_array('big_y')
         self.get_dask_array('big_y', np.s_[0:3, 0:30, 0:2])
-        self.has_dask_array('big_y', np.s_[0:3, 0:30, 0:2])
+        self.has_array('big_y', np.s_[0:3, 0:30, 0:2])
 
     def test_dask_array_put_parts_get_whole(self):
         # Split big array into quarters along existing chunks and reassemble

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -20,6 +20,7 @@ import tempfile
 import shutil
 import os
 import random
+import itertools
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -37,25 +38,28 @@ def ramp(shape, offset=1.0, slope=1.0, dtype=np.float_):
     return x.astype(dtype).reshape(shape)
 
 
-def to_dask_array(x):
+def to_dask_array(x, chunks=None):
     """Turn ndarray `x` into dask array with the standard vis-like chunking."""
-    itemsize = np.dtype('complex64').itemsize
-    # Special case for 2-D weights_channel array ensures one chunk per dump
-    n_corrprods = x.shape[2] if x.ndim >= 3 else x.shape[1] // itemsize
-    # This contrives to have a vis array with 1 dump and 4 channels per chunk
-    chunk_size = 4 * n_corrprods * itemsize
-    chunks = generate_chunks(x.shape, x.dtype, chunk_size,
-                             dims_to_split=(0, 1), power_of_two=True)
+    if chunks is None:
+        itemsize = np.dtype('complex64').itemsize
+        # Special case for 2-D weights_channel array ensures one chunk per dump
+        n_corrprods = x.shape[2] if x.ndim >= 3 else x.shape[1] // itemsize
+        # This contrives to have a vis array with 1 dump and 4 channels per chunk
+        chunk_size = 4 * n_corrprods * itemsize
+        chunks = generate_chunks(x.shape, x.dtype, chunk_size,
+                                 dims_to_split=(0, 1), power_of_two=True)
     return da.from_array(x, chunks)
 
 
-def put_fake_dataset(store, prefix, shape):
+def put_fake_dataset(store, prefix, shape, chunk_overrides=None):
     """Write a fake dataset into the chunk store."""
     data = {'correlator_data': ramp(shape, dtype=np.float32) * (1 - 1j),
             'flags': np.ones(shape, dtype=np.uint8),
             'weights': ramp(shape, slope=255. / np.prod(shape), dtype=np.uint8),
             'weights_channel': ramp(shape[:-1], dtype=np.float32)}
-    ddata = {k: to_dask_array(array) for k, array in data.items()}
+    if chunk_overrides is None:
+        chunk_overrides = {}
+    ddata = {k: to_dask_array(array, chunk_overrides.get(k)) for k, array in data.items()}
     chunk_info = {k: {'prefix': prefix, 'chunks': darray.chunks,
                       'dtype': darray.dtype, 'shape': darray.shape}
                   for k, darray in ddata.items()}
@@ -90,36 +94,49 @@ class TestChunkStoreVisFlagsWeights(object):
         assert_array_equal(vfw.flags.compute(), data['flags'])
         assert_array_equal(vfw.weights.compute(), weights)
 
-    def test_missing_chunks(self):
+    def _test_missing_chunks(self, shape, chunk_overrides=None):
         # Put fake dataset into chunk store
         store = NpyFileChunkStore(self.tempdir)
         prefix = 'cb2'
-        shape = (10, 64, 30)
-        data, chunk_info = put_fake_dataset(store, prefix, shape)
-        # Delete a random chunk in each array of the dataset
+        data, chunk_info = put_fake_dataset(store, prefix, shape, chunk_overrides)
+        # Delete some random chunks in each array of the dataset
         missing_chunks = {}
         rs = random.Random(4)
         for array, info in chunk_info.items():
             array_name = store.join(prefix, array)
             slices = da.core.slices_from_chunks(info['chunks'])
-            culled_slice = rs.choice(slices)
-            missing_chunks[array] = culled_slice
-            chunk_name, shape = store.chunk_metadata(array_name, culled_slice)
-            os.remove(os.path.join(store.path, chunk_name) + '.npy')
+            culled_slices = rs.sample(slices, len(slices) // 10 + 1)
+            missing_chunks[array] = culled_slices
+            for culled_slice in culled_slices:
+                chunk_name, shape = store.chunk_metadata(array_name, culled_slice)
+                os.remove(os.path.join(store.path, chunk_name) + '.npy')
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info)
         # Check that (only) missing chunks have been replaced by zeros
         vis = data['correlator_data']
-        vis[missing_chunks['correlator_data']] = 0.
+        for culled_slice in missing_chunks['correlator_data']:
+            vis[culled_slice] = 0.
         assert_array_equal(vfw.vis, vis)
         weights = data['weights'] * data['weights_channel'][..., np.newaxis]
-        weights[missing_chunks['weights']] = 0.
-        weights[missing_chunks['weights_channel']] = 0.
+        for culled_slice in missing_chunks['weights'] + missing_chunks['weights_channel']:
+            weights[culled_slice] = 0.
         assert_array_equal(vfw.weights, weights)
         # Check that (only) missing chunks have been flagged as 'data lost'
         flags = data['flags']
-        flags[missing_chunks['flags']] = 0.
-        flags[missing_chunks['correlator_data']] |= 8
-        flags[missing_chunks['weights']] |= 8
-        flags[missing_chunks['weights_channel']] |= 8
-        flags[missing_chunks['flags']] |= 8
+        for culled_slice in missing_chunks['flags']:
+            flags[culled_slice] = 0
+        for culled_slice in itertools.chain(*missing_chunks.values()):
+            flags[culled_slice] |= 8
         assert_array_equal(vfw.flags, flags)
+
+    def test_missing_chunks(self):
+        self._test_missing_chunks((100, 256, 30))
+
+    def test_missing_chunks_uneven_chunking(self):
+        self._test_missing_chunks(
+            (20, 210, 30),
+            {
+                'vis': (1, 6, 30),
+                'weights': (5, 10, 15),
+                'weights_channel': (1, 7),
+                'flags': (4, 15, 30)
+            })


### PR DESCRIPTION
Instead of synthesizing a sequence of masks (which are mostly zero), it
looks at the list of missing chunks, and computes the pieces of each
flag chunk that need the mask applied. A single map_blocks is then used
to apply the mask only where needed. This gives a 10x speedup.