### PR TITLE
bugfix: open_data_source() swallowing an exception

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -614,4 +614,4 @@ def open_data_source(url, **kwargs):
             raise DataSourceNotFound(
                 '{} (add a URL scheme if {!r} is not meant to be a file)'
                 .format(err, url_parts.path))
-        raise err
+        raise

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -614,3 +614,4 @@ def open_data_source(url, **kwargs):
             raise DataSourceNotFound(
                 '{} (add a URL scheme if {!r} is not meant to be a file)'
                 .format(err, url_parts.path))
+        raise err


### PR DESCRIPTION
open_data_source() must not swallow DataSourceNotFound exception for URL's that don't have "file" protocol.