### PR TITLE
Fix mvftoms after the oindex update

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -228,7 +228,7 @@ import urllib.parse
 
 from .datasources import open_data_source
 from .dataset import DataSet, WrongVersion
-from .lazy_indexer import LazyTransform
+from .lazy_indexer import LazyTransform, dask_getitem
 from .concatdata import ConcatenatedDataSet
 from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -127,7 +127,7 @@ def _dask_oindex(x, indices):
     return x
 
 
-def _dask_getitem(x, indices):
+def dask_getitem(x, indices):
     """Index a dask array, with N-D fancy index support and better performance.
 
     This is a drop-in replacement for ``x[indices]`` that goes one further
@@ -537,7 +537,7 @@ class DaskLazyIndexer(object):
         """Array after first-stage indexing and transformation."""
         with self._lock:
             if self._dataset is None:
-                dataset = _dask_getitem(self._orig_dataset, self.keep)
+                dataset = dask_getitem(self._orig_dataset, self.keep)
                 for transform in self.transforms:
                     dataset = transform(dataset)
                 self._dataset = dataset
@@ -578,7 +578,7 @@ class DaskLazyIndexer(object):
         out : :class:`numpy.ndarray`
             Extracted output array (computed from the final dask version)
         """
-        kept = _dask_getitem(self.dataset, keep)
+        kept = dask_getitem(self.dataset, keep)
         # Workaround for https://github.com/dask/dask/issues/3595
         # This is equivalent to kept.compute(), but does not
         # allocate excessive memory.

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -26,7 +26,7 @@ import dask.array as da
 from nose.tools import assert_raises, assert_equal
 
 from katdal.lazy_indexer import (_range_to_slice, _simplify_index,
-                                 _dask_oindex, _dask_getitem, DaskLazyIndexer)
+                                 _dask_oindex, dask_getitem, DaskLazyIndexer)
 
 
 def slice_to_range(s, l):
@@ -176,7 +176,7 @@ UNEVEN = [False, True, True, True, False, False, True, True, False, True]
 
 
 class TestDaskGetitem(object):
-    """Test the :func:`~katdal.lazy_indexer._dask_getitem` function."""
+    """Test the :func:`~katdal.lazy_indexer.dask_getitem` function."""
     def setup(self):
         shape = (10, 20, 30, 40)
         self.data = np.arange(np.product(shape)).reshape(shape)
@@ -188,7 +188,7 @@ class TestDaskGetitem(object):
             normalised_indices = indices
         npy_lite = numpy_oindex_lite(self.data, normalised_indices)
         oindex = _dask_oindex(self.data_dask, normalised_indices).compute()
-        getitem = _dask_getitem(self.data_dask, indices).compute()
+        getitem = dask_getitem(self.data_dask, indices).compute()
         np.testing.assert_array_equal(npy, npy_lite)
         np.testing.assert_array_equal(getitem, npy)
         np.testing.assert_array_equal(oindex, npy)

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -69,9 +69,9 @@ def load(dataset, indices, vis, weights, flags):
         Outputs, which must have the correct shape and type
     """
     if isinstance(dataset.vis, DaskLazyIndexer):
-        da.store([dataset.vis.dask_getitem(indices),
-                  dataset.weights.dask_getitem(indices),
-                  dataset.flags.dask_getitem(indices)],
+        da.store([katdal.dask_getitem(dataset.vis.dataset, indices),
+                  katdal.dask_getitem(dataset.weights.dataset, indices),
+                  katdal.dask_getitem(dataset.flags.dataset, indices)],
                  [vis, weights, flags], lock=False)
     else:
         vis[:] = dataset.vis[indices]


### PR DESCRIPTION
mvftowas was broken by #180, which took away the `dask_getitem` member
function and replaced it with a `_dask_getitem` free function. Fix by
renaming the free function to `dask_getitem`, importing it into the
top-level katdal namespace, and using it in mvftoms.

Closes #184.