### PR TITLE
Fix attribute lookup regression on H5 files

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -608,7 +608,7 @@ class H5DataV3(DataSet):
             # needs to stay binary
             value = self.file['TelescopeState'].attrs[key]
             return telstate_decode(value, no_decode)
-        except katsdptelstate.DecodeError:
+        except (KeyError, katsdptelstate.DecodeError):
             # In some cases the value is placed in a sensor instead. Return
             # the most recent value.
             try:


### PR DESCRIPTION
If an attribute in an HDF5v3 data set is not found in the `attrs` section of the `TelescopeState group`, one should check the sensors as well.

When #196 introduced telstate-level decoding, UnpicklingErrors was replaced by DecodeErrors but unfortunately the KeyError in this except clause got lost in the process.

This addresses JIRA ticket SR-1503.