### PR TITLE
Upgrade DaskLazyIndexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+*.eggs
 dist
 build
 eggs

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@
 # Packages
 *.egg
 *.egg-info
-*.eggs
 dist
 build
 eggs
+.eggs
 parts
 bin
 var

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -84,9 +84,12 @@ def _dask_getitem(x, keep):
     If `keep` contains multiple fancy indices, perform outer (`oindex`)
     indexing. This behaviour deviates from NumPy, which performs the more
     general (but also more obtuse) vectorized (`vindex`) indexing in this case.
-    See  NumPy `NEP 21`_, dask/dask#433 and h5py/h5py#652 for more details.
+    See  NumPy `NEP 21`_, `dask #433`_ and `h5py #652`_ for more
+    details.
 
     .. _NEP 21: http://www.numpy.org/neps/nep-0021-advanced-indexing.html
+    .. _dask #433: https://github.com/dask/dask/issues/433
+    .. _h5py #652: https://github.com/h5py/h5py/issues/652
 
     In addition, this optimises performance by culling unnecessary nodes from
     the dask graph after indexing, which makes it cheaper to compute if only a
@@ -493,6 +496,10 @@ class DaskLazyIndexer(object):
         dataset, which already has a first-stage index and optional transforms
         applied to it. The indexer also finally stops being lazy and triggers
         dask computation to arrive at the output array.
+
+        Both indexing stages perform "outer" indexing (aka oindex), which
+        indexes each dimension independently. This is especially relevant for
+        advanced or fancy indexing.
 
         Parameters
         ----------

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -474,6 +474,18 @@ class DaskLazyIndexer(object):
                 self._orig_dataset = None
             return self._dataset
 
+    def add_transform(self, transform):
+        """Add another transform to the end of the transform chain.
+
+        The `transform` is a callable that takes a dask array and returns
+        another dask array. Apply it directly to the current dataset if
+        first-stage indexing and initial transformation has already happened.
+        """
+        with self._lock:
+            if self._dataset is not None:
+                self._dataset = transform(self._dataset)
+            self.transforms.append(transform)
+
     def __getitem__(self, keep):
         """Extract a selected array from the underlying dataset.
 

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -25,6 +25,7 @@ import threading
 from numbers import Integral
 
 import numpy as np
+import dask
 import dask.array as da
 import dask.optimization
 from functools import reduce, partial
@@ -60,6 +61,20 @@ def _range_to_slice(index):
     return slice(start, stop if stop >= 0 else None, step)
 
 
+def _check_boolean_index_length(indices, shape):
+    """Workaround for check_index failure in dask < 0.18.2."""
+    if not isinstance(indices, tuple):
+        indices = (indices,)
+    indices = da.slicing.replace_ellipsis(len(shape), indices)
+    indices = (ind for ind in indices if ind is not np.newaxis)
+    for dim, ind in zip(shape, indices):
+        if isinstance(ind, (list, np.ndarray)):
+            x = np.asanyarray(ind)
+            if x.dtype == bool and x.size != dim:
+                raise IndexError("Boolean array length {} doesn't equal "
+                                 "dimension {}".format(x.size, dim))
+
+
 def _simplify_index(indices, shape):
     """Generate an equivalent index expression that is cheaper to evaluate.
 
@@ -75,6 +90,9 @@ def _simplify_index(indices, shape):
 
     .. _NEP 21: http://www.numpy.org/neps/nep-0021-advanced-indexing.html
     """
+    # XXX Workaround to be removed at some stage
+    if dask.__version__ < '0.18.2':
+        _check_boolean_index_length(indices, shape)
     # First clean up and check indices, unpacking ellipsis and boolean arrays
     indices = da.slicing.normalize_index(indices, shape)
     out = []

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -32,7 +32,7 @@ from functools import reduce
 # TODO support advanced integer indexing with non-strictly increasing indices (i.e. out-of-order and duplicates)
 
 
-def _simplify_index(shape, indices):
+def _simplify_index(indices, shape):
     """Generate an equivalent index expression that is cheaper to evaluate.
 
     In the current implementation, boolean numpy arrays which select contiguous
@@ -101,7 +101,7 @@ def _dask_getitem(x, keep):
     small piece of the graph is needed, and by collapsing fancy indices in
     `keep` to slices where possible (which also implies oindex semantics).
     """
-    keep = _simplify_index(x.shape, keep)
+    keep = _simplify_index(keep, x.shape)
     try:
         kept = x[keep]
     except NotImplementedError:

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -18,16 +18,16 @@
 from __future__ import print_function, division, absolute_import
 
 from builtins import object
+
 import numpy as np
 import dask.array as da
-
 from nose.tools import assert_raises
 
-from katdal.lazy_indexer import _simplify_index, DaskLazyIndexer
+from katdal.lazy_indexer import _simplify_index, _dask_getitem, DaskLazyIndexer
 
 
 class TestSimplifyIndices(object):
-    """Test the :func:`~katdal.lazy_indexer._simplify_indices function"""
+    """Test the :func:`~katdal.lazy_indexer._simplify_indices` function."""
     def setup(self):
         self.shape = (3, 4, 5)
         self.data = np.arange(np.product(self.shape)).reshape(self.shape)
@@ -73,8 +73,64 @@ class TestSimplifyIndices(object):
         self._test_index_error(np.s_[0, 0, 0, 0])
 
 
+class TestDaskGetitem(object):
+    """Test the :func:`~katdal.lazy_indexer._dask_getitem` function."""
+    def setup(self):
+        # Derived from example in NEP 21
+        shape = (5, 6, 7, 8)
+        self.data = np.arange(np.product(shape)).reshape(shape)
+        self.data_dask = da.from_array(self.data, chunks=(1, 2, 1, 2))
+
+    def _check_shape(self, indices, shape):
+        us = _dask_getitem(self.data_dask, indices).compute()
+        np.testing.assert_equal(us.shape, shape)
+
+    def _compare_indexing(self, indices):
+        npy = self.data[indices]
+        us = _dask_getitem(self.data_dask, indices).compute()
+        np.testing.assert_array_equal(us, npy)
+
+    def _test_with(self, indices, expected_error=None):
+        if expected_error is None:
+            self._compare_indexing(indices)
+        else:
+            with assert_raises(expected_error):
+                self._compare_indexing(indices)
+
+    def test_legacy_fancy_indexing(self):
+        self._test_with(np.s_[[0], ...])
+        self._test_with(np.s_[:, [0], ...])
+        self._test_with(np.s_[:, [0], [0], :], AssertionError)  # future error
+        self._test_with(np.s_[:, [0], :, [0]], AssertionError)  # future error
+        self._test_with(np.s_[:, [0], 0, :])
+        self._test_with(np.s_[:, [0], :, 0], AssertionError)  # future error
+        # Create boolean index with one True value for the last two dimensions
+        bindx = np.zeros((7, 8), dtype=np.bool_)
+        bindx[0, 0] = True
+        self._test_with(np.s_[:, 0, bindx], IndexError)  # dask can't handle it
+        self._test_with(np.s_[0, :, bindx], IndexError)  # dask can't handle it
+        self._test_with(np.s_[[0], :, bindx], IndexError)  # dask failure
+        self._test_with(np.s_[:, [0, 1], bindx], IndexError)  # dask failure
+
+    def test_outer_indexing(self):
+        self._check_shape(np.s_[:, [0], [0, 1], :], (5, 1, 2, 8))
+        self._check_shape(np.s_[:, [0], :, [0, 1]], (5, 1, 7, 2))
+        self._check_shape(np.s_[:, [0], 0, :], (5, 1, 8))
+        self._check_shape(np.s_[:, [0], :, 0], (5, 1, 7))
+        # Restrict ourselves to more practical 1-D boolean indices
+        bindx2 = np.zeros(7, dtype=np.bool_)
+        bindx2[0] = True
+        bindx3 = np.zeros(8, dtype=np.bool_)
+        bindx3[0] = True
+        bindx3[3] = True
+        self._check_shape(np.s_[:, 0, bindx2, bindx3], (5, 1, 2))
+        self._check_shape(np.s_[0, :, bindx2, bindx3], (6, 1, 2))
+        self._check_shape(np.s_[[0], :, bindx2, bindx3], (1, 6, 1, 2))
+        self._check_shape(np.s_[:, [0, 1], bindx2, bindx3], (5, 2, 1, 2))
+
+
 class TestDaskLazyIndexer(object):
-    """Test the :func:`~katdal.lazy_indexer.DaskLazyIndexer class."""
+    """Test the :class:`~katdal.lazy_indexer.DaskLazyIndexer` class."""
     def setup(self):
         shape = (10, 20, 30)
         self.data = np.arange(np.product(shape)).reshape(shape)
@@ -89,3 +145,11 @@ class TestDaskLazyIndexer(object):
         stage1 = tuple([True] * d for d in self.data.shape)
         indexer = DaskLazyIndexer(self.data_dask, stage1)
         np.testing.assert_array_equal(indexer[:], self.data)
+
+    def test_stage2_multiple_boolean_indices(self):
+        stage1 = tuple([True] * d for d in self.data.shape)
+        indexer = DaskLazyIndexer(self.data_dask, stage1)
+        stage2 = tuple([True] * 2 + [False] * (d - 2) for d in self.data.shape)
+        # Since this is oindex, direct NumPy indexing won't work - check shape
+        np.testing.assert_equal(indexer[stage2].shape,
+                                tuple(sum(s) for s in stage2))

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -161,6 +161,8 @@ class TestNumPyOIndex(object):
         # single ints
         self._test_with(np.s_[:, [0], 0, :])
         self._test_with(np.s_[:, [0], :, 0])
+        self._test_with(np.s_[:, [0], -1, :])
+        self._test_with(np.s_[:, [0], :, -1])
         # newaxis
         self._test_with(np.s_[np.newaxis, :, [0], :, 0])
         self._test_with(np.s_[:, [0], np.newaxis, 0, :])
@@ -204,6 +206,8 @@ class TestDaskGetitem(object):
         # single ints
         self._test_with(np.s_[:, [0], 0, :])
         self._test_with(np.s_[:, [0], :, 0])
+        self._test_with(np.s_[:, [0], -1, :])
+        self._test_with(np.s_[:, [0], :, -1])
         self._test_with(np.s_[:, 0, [0, 2], [1, 3, 5]])
         # newaxis
         self._test_with(np.s_[np.newaxis, :, [0], :, 0])

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -281,13 +281,14 @@ class TestDaskLazyIndexer(object):
     def test_stage2_ints(self):
         self._test_with(np.s_[5:, :, 1::2], np.s_[1, 2, -1])
 
-    def test_stage1_multiple_boolean_indices(self):
+    def test_stage1_multiple_fancy_indices(self):
         self._test_with(tuple([True] * d for d in self.data.shape))
         self._test_with(tuple([True, False] * (d // 2)
                               for d in self.data.shape))
         self._test_with(np.s_[UNEVEN, 2 * UNEVEN, :24])
+        self._test_with(np.s_[:3, [1, 2, 3, 4, 6, 9], [8, 6, 4, 2, 0]])
 
-    def test_stage2_multiple_boolean_indices(self):
+    def test_stage2_multiple_fancy_indices(self):
         stage1 = tuple([True] * d for d in self.data.shape)
         stage2 = tuple([True] * 4 + [False] * (d - 4) for d in self.data.shape)
         self._test_with(stage1, stage2)

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -35,12 +35,12 @@ class TestSimplifyIndices(object):
 
     def _test_with(self, indices):
         expected = self.data[indices]
-        simplified = _simplify_index(self.data.shape, indices)
+        simplified = _simplify_index(indices, self.data.shape)
         actual = self.data[simplified]
         np.testing.assert_array_equal(actual, expected)
 
     def _test_index_error(self, indices):
-        simplified = _simplify_index(self.data.shape, indices)
+        simplified = _simplify_index(indices, self.data.shape)
         with assert_raises(IndexError):
             self.data[simplified]
         with assert_raises(IndexError):

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -115,6 +115,8 @@ def numpy_oindex_lite(x, keep):
 
     It also assumes that `keep` contains no ellipsis to be as pure as possible.
     """
+    if not isinstance(keep, tuple):
+        keep = (keep,)
     dim = 0
     result = x
     for k in keep:
@@ -142,6 +144,8 @@ class TestNumPyOIndex(object):
 
     def test_outer_indexing(self):
         self._test_with(())
+        self._test_with(2)
+        self._test_with((2, 3, 4, 5))
         # ellipsis
         self._test_with(np.s_[[0], ...], np.s_[[0], :, :, :])
         self._test_with(np.s_[:, [0], ...], np.s_[:, [0], :, :])
@@ -185,6 +189,8 @@ class TestDaskGetitem(object):
 
     def test_outer_indexing(self):
         self._test_with(())
+        self._test_with(2)
+        self._test_with((2, 3, 4, 5))
         # ellipsis
         self._test_with(np.s_[[0], ...])
         self._test_with(np.s_[:, [0], ...])
@@ -232,6 +238,9 @@ class TestDaskLazyIndexer(object):
 
     def test_stage1_slices(self):
         self._test_with(np.s_[5:, :, 1::2])
+
+    def test_stage2_ints(self):
+        self._test_with(np.s_[5:, :, 1::2], np.s_[1, 2, -1])
 
     def test_stage1_multiple_boolean_indices(self):
         self._test_with(tuple([True] * d for d in self.data.shape))


### PR DESCRIPTION
This prepares to prepare for applycal...

The DaskLazyIndexer is given a bit of a facelift, with explicit oindex semantics (see JIRA [SR-1323](https://skaafrica.atlassian.net/browse/SR-1323)) and a way to add transforms after instantiation.