### PR TITLE
Make SpectralWindow do channel juggling

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -210,7 +210,7 @@ class SpectralWindow(object):
         """Base hash on description tuple, just like equality operator."""
         return hash(self._description)
 
-    def subset(self, first, last):
+    def subrange(self, first, last):
         """Get a new :class:`SpectralWindow` representing a subset of the channels.
 
         The returned :class:`SpectralWindow` covers the same frequencies as

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -222,7 +222,7 @@ class SpectralWindow(object):
             If [first, last) is not a (non-empty) subinterval of the channels
         """
         if not (0 <= first < last <= self.num_chans):
-            raise IndexError('indices out of range')
+            raise IndexError('channel indices out of range')
         channel_shift = (first + last) // 2 - self.num_chans // 2
         return SpectralWindow(
             self.centre_freq + channel_shift * self.channel_width * self.sideband,

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -1,0 +1,73 @@
+################################################################################
+# Copyright (c) 2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :py:mod:`katdal.dataset`."""
+from __future__ import print_function, division, absolute_import
+
+from builtins import object
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_equal
+
+from katdal.dataset import SpectralWindow
+
+
+class TestSpectralWindow(object):
+    def setUp(self):
+        self.lsb = SpectralWindow(1000.0, 10.0, 6, sideband=-1, product='lsb')
+        self.usb = SpectralWindow(1000.0, 10.0, 6, sideband=1, band='X')
+        self.odd = SpectralWindow(1000.0, 10.0, 5, sideband=1)
+
+    def test_channel_freqs(self):
+        assert_array_equal(self.lsb.channel_freqs,
+                           [1030.0, 1020.0, 1010.0, 1000.0, 990.0, 980.0])
+        assert_array_equal(self.usb.channel_freqs,
+                           [970.0, 980.0, 990.0, 1000.0, 1010.0, 1020.0])
+        assert_array_equal(self.odd.channel_freqs,
+                           [980.0, 990.0, 1000.0, 1010.0, 1020.0])
+
+    def test_repr(self):
+        # Just a smoke test to check that it doesn't crash
+        repr(self.lsb)
+        repr(self.usb)
+
+    def test_subrange(self):
+        lsb_sub = self.lsb.subrange(0, 3)
+        assert_array_equal(lsb_sub.channel_freqs, [1030.0, 1020.0, 1010.0])
+        assert_equal(lsb_sub.product, self.lsb.product)
+        usb_sub = self.usb.subrange(2, 6)
+        assert_array_equal(usb_sub.channel_freqs, [990.0, 1000.0, 1010.0, 1020.0])
+        assert_equal(usb_sub.band, self.usb.band)
+
+    def test_rechannelise_same(self):
+        lsb = self.lsb.rechannelise(6)
+        assert lsb == self.lsb
+
+    def test_rechannelise_to_even(self):
+        lsb = self.lsb.rechannelise(2)
+        assert_array_equal(lsb.channel_freqs, [1020.0, 990.0])
+        usb = self.usb.rechannelise(2)
+        assert_array_equal(usb.channel_freqs, [980.0, 1010.0])
+
+    def test_rechannelise_to_odd(self):
+        lsb = self.lsb.rechannelise(3)
+        assert_array_equal(lsb.channel_freqs, [1025.0, 1005.0, 985.0])
+        usb = self.usb.rechannelise(3)
+        assert_array_equal(usb.channel_freqs, [975.0, 995.0, 1015.0])
+        odd = self.odd.rechannelise(1)
+        assert_array_equal(odd.channel_freqs, [1000.0])
+


### PR DESCRIPTION
Can now compute a new spectral window with a (contiguous) subset of
channels or a new channelisation of the bandwidth.

Closes SR-1369.