### PR TITLE
Make L1: apply to weights and flags and plumb it into v4

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -87,6 +87,17 @@ def complex_interp(x, xi, yi, left=None, right=None):
     return y.astype(yi.dtype)
 
 
+def has_cal_product(cache, attrs, product):
+    """Check if calibration solution `product` is available in `cache`."""
+    key = 'cal_product_' + product
+    try:
+        parts = int(attrs[key + '_parts'])
+    except KeyError:
+        return key in cache
+    else:
+        return all(key + str(part) in cache for part in range(parts))
+
+
 def get_cal_product(cache, attrs, product):
     """Extract calibration solution `product` from `cache` as a sensor.
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -29,7 +29,7 @@ from .categorical import CategoricalData, ComparableArrayWrapper
 from .spectral_window import SpectralWindow
 
 
-INVALID_GAIN = np.complex64(np.nan + 1j * np.nan)
+INVALID_GAIN = np.complex64(complex(np.nan, np.nan))
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -283,6 +283,19 @@ def apply_vis_correction(out, correction):
     out *= correction
 
 
+def apply_weights_correction(out, correction):
+    """Clean up and apply `correction` in-place to weight data in `out`."""
+    correction2 = correction.real ** 2 + correction.imag ** 2
+    correction2[np.isnan(correction2)] = np.inf
+    correction2[correction2 == 0] = np.inf
+    out /= correction2
+
+
+def apply_flags_correction(out, correction):
+    """Update flag data in `out` to True wherever `correction` is invalid."""
+    out[np.isnan(correction)] = True
+
+
 def add_applycal_transform(indexer, cache, corrprods, cal_products,
                            apply_correction):
     """Add transform to indexer that applies calibration corrections.

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -29,7 +29,10 @@ from .categorical import CategoricalData, ComparableArrayWrapper
 from .spectral_window import SpectralWindow
 
 
+# A constant indicating invalid / absent gain (typically due to flagged data)
 INVALID_GAIN = np.complex64(complex(np.nan, np.nan))
+# All the calibration products katdal knows about
+CAL_PRODUCTS = ('K', 'B', 'G')
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -21,7 +21,6 @@ from builtins import range, zip
 from functools import partial
 import copy
 import logging
-import threading
 
 import numpy as np
 import dask.array as da
@@ -36,7 +35,6 @@ INVALID_GAIN = np.complex64(complex(np.nan, np.nan))
 CAL_PRODUCTS = ('K', 'B', 'G')
 
 logger = logging.getLogger(__name__)
-cal_product_lock = threading.Lock()
 
 
 def complex_interp(x, xi, yi, left=None, right=None):
@@ -106,12 +104,6 @@ def get_cal_product(cache, attrs, product):
     This takes care of stitching together multiple parts of the product
     if this is indicated in the `attrs` dict.
     """
-    with cal_product_lock:
-        return _get_cal_product(cache, attrs, product)
-
-
-def _get_cal_product(cache, attrs, product):
-    """Extract calibration solution `product` from `cache` as a sensor."""
     key = 'cal_product_' + product
     try:
         n_parts = int(attrs[key + '_parts'])

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -21,6 +21,7 @@ from builtins import range, zip
 from functools import partial
 import copy
 import logging
+import threading
 
 import numpy as np
 import dask.array as da
@@ -35,6 +36,7 @@ INVALID_GAIN = np.complex64(complex(np.nan, np.nan))
 CAL_PRODUCTS = ('K', 'B', 'G')
 
 logger = logging.getLogger(__name__)
+cal_product_lock = threading.Lock()
 
 
 def complex_interp(x, xi, yi, left=None, right=None):
@@ -104,6 +106,12 @@ def get_cal_product(cache, attrs, product):
     This takes care of stitching together multiple parts of the product
     if this is indicated in the `attrs` dict.
     """
+    with cal_product_lock:
+        return _get_cal_product(cache, attrs, product)
+
+
+def _get_cal_product(cache, attrs, product):
+    """Extract calibration solution `product` from `cache` as a sensor."""
     key = 'cal_product_' + product
     try:
         parts = int(attrs[key + '_parts'])

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -16,10 +16,8 @@
 
 """Data accessor class for HDF5 files produced by KAT-7 correlator."""
 from __future__ import print_function, division, absolute_import
+from builtins import zip, range
 
-from builtins import zip
-from builtins import range
-from past.builtins import basestring
 import logging
 
 import numpy as np
@@ -28,7 +26,7 @@ import katpoint
 
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
-                      _robust_target)
+                      _robust_target, _selection_to_list)
 from .spectral_window import SpectralWindow
 from .sensordata import RecordSensorData, SensorCache, to_str
 from .categorical import CategoricalData, sensor_to_categorical
@@ -472,8 +470,7 @@ class H5DataV2(DataSet):
     def _weights_keep(self, names):
         known_weights = [row[0] for row in getattr(self, '_weights_description', [])]
         # Ensure a sequence of weight names
-        names = known_weights if names == 'all' else \
-            names.split(',') if isinstance(names, basestring) else names
+        names = _selection_to_list(names, all=known_weights)
         # Create index list for desired weights
         selection = []
         for name in names:
@@ -504,12 +501,7 @@ class H5DataV2(DataSet):
             return
         known_flags = [row[0] for row in self._flags_description]
         # Ensure `names` is a sequence of valid flag names (or an empty list)
-        if names == 'all':
-            names = known_flags
-        elif names == '':
-            names == []
-        elif isinstance(names, basestring):
-            names = names.split(',')
+        names = _selection_to_list(names, all=known_flags)
         # Create boolean list for desired flags
         selection = np.zeros(8, dtype=np.uint8)
         assert len(known_flags) == len(selection), \

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -16,12 +16,10 @@
 
 """Data accessor class for HDF5 files produced by RTS correlator."""
 from __future__ import print_function, division, absolute_import
-
 from future import standard_library
-standard_library.install_aliases()
-from builtins import zip
-from builtins import range
-from past.builtins import basestring
+standard_library.install_aliases()    # noqa: E402
+from builtins import zip, range
+
 import logging
 from collections import Counter
 
@@ -32,7 +30,7 @@ import katsdptelstate
 
 from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray,
                       DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
-                      _robust_target)
+                      _robust_target, _selection_to_list)
 from .spectral_window import SpectralWindow
 from .sensordata import (SensorCache, RecordSensorData,
                          H5TelstateSensorData, telstate_decode, to_str)
@@ -885,8 +883,7 @@ class H5DataV3(DataSet):
     def _weights_keep(self, names):
         known_weights = [row[0] for row in getattr(self, '_weights_description', [])]
         # Ensure a sequence of weight names
-        names = known_weights if names == 'all' else \
-            names.split(',') if isinstance(names, basestring) else names
+        names = _selection_to_list(names, all=known_weights)
         # Create index list for desired weights
         selection = []
         for name in names:
@@ -917,12 +914,7 @@ class H5DataV3(DataSet):
             return
         known_flags = [row[0] for row in self._flags_description]
         # Ensure `names` is a sequence of valid flag names (or an empty list)
-        if names == 'all':
-            names = known_flags
-        elif names == '':
-            names == []
-        elif isinstance(names, basestring):
-            names = names.split(',')
+        names = _selection_to_list(names, all=known_flags)
         # Create boolean list for desired flags
         selection = np.zeros(8, dtype=np.uint8)
         assert len(known_flags) == len(selection), \

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -28,11 +28,11 @@ from katdal.sensordata import SensorCache
 from katdal.categorical import ComparableArrayWrapper, CategoricalData
 from katdal.lazy_indexer import DaskLazyIndexer
 from katdal.applycal import (complex_interp, calc_correction_per_corrprod,
-                             get_cal_product, calc_delay_correction,
-                             calc_bandpass_correction, calc_gain_correction,
-                             add_applycal_sensors, add_applycal_transform,
-                             apply_vis_correction, apply_weights_correction,
-                             apply_flags_correction, INVALID_GAIN)
+                             has_cal_product, get_cal_product, INVALID_GAIN,
+                             calc_delay_correction, calc_bandpass_correction,
+                             calc_gain_correction, apply_vis_correction,
+                             apply_weights_correction, apply_flags_correction,
+                             add_applycal_sensors, add_applycal_transform)
 
 
 POLS = ['v', 'h']
@@ -237,10 +237,19 @@ class TestComplexInterp(object):
         assert_allclose(y[-1], 1j, rtol=1e-14)
 
 
-class TestGetCalProduct(object):
-    """Test the :func:`~katdal.applycal.get_cal_product` function."""
+class TestCalProductAccess(object):
+    """Test the :func:`~katdal.applycal.*_cal_product` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
+
+    def test_has_cal_product(self):
+        assert_equal(has_cal_product(self.cache, ATTRS, 'K'), True)
+        assert_equal(has_cal_product(self.cache, ATTRS, 'B'), True)
+        assert_equal(has_cal_product(self.cache, ATTRS, 'G'), True)
+        assert_equal(has_cal_product(self.cache, ATTRS, 'haha'), False)
+        # Remove one part of multi-part cal product
+        self.cache.pop('cal_product_B0')
+        assert_equal(has_cal_product(self.cache, ATTRS, 'B'), False)
 
     def test_get_cal_product_basic(self):
         product_sensor = get_cal_product(self.cache, ATTRS, 'K')

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -318,10 +318,15 @@ class TestVirtualCorrectionSensors(object):
         self.cache = create_sensor_cache()
         add_applycal_sensors(self.cache, ATTRS, FREQS)
 
-    def test_add_sensors_does_nothing_if_no_ants_or_pols(self):
+    def test_add_sensors_does_nothing_if_no_ants_pols_or_spw(self):
         cache = create_sensor_cache()
         n_virtuals_before = len(cache.virtual)
         add_applycal_sensors(cache, {}, [])
+        n_virtuals_after = len(cache.virtual)
+        assert_equal(n_virtuals_after, n_virtuals_before)
+        attrs = ATTRS.copy()
+        del attrs['cal_center_freq']
+        add_applycal_sensors(self.cache, attrs, FREQS)
         n_virtuals_after = len(cache.virtual)
         assert_equal(n_virtuals_after, n_virtuals_before)
 

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2018, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+"""Tests for :py:mod:`katdal.dataset`."""
+
+from __future__ import print_function, division, absolute_import
+
+from nose.tools import assert_equal
+
+from katdal.dataset import _selection_to_list
+
+
+def test_selection_to_list():
+    # Empty
+    assert_equal(_selection_to_list(''), [])
+    assert_equal(_selection_to_list([]), [])
+    # Names
+    assert_equal(_selection_to_list('a,b,c'), ['a', 'b', 'c'])
+    assert_equal(_selection_to_list('a, b,c'), ['a', 'b', 'c'])
+    assert_equal(_selection_to_list(['a', 'b', 'c']), ['a', 'b', 'c'])
+    assert_equal(_selection_to_list(('a', 'b', 'c')), ['a', 'b', 'c'])
+    assert_equal(_selection_to_list('a'), ['a'])
+    # Objects
+    assert_equal(_selection_to_list([1, 2, 3]), [1, 2, 3])
+    assert_equal(_selection_to_list(1), [1])
+    # Groups
+    assert_equal(_selection_to_list('all', all=['a', 'b']), ['a', 'b'])

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -33,7 +33,7 @@ from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, add_applycal_transform,
                        apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction)
+                       apply_flags_correction, CAL_PRODUCTS)
 
 
 logger = logging.getLogger(__name__)
@@ -105,9 +105,10 @@ class VisibilityDataV4(DataSet):
     applycal : string or sequence of strings, optional
         List of names of calibration products to apply to vis/weights/flags,
         as a sequence or string of comma-separated names. An empty string or
-        sequence means no calibration will be applied (the default for now).
-        *NB* In future the default will probably change to the opposite case:
-        apply all calibrations to get an L1 product by default.
+        sequence means no calibration will be applied (the default for now),
+        while the keyword 'all' means all available products will be applied.
+        *NB* In future the default will probably change to 'all'.
+        *NB* This is still very much an experimental feature...
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
 
@@ -302,7 +303,7 @@ class VisibilityDataV4(DataSet):
 
         freqs = self.spectral_windows[0].channel_freqs
         add_applycal_sensors(self.sensor, attrs, freqs)
-        self._applycal = _selection_to_list(applycal)
+        self._applycal = _selection_to_list(applycal, all=CAL_PRODUCTS)
 
         # Apply default selection and initialise all members that depend
         # on selection in the process

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -16,18 +16,17 @@
 
 """Data accessor class for data and metadata from various sources in v4 format."""
 from __future__ import print_function, division, absolute_import
+from builtins import zip, range
 
-from builtins import zip
-from builtins import range
-from past.builtins import basestring
 import logging
 
 import numpy as np
 import katpoint
 import dask.array as da
 
-from .dataset import (DataSet, BrokenFile, Subarray, _robust_target,
-                      DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS)
+from .dataset import (DataSet, BrokenFile, Subarray, DEFAULT_SENSOR_PROPS,
+                      DEFAULT_VIRTUAL_SENSORS, _robust_target,
+                      _selection_to_list)
 from .spectral_window import SpectralWindow
 from .sensordata import SensorCache
 from .categorical import CategoricalData
@@ -303,9 +302,7 @@ class VisibilityDataV4(DataSet):
 
         freqs = self.spectral_windows[0].channel_freqs
         add_applycal_sensors(self.sensor, attrs, freqs)
-        if isinstance(applycal, basestring):
-            applycal = applycal.split(',')
-        self._applycal = applycal
+        self._applycal = _selection_to_list(applycal)
 
         # Apply default selection and initialise all members that depend
         # on selection in the process
@@ -322,12 +319,7 @@ class VisibilityDataV4(DataSet):
     @_flags_keep.setter
     def _flags_keep(self, names):
         # Ensure `names` is a sequence of valid flag names (or an empty list)
-        if names == 'all':
-            names = FLAG_NAMES
-        elif names == '':
-            names == []
-        elif isinstance(names, basestring):
-            names = names.split(',')
+        names = _selection_to_list(names, all=FLAG_NAMES)
         # Create boolean list for desired flags
         selection = np.zeros(8, dtype=np.uint8)
         assert len(FLAG_NAMES) == len(selection), \

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -33,7 +33,7 @@ from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, add_applycal_transform,
                        apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction, get_cal_product, CAL_PRODUCTS)
+                       apply_flags_correction, has_cal_product, CAL_PRODUCTS)
 
 
 logger = logging.getLogger(__name__)
@@ -303,14 +303,8 @@ class VisibilityDataV4(DataSet):
 
         freqs = self.spectral_windows[0].channel_freqs
         add_applycal_sensors(self.sensor, attrs, freqs)
-        available_products = []
-        for product in CAL_PRODUCTS:
-            try:
-                get_cal_product(self.sensor, attrs, product)
-            except KeyError:
-                pass
-            else:
-                available_products.append(product)
+        available_products = [product for product in CAL_PRODUCTS
+                              if has_cal_product(self.sensor, attrs, product)]
         self._applycal = _selection_to_list(applycal, all=available_products)
 
         # Apply default selection and initialise all members that depend


### PR DESCRIPTION
Apply calibration corrections to weights and flags. The weights are divided by the magnitude squared of the corrections. The flags are set to True wherever the gains were invalid. This is
done after the flags are combined, on the boolean level (as opposed to the "raw" uint8 level). Ideally a new "cal_failure" flag type should be introduced instead, but that is left for a future PR.

Enable applycal upon opening a v4 data set, by listing the desired cal products to apply. This is disabled by default for now until the functionality has been thoroughly vetted.

There are still some issues with the final version running on real data, which seems to be due to the multi-threading introduced by the default dask scheduler. Adding a lock to `get_cal_product` seems to fix this, but I'm leaving that to another future investigation.

