### PR TITLE
Fix S3ChunkStore for Python 3.6

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -384,7 +384,7 @@ class S3ChunkStore(ChunkStore):
             # Python 2's httplib doesn't support a sequence of byte-likes.
             data = npy_header + chunk.tobytes()
         else:
-            data = _Multipart([npy_header, chunk])
+            data = _Multipart([npy_header, memoryview(chunk)])
         with self._request(chunk_name, 'PUT', url, headers=headers, data=data):
             pass
 


### PR DESCRIPTION
While testing on my home machine, I ran into unit test failures because
code inside Python 3.6's httplib does
```
if not chunk:
```
and if chunk is an ndarray then raises ValueError.

Wrap it in a memoryview so that truthiness is more sensible. I haven't
measured the performance impact, but the initial development of the
_Multipart optimisation used a memoryview and performed acceptably
well.