### PR TITLE
Make L1: bandpass

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -136,7 +136,9 @@ def calc_bandpass_correction(sensor, index, data_freqs, cal_freqs):
         valid = np.isfinite(bp)
         if valid.any():
             bp = complex_interp(data_freqs, cal_freqs[valid], bp[valid])
-        corrections.append(ComparableArrayWrapper(1 / bp))
+        else:
+            bp = np.full(len(data_freqs), np.nan + 1j * np.nan, dtype=bp.dtype)
+        corrections.append(ComparableArrayWrapper(np.reciprocal(bp)))
     return CategoricalData(corrections, sensor.events)
 
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -15,6 +15,8 @@
 ###############################################################################
 
 """Utilities for applying calibration solutions to visibilities and weights."""
+from __future__ import print_function, division, absolute_import
+from builtins import range, zip
 
 from functools import partial
 import copy

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -20,12 +20,16 @@ from builtins import range, zip
 
 from functools import partial
 import copy
+import logging
 
 import numpy as np
 import dask.array as da
 
 from .categorical import CategoricalData, ComparableArrayWrapper
 from .spectral_window import SpectralWindow
+
+
+logger = logging.getLogger(__name__)
 
 
 def complex_interp(x, xi, yi):
@@ -160,6 +164,7 @@ def add_applycal_sensors(cache, attrs, data_freqs):
                                  bandwidth=attrs['cal_bandwidth'])
         cal_freqs = cal_spw.channel_freqs
     except KeyError:
+        logger.warning('Missing cal spectral attributes, disabling applycal')
         return
 
     def calc_correction_per_input(cache, name, inp, product):

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -142,7 +142,9 @@ def calc_bandpass_correction(sensor, index, data_freqs, cal_freqs):
         bp = sensor[n][(slice(None),) + index]
         valid = np.isfinite(bp)
         if valid.any():
-            bp = complex_interp(data_freqs, cal_freqs[valid], bp[valid])
+            # Don't extrapolate to edges of band where gain typically drops off
+            bp = complex_interp(data_freqs, cal_freqs[valid], bp[valid],
+                                left=np.nan, right=np.nan)
         else:
             bp = np.full(len(data_freqs), np.nan + 1j * np.nan, dtype=bp.dtype)
         corrections.append(ComparableArrayWrapper(np.reciprocal(bp)))

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -75,7 +75,10 @@ def complex_interp(x, xi, yi, left=None, right=None):
     # Interpolate magnitude and phase separately, and reassemble
     mag = np.interp(x, xi, mag_i, left=mag_left, right=mag_right)
     phase = np.interp(x, xi, phase_i, left=phase_left, right=phase_right)
-    y = mag * np.exp(1j * phase)
+    y = np.empty_like(phase, dtype=np.complex128)
+    np.cos(phase, out=y.real)
+    np.sin(phase, out=y.imag)
+    y *= mag
     return y.astype(yi.dtype)
 
 

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -125,7 +125,8 @@ def bandpass_gains(pol, ant):
     bp = create_bandpass(pol, ant)
     valid = np.isfinite(bp)
     if valid.any():
-        bp = complex_interp(FREQS, CAL_FREQS[valid], bp[valid])
+        bp = complex_interp(FREQS, CAL_FREQS[valid], bp[valid],
+                            left=np.nan, right=np.nan)
     else:
         bp = np.full(N_CHANS, np.nan + 1j * np.nan, dtype=bp.dtype)
     return np.reciprocal(bp)
@@ -228,12 +229,14 @@ class TestCorrectionPerInput(object):
 
     def test_calc_bandpass_correction(self):
         product_sensor = get_cal_product(self.cache, ATTRS, 'B')
+        constant_bandpass = np.ones(N_CHANS, dtype='complex64')
+        constant_bandpass[FREQS < CAL_FREQS[0]] = np.nan
+        constant_bandpass[FREQS > CAL_FREQS[-1]] = np.nan
         for n in range(len(ANTS)):
             for m in range(len(POLS)):
                 correction_sensor = calc_bandpass_correction(
                     product_sensor, (m, n), FREQS, CAL_FREQS)
-                assert_array_equal(correction_sensor[n],
-                                   np.ones(N_CHANS, dtype='complex64'))
+                assert_array_equal(correction_sensor[n], constant_bandpass)
                 assert_array_equal(correction_sensor[12 + n],
                                    bandpass_gains(m, n))
 

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -191,8 +191,8 @@ class TestComplexInterp(object):
     def test_left_right(self):
         # Extend yi[0] and yi[-1] at edges
         y = complex_interp(sorted(self.x), self.xi, self.yi)
-        assert_equal(y[0], self.yi[0])
-        assert_equal(y[-1], self.yi[-1])
+        assert_allclose(y[0], self.yi[0], rtol=1e-14)
+        assert_allclose(y[-1], self.yi[-1], rtol=1e-14)
         # Explicit edge values
         y = complex_interp(sorted(self.x), self.xi, self.yi, left=0, right=1j)
         assert_allclose(y[0], 0, rtol=1e-14)

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -82,11 +82,9 @@ def create_product(func):
     values = [func(pol, ant) for pol in pols for ant in ants]
     values = np.array(values)
     pol_ant = (len(pols), len(ants))
-    if values.ndim == 1:
-        return values.reshape(pol_ant)
-    else:
-        rest = values.shape[1:]
-        return np.moveaxis(values, 0, -1).reshape(rest + pol_ant)
+    # Pols, ants are final 2 dims; values shape (8, 128) becomes (128, 2, 4)
+    rest = values.shape[1:]
+    return np.moveaxis(values, 0, -1).reshape(rest + pol_ant)
 
 
 def create_sensor_cache():


### PR DESCRIPTION
The bandpass solutions are linearly interpolated from the cal frequencies onto the visibility frequencies, across any invalid channels with NaNs (unless all channels are bad). There is no
interpolation over time.

This still uses the complex interpolator introduced in ska-sa/katsdppipelines#117, but this will soon be reworked to operate on magnitude + unwrapped phase directly.