### PR TITLE
Add missing import of dask.sharedict

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -27,6 +27,7 @@ import io
 import numpy as np
 import dask
 import dask.array as da
+import dask.sharedict
 import toolz
 
 


### PR DESCRIPTION
In previous dask versions it was automatically imported, but now needs
to be imported explicitly. It is also deprecated in dask 1.1, but that's
a problem for another day.