### PR TITLE
Modernise tab completion

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -234,7 +234,6 @@ from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2
 from .h5datav3 import H5DataV3
 from .visdatav4 import VisibilityDataV4
-from .sensordata import _sensor_completer
 
 
 # Clean up top-level namespace a bit
@@ -242,16 +241,6 @@ _dataset, _concatdata, _sensordata = dataset, concatdata, sensordata
 _h5datav1, _h5datav2, _h5datav3 = h5datav1, h5datav2, h5datav3
 _categorical, _lazy_indexer = categorical, lazy_indexer
 del dataset, concatdata, h5datav1, h5datav2, h5datav3, sensordata, categorical, lazy_indexer
-
-# Attempt to register custom IPython tab completer for sensor cache name lookups (only when run from IPython shell)
-try:
-    # IPython 0.11 and above
-    _ip = get_ipython()
-except NameError:
-    # IPython 0.10 and below (or normal Python shell)
-    _ip = __builtins__.get('__IPYTHON__')
-if hasattr(_ip, 'set_hook'):
-    _ip.set_hook('complete_command', _sensor_completer, re_key=r"(?:.*\=)?(.+?)\[")
 
 
 # Setup library logger and add a print-like handler used when no logging is configured


### PR DESCRIPTION
Since IPython 5.0 (PR ipython/ipython#9289 specifically) the
customisation of dict key lookups has been considerably simplified by
adding a specific method (`_ipython_key_completions_`) to your object.
For the `SensorCache` it is not even necessary to add this method since
it is derived from the standard dict. Strip out all the old tab
completion machinery as a result.

Unfortunately the rest of the IPython machinery is still a bit clunky
and the default completions now include all known tokens with that
prefix, not only the ones returned by `_ipython_key_completions_`.
This can be fixed by monkeypatching IPython in one of its startup files
(ask the author).