### PR TITLE
Support AWS-style authentication to S3ChunkStore

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -211,6 +211,21 @@ class ChunkStore(object):
             chunk_name, shape = self.chunk_metadata(array_name, slices)
             return np.zeros(shape, dtype)
 
+    def create_array(self, array_name):
+        """Create a new array if it does not already exist.
+
+        Parameters
+        ----------
+        array_name : string
+            Identifier of array
+
+        Raises
+        ------
+        :exc:`chunkstore.StoreUnavailable`
+            If interaction with chunk store failed (offline, bad auth, bad config)
+        """
+        raise NotImplementedError
+
     def put_chunk(self, array_name, slices, chunk):
         """Put chunk into the store.
 

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -50,6 +50,10 @@ class DictChunkStore(ChunkStore):
                                    dtype, shape))
         return chunk
 
+    def create_array(self, array_name):
+        if array_name not in self.arrays:
+            raise NotImplementedError
+
     def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put_chunk`."""
         self.chunk_metadata(array_name, slices, chunk=chunk)

--- a/katdal/chunkstore_rados.py
+++ b/katdal/chunkstore_rados.py
@@ -120,6 +120,9 @@ class RadosChunkStore(ChunkStore):
                                    actual_bytes))
         return np.ndarray(shape, dtype, data_str)
 
+    def create_array(self, array_name):
+        pass
+
     def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put_chunk`."""
         key, _ = self.chunk_metadata(array_name, slices, chunk=chunk)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -137,6 +137,7 @@ class ChunkStoreTestBase(object):
         """Put a single chunk into store, check it, get it back and compare."""
         array_name = self.array_name(var_name)
         chunk = getattr(self, var_name)[slices]
+        self.store.create_array(array_name)
         self.store.put_chunk(array_name, slices, chunk)
         assert_true(self.store.has_chunk(array_name, slices, chunk.dtype))
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
@@ -156,6 +157,7 @@ class ChunkStoreTestBase(object):
     def put_dask_array(self, var_name, slices=()):
         """Put (part of) an array into store via dask."""
         array_name, dask_array, offset = self.make_dask_array(var_name, slices)
+        self.store.create_array(array_name)
         push = self.store.put_dask_array(array_name, dask_array, offset)
         results = push.compute()
         divisions_per_dim = [len(c) for c in dask_array.chunks]
@@ -213,6 +215,7 @@ class ChunkStoreTestBase(object):
         self.put_has_get_chunk('z', ())
 
     def test_put_chunk_noraise(self):
+        self.store.create_array("x")
         result = self.store.put_chunk_noraise("x", (1, 2), [])
         assert_is_instance(result, BadChunk)
 

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -65,6 +65,8 @@ def put_fake_dataset(store, prefix, shape, chunk_overrides=None):
     chunk_info = {k: {'prefix': prefix, 'chunks': darray.chunks,
                       'dtype': darray.dtype, 'shape': darray.shape}
                   for k, darray in ddata.items()}
+    for k, darray in ddata.items():
+        store.create_array(store.join(prefix, k))
     push = [store.put_dask_array(store.join(prefix, k), darray)
             for k, darray in ddata.items()]
     da.compute(*push)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+botocore==1.10.78
 dask
 defusedxml
 docutils
+jmespath==0.9.3
 fakeredis
 future
 h5py

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(name='katdal',
       extras_require={
           'ms': ['python-casacore >= 2.2.1', 'numba'],
           's3': [],
+          's3credentials': ['botocore'],
           # rados is not in PyPI but available as Debian package python-rados
           'rados': ['rados']
       },


### PR DESCRIPTION
The token-based authentication authenticates with our JWT-based proxy.
This adds credential authentication using an access key and secret key.
It relies on botocore to generate the signatures, which is added as an
optional dependency ("s3credentials").

Also adds a create_array method to ChunkStore, which should be used
before calling put_chunk or put_dask_array to ensure that the bucket
(S3ChunkStore) or directory (NpyFileChunkStore) is created, and that the
bucket policy allows public access if requested.