### PR TITLE
Make L1 product (the scaffolding)

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -79,3 +79,110 @@ def add_applycal_sensors(cache, cal_ants, cal_pols, freqs):
 
     correction_sensor = 'Calibration/{inp}_correction_{product}'
     cache.virtual[correction_sensor] = calc_correction_per_input
+
+
+def calc_correction_per_corrprod(dump, channels, cache, inputs,
+                                 input1_index, input2_index, cal_products):
+    """Gain correction per channel per correlation product for a given dump.
+
+    This calculates an array of complex gain correction terms of shape
+    (n_chans, n_corrprods) that can be directly applied to visibility data.
+    This incorporates all requested calibration products at the specified
+    dump and channels.
+
+    Parameters
+    ----------
+    dump : int
+        Dump index (applicable to full data set, i.e. absolute)
+    channels : list of int, length n_chans
+        Channel indices (applicable to full data set, i.e. absolute)
+    cache : :class:`katdal.sensordata.SensorCache` object
+        Sensor cache, used to look up individual correction sensors
+    inputs : sequence of string
+        Correlator input labels
+    input1_index, input2_index : list of int, length n_corrprods
+        Indices into `inputs` of first and second items of correlation product
+    cal_products : sequence of string
+        Calibration products that will contribute to corrections
+
+    Returns
+    -------
+    gains : array of complex64, shape (n_chans, n_corrprods)
+        Gain corrections per channel per correlation product
+
+    Raises
+    ------
+    KeyError
+        If input and/or cal product has no associated correction
+    """
+    g_per_input = np.ones((len(inputs), len(channels)), dtype='complex64')
+    for product in cal_products:
+        for n, inp in enumerate(inputs):
+            sensor_name = 'Calibration/{}_correction_{}'.format(inp, product)
+            g_product = cache.get(sensor_name)[dump]
+            if np.shape(g_product) != ():
+                g_product = g_product[channels]
+            g_per_input[n] *= g_product
+    g_per_cp = g_per_input[input1_index] * g_per_input[input2_index].conj()
+    return g_per_cp.T
+
+
+def apply_vis_correction(out, correction):
+    """Apply `correction` in-place to visibility data in `out`."""
+    correction[np.isnan(correction)] = np.complex64(1)
+    out *= correction
+
+
+def add_applycal_transform(indexer, cache, corrprods, cal_products,
+                           apply_correction):
+    """Add transform to indexer that applies calibration corrections.
+
+    This adds a transform to the indexer which wraps the underlying data
+    (visibilities, weights or flags). The transform will apply all calibration
+    corrections specified in `cal_products` to each dask chunk individually.
+    The actual application method is also user-specified, which allows most
+    of the machinery to be reused between visibilities, weights and flags.
+    The time and frequency selections are salvaged from `indexer` but the
+    selected `corrprods` still needs to be passed in as a parameter to identify
+    the relevant inputs in order to access correction sensors.
+
+    Parameters
+    ----------
+    indexer : :class:`katdal.lazy_indexer.DaskLazyIndexer` object
+        Indexer with underlying dask array that will be transformed
+    cache : :class:`katdal.sensordata.SensorCache` object
+        Sensor cache, used to look up individual correction sensors
+    corrprods : sequence of (string, string)
+        Selected correlation products as pairs of correlator input labels
+    cal_products : sequence of string
+        Calibration products that will contribute to corrections
+    apply_correction : function, signature ``out = f(out, correction)``
+        Function that will actually apply correction to data from indexer
+    """
+    if indexer.dataset.chunks[2] != (len(corrprods),):
+        raise ValueError('Applycal currently assumes a single chunk '
+                         'along the corrprod axis')
+    chunk_starts = [np.cumsum((0,) + c) for c in indexer.dataset.chunks]
+    dump_index = indexer.keep[0].nonzero()[0]
+    channel_index = indexer.keep[1].nonzero()[0]
+    # Turn corrprods into a list of input labels and two lists of indices
+    inputs = sorted(set(np.ravel(corrprods)))
+    input1_index = [inputs.index(cp[0]) for cp in corrprods]
+    input2_index = [inputs.index(cp[1]) for cp in corrprods]
+    ccpc_args = (cache, inputs, input1_index, input2_index, cal_products)
+
+    def calibrate_chunk(chunk, block_id):
+        """Apply all specified calibration corrections to chunk."""
+        corrected_chunk = chunk.copy()
+        array_location = [(chunk_starts[ij][j], chunk_starts[ij][j + 1])
+                          for ij, j in enumerate(block_id)]
+        dumps = dump_index[slice(*array_location[0])]
+        chans = channel_index[slice(*array_location[1])]
+        for n, dump in enumerate(dumps):
+            correction = calc_correction_per_corrprod(dump, chans, *ccpc_args)
+            apply_correction(corrected_chunk[n], correction)
+        return corrected_chunk
+
+    transform = partial(da.map_blocks, calibrate_chunk, dtype=indexer.dtype)
+    transform.__name__ = 'applycal[{}]'.format(','.join(cal_products))
+    indexer.add_transform(transform)

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -1,0 +1,81 @@
+###############################################################################
+# Copyright (c) 2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+"""Utilities for applying calibration solutions to visibilities and weights."""
+
+from functools import partial
+
+import numpy as np
+import dask.array as da
+
+from katdal.categorical import CategoricalData
+
+
+def calc_delay_correction(cache, product, index, freqs):
+    """Calculate correction sensor from delay calibration solutions.
+
+    This extracts the cal solution sensor associated with `product` from
+    `cache`, then extracts the delay time series of the input specified by
+    `index` (in the form (pol, ant)) and builds a categorical sensor for
+    the corresponding complex correction terms (channelised by `freqs`).
+
+    Invalid delays (NaNs) are replaced by zeros, since bandpass calibration
+    still has a shot at fixing any residual delay. An invalid `product` results
+    in a :exc:`KeyError`.
+    """
+    all_delays = cache.get('cal_product_' + product)
+    events = all_delays.events
+    delays = [np.nan_to_num(all_delays[n][index]) for n in events[:-1]]
+    # Delays returned by cal pipeline are already corrections (no minus needed)
+    corrections = [np.exp(2j * np.pi * d * freqs).astype('complex64')
+                   for d in delays]
+    return CategoricalData(corrections, events)
+
+
+def add_applycal_sensors(cache, cal_ants, cal_pols, freqs):
+    """Add virtual sensors that store calibration corrections, to sensor cache.
+
+    This maps receptor inputs to the relevant indices in each calibration
+    product based on the `cal_ants` and `cal_pols` lists. It then registers
+    a virtual sensor per input and per cal product in the SensorCache `cache`,
+    with template 'Calibration/{inp}_correction_{product}'. The virtual sensor
+    function picks the appropriate correction calculator based on the cal
+    product name, which also uses auxiliary info like the channel frequencies,
+    `freqs`.
+    """
+    cal_input_map = {ant + pol: (pol_idx, ant_idx)
+                     for (pol_idx, pol) in enumerate(cal_pols)
+                     for (ant_idx, ant) in enumerate(cal_ants)}
+    if not cal_input_map:
+        return
+
+    def calc_correction_per_input(cache, name, inp, product):
+        """Calculate correction sensor for input `inp` from cal solutions."""
+        try:
+            index = cal_input_map[inp]
+        except KeyError:
+            raise KeyError("No calibration solutions available for input "
+                           "'{}' - available ones are {}"
+                           .format(inp, sorted(cal_input_map.keys())))
+        if product.startswith('K'):
+            sensor_data = calc_delay_correction(cache, product, index, freqs)
+        else:
+            raise KeyError("Unknown calibration product '{}'".format(product))
+        cache[name] = sensor_data
+        return sensor_data
+
+    correction_sensor = 'Calibration/{inp}_correction_{product}'
+    cache.virtual[correction_sensor] = calc_correction_per_input

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -155,20 +155,11 @@ class TestApplyCal(object):
         self.corrprods = [cp for n, cp in enumerate(CORRPRODS)
                           if corrprod_keep[n]]
 
-    def test_applycal_expects_single_chunk_along_corrprod_axis(self):
-        vis = da.ones((N_DUMPS, N_CHANS, N_CORRPRODS), dtype='complex64',
-                      chunks=(10, 4, N_CORRPRODS // 4))
-        indexer = DaskLazyIndexer(vis, self.stage1)
-        cal_products = ['K']
-        with assert_raises(ValueError):
-            add_applycal_transform(indexer, self.cache, self.corrprods,
-                                   cal_products, apply_vis_correction)
-
     def test_applycal_vis(self):
         vis_real = np.random.randn(N_DUMPS, N_CHANS, N_CORRPRODS)
         vis_imag = np.random.randn(N_DUMPS, N_CHANS, N_CORRPRODS)
         vis = np.asarray(vis_real + 1j * vis_imag, dtype='complex64')
-        vis_dask = da.from_array(vis, chunks=(10, 4, N_CORRPRODS))
+        vis_dask = da.from_array(vis, chunks=(10, 4, 6))
         indexer = DaskLazyIndexer(vis_dask, self.stage1)
         cal_products = ['K']
         add_applycal_transform(indexer, self.cache, self.corrprods,

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -1,0 +1,92 @@
+###############################################################################
+# Copyright (c) 2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+"""Tests for :py:mod:`katdal.applycal`."""
+from __future__ import print_function, division, absolute_import
+from builtins import object, range
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_raises
+
+from katdal.sensordata import SensorCache
+from katdal.categorical import CategoricalData
+from katdal.applycal import calc_delay_correction, add_applycal_sensors
+
+
+CAL_POLS = ['v', 'h']
+CAL_ANTS = ['m000', 'm001', 'm002', 'm003']
+CENTRE_FREQ = 1284.0
+BANDWIDTH = 856.0
+N_CHANS = 128
+N_DUMPS = 100
+SAMPLE_RATE = 1712.
+FREQS = CENTRE_FREQ + BANDWIDTH / N_CHANS * (np.arange(N_CHANS) - N_CHANS // 2)
+
+
+def delay_gains(delay):
+    return np.exp(2j * np.pi * delay / SAMPLE_RATE * FREQS).astype('complex64')
+
+
+def create_sensor_cache():
+    """Create a SensorCache for testing applycal sensors."""
+    cache = {}
+    delays = np.arange(len(CAL_ANTS))
+    delays = np.array([delays, -delays]) / SAMPLE_RATE
+    cache['cal_product_K'] = CategoricalData([np.zeros_like(delays), delays],
+                                             events=[0, 10, N_DUMPS])
+    return SensorCache(cache, timestamps=np.arange(N_DUMPS, dtype=float),
+                       dump_period=1.)
+
+
+class TestCalcCorrection(object):
+    """Test the :func:`~katdal.applycal.calc_*_correction` functions."""
+    def setup(self):
+        self.cache = create_sensor_cache()
+
+    def test_calc_delay_correction(self):
+        for n in range(len(CAL_ANTS)):
+            for m in range(len(CAL_POLS)):
+                sensor = calc_delay_correction(self.cache, 'K', (m, n), FREQS)
+                assert_array_equal(sensor[n],
+                                   np.ones(N_CHANS, dtype='complex64'))
+                expected_delay = (-1) ** m * n
+                assert_array_equal(sensor[10 + n], delay_gains(expected_delay))
+
+
+class TestVirtualCorrectionSensors(object):
+    """Test :func:`~katdal.applycal.add_applycal_sensors` function."""
+    def setup(self):
+        self.cache = create_sensor_cache()
+        add_applycal_sensors(self.cache, [], [], [])   # this does nothing
+        add_applycal_sensors(self.cache, CAL_ANTS, CAL_POLS, FREQS)
+
+    def test_delay_sensors(self):
+        for n, ant in enumerate(CAL_ANTS):
+            for m, pol in enumerate(CAL_POLS):
+                sensor_name = 'Calibration/{}{}_correction_K'.format(ant, pol)
+                sensor = self.cache.get(sensor_name)
+                expected_delay = (-1) ** m * n
+                assert_array_equal(sensor[10 + n], delay_gains(expected_delay))
+
+    def test_unknown_inputs_and_products(self):
+        known_input = 'Calibration/{}{}'.format(CAL_ANTS[0], CAL_POLS[0])
+        with assert_raises(KeyError):
+            self.cache.get('Calibration/unknown_correction_K')
+        with assert_raises(KeyError):
+            self.cache.get(known_input + '_correction_unknown')
+        with assert_raises(KeyError):
+            self.cache.get(known_input + '_correction_K_unknown')

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -32,6 +32,7 @@ from .dataset import (DataSet, BrokenFile, Subarray, SpectralWindow,
 from .sensordata import SensorCache
 from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
+from .applycal import add_applycal_sensors
 
 
 logger = logging.getLogger(__name__)
@@ -288,6 +289,13 @@ class VisibilityDataV4(DataSet):
         # Ensure that each target flux model spans all frequencies
         # in data set if possible
         self._fix_flux_freq_range()
+
+        # ------ Register applycal virtual sensors ------
+
+        cal_ants = attrs.get('cal_antlist', [])
+        cal_pols = attrs.get('cal_pol_ordering', [])
+        freqs = self.spectral_windows[0].channel_freqs
+        add_applycal_sensors(self.sensor, cal_ants, cal_pols, freqs)
 
         # Apply default selection and initialise all members that depend
         # on selection in the process

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 botocore==1.10.78
 certifi
 chardet
-dask
+dask==0.19.2
 defusedxml
 docutils
 jmespath==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 botocore==1.10.78
 certifi
 chardet
-dask==0.19.2
+dask
 defusedxml
 docutils
 jmespath==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py>=2.3',
-                        'katsdptelstate[rdb]', 'dask[array]',
+                        'katsdptelstate[rdb]', 'dask[array] >= 0.18.2',
                         'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1', 'numba'],


### PR DESCRIPTION
This is a first stab at the machinery of "Make L1". It only does `cal_product_K`, and only corrects visibilities.

I am looking for comments on the basic idea before forging ahead...

It is based on a set of per-input gain correction sensors, which is about the smallest thing one can cache that makes sense. The corrections are meant to be cleaned up and interpolated where needed.

The corrections are then applied per chunk via dask `map_blocks`, by obtaining the appropriate sensor values per chunk, expanding them to become per baseline, and applying them with a vis-weights-flags specific method.
