### PR TITLE
Expose S3 bucket name on data source

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -194,12 +194,12 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
 
     Attributes
     ----------
-    prefix : string
-        Prefix of correlator_data / visibility array (i.e. the S3 bucket name)
+    vis_prefix : string
+        Prefix of correlator_data / visibility array, viz. its S3 bucket name
     """
     def __init__(self, store, chunk_info, corrprods):
         self.store = store
-        self.prefix = chunk_info['correlator_data']['prefix']
+        self.vis_prefix = chunk_info['correlator_data']['prefix']
         darray = {}
         has_arrays = []
         for array, info in chunk_info.items():
@@ -240,7 +240,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
                                         auto_indices=auto_indices, index1=index1, index2=index2)
             weights *= power_scale
 
-        VisFlagsWeights.__init__(self, vis, flags, weights, self.prefix)
+        VisFlagsWeights.__init__(self, vis, flags, weights, self.vis_prefix)
 
 
 class DataSource(object):

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -191,9 +191,15 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
         Correlation products. If given, the weights for baseline (inp1, inp2)
         will be divided by the square root of the product of the corresponding
         autocorrelations vis[inp1,inp1] and vis[inp2,inp2].
+
+    Attributes
+    ----------
+    prefix : string
+        Prefix of correlator_data / visibility array (i.e. the S3 bucket name)
     """
     def __init__(self, store, chunk_info, corrprods):
         self.store = store
+        self.prefix = chunk_info['correlator_data']['prefix']
         darray = {}
         has_arrays = []
         for array, info in chunk_info.items():
@@ -204,7 +210,6 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             has_arrays.append((store.has_array(array_name, info['chunks'], info['dtype']),
                                info['chunks']))
         vis = darray['correlator_data']
-        base_name = chunk_info['correlator_data']['prefix']
         flags_raw_name = store.join(chunk_info['flags']['prefix'], 'flags_raw')
         # Combine original flags with data_lost indicating where values were lost from
         # other arrays.
@@ -235,7 +240,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
                                         auto_indices=auto_indices, index1=index1, index2=index2)
             weights *= power_scale
 
-        VisFlagsWeights.__init__(self, vis, flags, weights, base_name)
+        VisFlagsWeights.__init__(self, vis, flags, weights, self.prefix)
 
 
 class DataSource(object):

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -157,7 +157,7 @@ class TestChunkStoreVisFlagsWeights(object):
                 os.remove(os.path.join(store.path, chunk_name) + '.npy')
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info, None)
         assert_equal(vfw.store, store)
-        assert_equal(vfw.prefix, prefix)
+        assert_equal(vfw.vis_prefix, prefix)
         # Check that (only) missing chunks have been replaced by zeros
         vis = data['correlator_data']
         for culled_slice in missing_chunks['correlator_data']:

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -156,6 +156,8 @@ class TestChunkStoreVisFlagsWeights(object):
                 chunk_name, shape = store.chunk_metadata(array_name, culled_slice)
                 os.remove(os.path.join(store.path, chunk_name) + '.npy')
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info, None)
+        assert_equal(vfw.store, store)
+        assert_equal(vfw.prefix, prefix)
         # Check that (only) missing chunks have been replaced by zeros
         vis = data['correlator_data']
         for culled_slice in missing_chunks['correlator_data']:


### PR DESCRIPTION
The `ChunkStoreVisFlagsWeights` class gains a `prefix` attribute
which corresponds to the S3 bucket name for the visibility data
(considered the main payload and therefore representative of the
data set). This aids the archive metadata extractor by removing the
need to scavenge around in `chunk_info`.

This addresses JIRA ticket SR-1401.