### PR TITLE
Let L1 flag dumps match those of L0

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -272,8 +272,8 @@ def _upgrade_chunk_info(chunk_info, improved_chunk_info):
         time_chunks = chunks[0]
         n_improved_dumps = sum(time_chunks)
         if n_improved_dumps != n_original_dumps:
-            logger.debug('Original %r array has %d dumps while improved '
-                         'version has %d - forcing it to %d dumps', key,
+            logger.debug("Original '%s' array has %d dumps while improved "
+                         "version has %d - forcing it to %d dumps", key,
                          n_original_dumps, n_improved_dumps, n_original_dumps)
             # Extend/truncate improved version to match original number of dumps
             if n_improved_dumps < n_original_dumps:
@@ -285,8 +285,8 @@ def _upgrade_chunk_info(chunk_info, improved_chunk_info):
         shape = improved_info['shape']
         improved_info['shape'] = (sum(time_chunks),) + shape[1:]
         if improved_info['shape'] != original_info['shape']:
-            raise ValueError('Original {!r} array has shape {} while improved'
-                             'version has shape {}, even after fixing dumps'
+            raise ValueError("Original '{}' array has shape {} while improved"
+                             "version has shape {}, even after fixing dumps"
                              .format(key, original_info['shape'],
                                      improved_info['shape']))
         chunk_info[key] = improved_info

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -263,6 +263,36 @@ def _ensure_prefix_is_set(chunk_info, telstate):
     return chunk_info
 
 
+def _upgrade_chunk_info(chunk_info, improved_chunk_info):
+    """Replace chunk info items with better ones while preserving number of dumps."""
+    for key, improved_info in improved_chunk_info.items():
+        original_info = chunk_info.get(key, improved_info)
+        n_original_dumps = original_info['shape'][0]
+        chunks = improved_info['chunks']
+        time_chunks = chunks[0]
+        n_improved_dumps = sum(time_chunks)
+        if n_improved_dumps != n_original_dumps:
+            logger.debug('Original %r array has %d dumps while improved '
+                         'version has %d - forcing it to %d dumps', key,
+                         n_original_dumps, n_improved_dumps, n_original_dumps)
+            # Extend/truncate improved version to match original number of dumps
+            if n_improved_dumps < n_original_dumps:
+                time_chunks += (n_original_dumps - n_improved_dumps) * (1,)
+            else:
+                while time_chunks and sum(time_chunks) > n_original_dumps:
+                    time_chunks = time_chunks[:-1]
+        improved_info['chunks'] = (time_chunks,) + chunks[1:]
+        shape = improved_info['shape']
+        improved_info['shape'] = (sum(time_chunks),) + shape[1:]
+        if improved_info['shape'] != original_info['shape']:
+            raise ValueError('Original {!r} array has shape {} while improved'
+                             'version has shape {}, even after fixing dumps'
+                             .format(key, original_info['shape'],
+                                     improved_info['shape']))
+        chunk_info[key] = improved_info
+    return chunk_info
+
+
 def _infer_chunk_store(url_parts, telstate, npy_store_path=None,
                        s3_endpoint_url=None, **kwargs):
     """Construct chunk store automatically from dataset URL and telstate.
@@ -330,7 +360,7 @@ def _upgrade_flags(chunk_info, telstate):
         telstate_cs = telstate_s.view(flags_cs)
         flags_info = telstate_cs['chunk_info']
         flags_info = _ensure_prefix_is_set(flags_info, telstate_cs)
-        chunk_info.update(flags_info)
+        chunk_info = _upgrade_chunk_info(chunk_info, flags_info)
     return chunk_info
 
 


### PR DESCRIPTION
The number of dumps in the `sdp_l1_flags` stream may differ from that of the source `sdp_l0` stream, since the chunks are produced in separate unsynchronised writers (`flag_writer` vs `vis_writer`) which may experience different load conditions and dropouts. Consider the `sdp_l0` stream to be the gold standard (it has the visibilities, after all) and extend or truncate the number of dumps in the `sdp_l1_flags` chunk info to match it.

This addresses JIRA ticket [MKAIV-1220](https://skaafrica.atlassian.net/browse/MKAIV-1220).