### PR TITLE
Improvements in S3 unit test

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -190,7 +190,7 @@ class S3ChunkStore(ChunkStore):
             # error if we do not have credentials (this occurs for minio, but
             # Ceph RGW just returns an empty list).
             with session_factory() as session:
-                with contextlib.closing(session.get(url)) as response:
+                with session.get(url) as response:
                     if (response.status_code != 403
                             or 'Authorization' in response.request.headers):
                         _raise_for_status(response)
@@ -298,7 +298,7 @@ class S3ChunkStore(ChunkStore):
     def _request(self, chunk_name, method, url, *args, **kwargs):
         """Run a request on a session from the pool, raising HTTP errors"""
         with self._standard_errors(chunk_name), self._session_pool() as session:
-            with contextlib.closing(session.request(method, url, *args, **kwargs)) as response:
+            with session.request(method, url, *args, **kwargs) as response:
                 _raise_for_status(response)
                 yield response
 
@@ -323,7 +323,7 @@ class S3ChunkStore(ChunkStore):
         bucket = array_name.split(self.NAME_SEP)[0]
         url = urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(bucket)))
         with self._standard_errors(), self._session_pool() as session:
-            with contextlib.closing(session.put(url)) as response:
+            with session.put(url) as response:
                 if response.status_code != 409:
                     # 409 indicates the bucket already exists
                     _raise_for_status(response)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -72,7 +72,6 @@ def get_free_port(host):
     the temporary socket.
     """
     with contextlib.closing(socket.socket()) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind((host, 0))
         port = sock.getsockname()[1]

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -122,7 +122,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         health_url = urllib.parse.urljoin(url, '/minio/health/live')
         for i in range(100):
             try:
-                with contextlib.closing(requests.get(health_url)) as resp:
+                with requests.get(health_url) as resp:
                     if resp.status_code == 200:
                         return url
             except requests.ConnectionError:
@@ -238,12 +238,11 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
                 del request_headers[header]
 
         try:
-            with contextlib.closing(
-                    self.server.session.request(self.command, url,
-                                                headers=request_headers, data=data,
-                                                auth=self.server.auth,
-                                                allow_redirects=False,
-                                                timeout=5)) as resp:
+            with self.server.session.request(self.command, url,
+                                             headers=request_headers, data=data,
+                                             auth=self.server.auth,
+                                             allow_redirects=False,
+                                             timeout=5) as resp:
                 content = resp.content
                 status_code = resp.status_code
                 reason = resp.reason

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -232,7 +232,7 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
                                                 headers=self.headers, data=data,
                                                 auth=self.server.auth,
                                                 allow_redirects=False,
-                                                timeout=20)) as resp:
+                                                timeout=5)) as resp:
                 content = resp.content
                 status_code = resp.status_code
                 reason = resp.reason

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ rdbtools
 redis
 requests
 six
-subprocess32
+subprocess32==3.5.2     # katsdpdockerbase version refuses to install on Python 3
 toolz
 urllib3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ rdbtools
 redis
 requests
 six
+subprocess32
 toolz
 urllib3
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='katdal',
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py>=2.3',
                         'katsdptelstate[rdb]', 'dask[array]',
-                        'requests', 'defusedxml', 'future'],
+                        'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1', 'numba'],
           's3': [],

--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,4 @@ setup(name='katdal',
           # rados is not in PyPI but available as Debian package python-rados
           'rados': ['rados']
       },
-      tests_require=['mock', 'nose'])
+      tests_require=['mock', 'nose', 'subprocess32'])


### PR DESCRIPTION
- Require the latest version of minio (which has bug-fixes), otherwise skip test
- In the test proxy, sanitise HTTP headers that shouldn't be passed through a proxy
- Remove no-longer-needed contextlib.closing wrapping
- Fix unit tests on OS X