### PR TITLE
Scale weights by autocorrelation power during read

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -164,6 +164,9 @@ def weight_power_scale(block, auto_indices, index1, index2, out=None, tmp=None):
     for i in range(block.shape[0]):
         for j in range(block.shape[1]):
             for k in range(len(auto_indices)):
+                # Have to use np.divide here, because 1 / x raises
+                # ZeroDivisionError on divide by zero whereas we want it
+                # to produce a non-finite value.
                 auto_scale[k] = np.divide(1, block[i, j, auto_indices[k]].real)
             for k in range(block.shape[2]):
                 p = auto_scale[index1[k]] * auto_scale[index2[k]]

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -511,7 +511,7 @@ class TelstateDataSource(DataSource):
             data = None
         else:
             chunk_info = telstate['chunk_info']
-            if True or telstate.get('need_weights_power_scale', False):
+            if telstate.get('need_weights_power_scale', False):
                 corrprods = telstate['bls_ordering']
             else:
                 corrprods = None

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -164,10 +164,10 @@ def weight_power_scale(block, auto_indices, index1, index2, out=None, tmp=None):
     for i in range(block.shape[0]):
         for j in range(block.shape[1]):
             for k in range(len(auto_indices)):
-                # Have to use np.divide here, because 1 / x raises
-                # ZeroDivisionError on divide by zero whereas we want it
-                # to produce a non-finite value.
-                auto_scale[k] = np.divide(1, block[i, j, auto_indices[k]].real)
+                # Have to force to an array here, because standard Python
+                # division raises ZeroDivisionError on divide by zero but we
+                # want to get IEEE semantics (Inf/NaN).
+                auto_scale[k] = 1 / np.array(block[i, j, auto_indices[k]].real)
             for k in range(block.shape[2]):
                 p = auto_scale[index1[k]] * auto_scale[index2[k]]
                 # If either or both of the autocorrelations has zero power then

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -145,7 +145,7 @@ def _power_scale(block, auto_indices, index1, index2):
     for i in range(block.shape[0]):
         for j in range(block.shape[1]):
             for k in range(len(auto_indices)):
-                auto_scale[k] = np.divide(1, np.sqrt(block[i, j, auto_indices[k]].real))
+                auto_scale[k] = np.divide(1, block[i, j, auto_indices[k]].real)
             for k in range(block.shape[2]):
                 p = auto_scale[index1[k]] * auto_scale[index2[k]]
                 # If either or both of the autocorrelations has zero power then

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -103,20 +103,20 @@ def _apply_data_lost(orig_flags, lost, block_id):
     return flags
 
 
-def corrprod_to_autocorr(corrprod):
+def corrprod_to_autocorr(corrprods):
     """Find the autocorrelation indices of correlation products.
 
     Parameters
     ----------
-    corrprod : sequence of 2-tuples or ndarray
+    corrprods : sequence of 2-tuples or ndarray
         Input labels of the correlation products
 
     Returns
     -------
     auto_indices : np.ndarray
-        The indices in corrprod that correspond to auto-correlations
+        The indices in corrprods that correspond to auto-correlations
     index1, index2 : np.ndarray
-        Lists of the same length as corrprod, containing the indices within
+        Lists of the same length as corrprods, containing the indices within
         `auto_indices` referring to the first and second corresponding
         autocorrelations.
 
@@ -127,12 +127,12 @@ def corrprod_to_autocorr(corrprod):
     """
     auto_indices = []
     auto_lookup = {}
-    for i, baseline in enumerate(corrprod):
+    for i, baseline in enumerate(corrprods):
         if baseline[0] == baseline[1]:
             auto_lookup[baseline[0]] = len(auto_indices)
             auto_indices.append(i)
-    index1 = [auto_lookup[a] for (a, b) in corrprod]
-    index2 = [auto_lookup[b] for (a, b) in corrprod]
+    index1 = [auto_lookup[a] for (a, b) in corrprods]
+    index2 = [auto_lookup[b] for (a, b) in corrprods]
     return np.array(auto_indices), np.array(index1), np.array(index2)
 
 

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -113,12 +113,12 @@ class TestChunkStoreVisFlagsWeights(object):
 
         # Make up some vis data where the expected scaling factors can be
         # computed by hand. Note: the autocorrs are all set to powers of
-        # 4 so that we avoid any rounding errors.
+        # 2 so that we avoid any rounding errors.
         vis = np.full(shape, 2 + 3j, np.complex64)
-        vis[:, :, index1 == index2] = 4     # Make all autocorrs real
-        vis[3, :, index1 == index2] = 16     # Tests time indexing
-        vis[:, 7, index1 == index2] = 16    # Tests frequency indexing
-        vis[:, :, ants] *= 64               # The (1, 1) baseline
+        vis[:, :, index1 == index2] = 2     # Make all autocorrs real
+        vis[3, :, index1 == index2] = 4     # Tests time indexing
+        vis[:, 7, index1 == index2] = 4     # Tests frequency indexing
+        vis[:, :, ants] *= 8                # The (1, 1) baseline
         vis[4, 5, 0] = 0                    # The (0, 0) baseline
         expected_scale = np.full(shape, 0.25, np.float32)
         expected_scale[3, :, :] = 1 / 16

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -90,7 +90,7 @@ class TestChunkStoreVisFlagsWeights(object):
         prefix = 'cb1'
         shape = (10, 64, 30)
         data, chunk_info = put_fake_dataset(store, prefix, shape)
-        vfw = ChunkStoreVisFlagsWeights(store, chunk_info)
+        vfw = ChunkStoreVisFlagsWeights(store, chunk_info, None)
         weights = data['weights'] * data['weights_channel'][..., np.newaxis]
         # Check that data is as expected when accessed via VisFlagsWeights
         assert_equal(vfw.shape, data['correlator_data'].shape)
@@ -114,7 +114,7 @@ class TestChunkStoreVisFlagsWeights(object):
             for culled_slice in culled_slices:
                 chunk_name, shape = store.chunk_metadata(array_name, culled_slice)
                 os.remove(os.path.join(store.path, chunk_name) + '.npy')
-        vfw = ChunkStoreVisFlagsWeights(store, chunk_info)
+        vfw = ChunkStoreVisFlagsWeights(store, chunk_info, None)
         # Check that (only) missing chunks have been replaced by zeros
         vis = data['correlator_data']
         for culled_slice in missing_chunks['correlator_data']:

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -53,12 +53,15 @@ def to_dask_array(x, chunks=None):
     return da.from_array(x, chunks)
 
 
-def put_fake_dataset(store, prefix, shape, chunk_overrides=None):
+def put_fake_dataset(store, prefix, shape, chunk_overrides=None, array_overrides={}):
     """Write a fake dataset into the chunk store."""
     data = {'correlator_data': ramp(shape, dtype=np.float32) * (1 - 1j),
             'flags': np.ones(shape, dtype=np.uint8),
             'weights': ramp(shape, slope=255. / np.prod(shape), dtype=np.uint8),
             'weights_channel': ramp(shape[:-1], dtype=np.float32)}
+    for name in data:
+        if name in array_overrides:
+            data[name] = array_overrides[name]
     if chunk_overrides is None:
         chunk_overrides = {}
     ddata = {k: to_dask_array(array, chunk_overrides.get(k)) for k, array in data.items()}
@@ -92,6 +95,44 @@ class TestChunkStoreVisFlagsWeights(object):
         data, chunk_info = put_fake_dataset(store, prefix, shape)
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info, None)
         weights = data['weights'] * data['weights_channel'][..., np.newaxis]
+        # Check that data is as expected when accessed via VisFlagsWeights
+        assert_equal(vfw.shape, data['correlator_data'].shape)
+        assert_array_equal(vfw.vis.compute(), data['correlator_data'])
+        assert_array_equal(vfw.flags.compute(), data['flags'])
+        assert_array_equal(vfw.weights.compute(), weights)
+
+    def test_weight_power_scale(self):
+        ants = 7
+        index1, index2 = np.triu_indices(ants)
+        inputs = ['m{:03}h'.format(i) for i in range(ants)]
+        corrprods = np.array([(inputs[a], inputs[b]) for (a, b) in zip(index1, index2)])
+        # Put fake dataset into chunk store
+        store = NpyFileChunkStore(self.tempdir)
+        prefix = 'cb1'
+        shape = (10, 64, len(index1))
+
+        # Make up some vis data where the expected scaling factors can be
+        # computed by hand. Note: the autocorrs are all set to powers of
+        # 4 so that we avoid any rounding errors.
+        vis = np.full(shape, 2 + 3j, np.complex64)
+        vis[:, :, index1 == index2] = 4     # Make all autocorrs real
+        vis[3, :, index1 == index2] = 16     # Tests time indexing
+        vis[:, 7, index1 == index2] = 16    # Tests frequency indexing
+        vis[:, :, ants] *= 64               # The (1, 1) baseline
+        vis[4, 5, 0] = 0                    # The (0, 0) baseline
+        expected_scale = np.full(shape, 0.25, np.float32)
+        expected_scale[3, :, :] = 1 / 16
+        expected_scale[:, 7, :] = 1 / 16
+        expected_scale[:, :, index1 == 1] /= 8
+        expected_scale[:, :, index2 == 1] /= 8
+        expected_scale[4, 5, index1 == 0] = 2.0**-32
+        expected_scale[4, 5, index2 == 0] = 2.0**-32
+
+        data, chunk_info = put_fake_dataset(
+            store, prefix, shape, array_overrides={'correlator_data': vis})
+        vfw = ChunkStoreVisFlagsWeights(store, chunk_info, corrprods)
+        weights = data['weights'] * data['weights_channel'][..., np.newaxis] * expected_scale
+
         # Check that data is as expected when accessed via VisFlagsWeights
         assert_equal(vfw.shape, data['correlator_data'].shape)
         assert_array_equal(vfw.vis.compute(), data['correlator_data'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ chardet
 dask
 defusedxml
 docutils
+enum34
+funcsigs
 jmespath==0.9.3
 fakeredis
 future
@@ -21,6 +23,7 @@ python-lzf
 rdbtools
 redis
 requests
+singledispatch
 six
 subprocess32==3.5.2     # katsdpdockerbase version refuses to install on Python 3
 toolz

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ h5py
 idna
 ipaddress
 katversion
+llvmlite
 netifaces
+numba
 numpy
 pyephem
 python-dateutil

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -69,10 +69,8 @@ def load(dataset, indices, vis, weights, flags):
         Outputs, which must have the correct shape and type
     """
     if isinstance(dataset.vis, DaskLazyIndexer):
-        da.store([katdal.dask_getitem(dataset.vis.dataset, indices),
-                  katdal.dask_getitem(dataset.weights.dataset, indices),
-                  katdal.dask_getitem(dataset.flags.dataset, indices)],
-                 [vis, weights, flags], lock=False)
+        DaskLazyIndexer.get([dataset.vis, dataset.weights, dataset.flags], indices,
+                            out=[vis, weights, flags])
     else:
         vis[:] = dataset.vis[indices]
         weights[:] = dataset.weights[indices]

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,10 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py>=2.3',
-                        'katsdptelstate[rdb]', 'dask[array]',
+                        'katsdptelstate[rdb]', 'dask[array]', 'numba',
                         'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={
-          'ms': ['python-casacore >= 2.2.1', 'numba'],
+          'ms': ['python-casacore >= 2.2.1'],
           's3': [],
           's3credentials': ['botocore'],
           # rados is not in PyPI but available as Debian package python-rados


### PR DESCRIPTION
If the telstate key 'need_weights_power_scale' is set on the L0 stream, the weights are divided by the product of the autocorrelation visibilities. This will be matched with changes to katsdpingest and katsdpdata to set this flag and remove the equivalent scaling done in ingest.

Relates to SR-1230.