### PR TITLE
Add mark_complete and is_complete to ChunkStore

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -289,6 +289,29 @@ class ChunkStore(object):
         else:
             return True
 
+    def mark_complete(self, array_name):
+        """Write a special object to indicate that `array_name` is finished.
+
+        This operation is idempotent.
+
+        The `array_name` need not correspond to any array written with
+        :meth:`put_chunk`. This has no effect on katdal, but a producer can
+        call this method to provide a hint to a consumer that no further data
+        will be coming for this array. When arrays are arranged in a hierarchy,
+        a producer and consumer may agree to write a single completion marker
+        at a higher level of the hierarchy rather than one per actual array.
+
+        It is not necessary to call :meth:`create_array` first; the
+        implementation will do so if appropriate.
+
+        The presence of this marker can be checked with :meth:`is_complete`.
+        """
+        raise NotImplementedError
+
+    def is_complete(self, array_name):
+        """Check whether :meth:`mark_complete` has been called for this array."""
+        raise NotImplementedError
+
     NAME_SEP = '/'
     # Width sufficient to store any dump / channel / corrprod index for MeerKAT
     NAME_INDEX_WIDTH = 5

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -111,7 +111,21 @@ class NpyFileChunkStore(ChunkStore):
                 raise
             return []
 
+    def mark_complete(self, array_name):
+        """See the docstring of :meth:`ChunkStore.mark_complete`."""
+        self.create_array(array_name)
+        touch_file = os.path.join(self.path, array_name, 'complete')
+        with open(touch_file, 'a'):
+            os.utime(touch_file, None)
+
+    def is_complete(self, array_name):
+        """See the docstring of :meth:`ChunkStore.is_complete`."""
+        touch_file = os.path.join(self.path, array_name, 'complete')
+        return os.path.isfile(touch_file)
+
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__
     has_chunk.__doc__ = ChunkStore.has_chunk.__doc__
     list_chunk_ids.__doc__ = ChunkStore.list_chunk_ids.__doc__
+    mark_complete.__doc__ = ChunkStore.mark_complete.__doc__
+    is_complete.__doc__ = ChunkStore.is_complete.__doc__

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -395,7 +395,28 @@ class S3ChunkStore(ChunkStore):
         # Strip the array name and .npy extension to get the chunk ID string
         return [key[len(prefix) + 1:-4] for key in keys if key.endswith('.npy')]
 
+    def mark_complete(self, array_name):
+        """See the docstring of :meth:`ChunkStore.mark_complete`."""
+        self.create_array(array_name)
+        obj_name = self.join(array_name, 'complete')
+        url = urllib.parse.urljoin(self._url, obj_name)
+        with self._request(obj_name, 'PUT', url, data=b''):
+            pass
+
+    def is_complete(self, array_name):
+        """See the docstring of :meth:`ChunkStore.is_complete`."""
+        obj_name = self.join(array_name, 'complete')
+        url = urllib.parse.urljoin(self._url, obj_name)
+        try:
+            with self._request(obj_name, 'GET', url):
+                pass
+        except ChunkNotFound:
+            return False
+        return True
+
     get_chunk.__doc__ = ChunkStore.get_chunk.__doc__
     put_chunk.__doc__ = ChunkStore.put_chunk.__doc__
     has_chunk.__doc__ = ChunkStore.has_chunk.__doc__
     list_chunk_ids.__doc__ = ChunkStore.list_chunk_ids.__doc__
+    mark_complete.__doc__ = ChunkStore.mark_complete.__doc__
+    is_complete.__doc__ = ChunkStore.is_complete.__doc__

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -257,3 +257,13 @@ class ChunkStoreTestBase(object):
             slices = da.core.slices_from_chunks(dask_array.chunks)
             ref_chunk_ids = [self.store.chunk_id_str(s) for s in slices]
             assert_equal(set(chunk_ids), set(ref_chunk_ids))
+
+    def test_mark_complete(self):
+        name = self.array_name('completetest')
+        try:
+            assert_false(self.store.is_complete(name))
+        except NotImplementedError:
+            pass
+        else:
+            self.store.mark_complete(name)
+            assert_true(self.store.is_complete(name))

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -288,4 +288,4 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
             cls.proxy_url = 'http://{}:{}'.format(proxy_host, proxy_port)
         elif url != cls.httpd.target:
             raise RuntimeError('Cannot use multiple target URLs with http proxy')
-        return S3ChunkStore.from_url(cls.proxy_url, timeout=1, token='mysecret', **kwargs)
+        return S3ChunkStore.from_url(cls.proxy_url, timeout=10, token='mysecret', **kwargs)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -270,7 +270,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
     def from_url(cls, url, authenticate=True, **kwargs):
         """Create the chunk store"""
         if not authenticate:
-            return S3ChunkStore.from_url(url, timeout=1, **kwargs)
+            return S3ChunkStore.from_url(url, timeout=10, **kwargs)
 
         if cls.httpd is None:
             proxy_host = '127.0.0.1'


### PR DESCRIPTION
This was being handled by katsdpdatawriter, but in a way that would only
work for NpyFileChunkStore. This will allow katsdpdatawriter's internals
to be chunk store agnostic.

It's not implemented for RadosChunkStore, because I don't have a
convenient way to test that. We should consider just deleting
RadosChunkStore since it's never used nor planned to be used.