### PR TITLE
Add max_dim_elements option to generate_chunks

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -51,18 +51,6 @@ def _floor_power_of_two(x):
     return 2 ** int(np.floor(np.log2(x)))
 
 
-def _generate_chunks_dim(length, chunk):
-    """Generate single-dimension chunk specification.
-
-    It splits `length` into pieces of length `chunk`, possibly with one
-    smaller chunk left over.
-    """
-    if length % chunk == 0:
-        return (chunk,) * (length // chunk)
-    else:
-        return (chunk,) * (length // chunk) + (length % chunk,)
-
-
 def generate_chunks(shape, dtype, max_chunk_size, dims_to_split=None,
                     power_of_two=False, max_dim_elements=None):
     """Generate dask chunk specification from ndarray parameters.
@@ -127,8 +115,7 @@ def generate_chunks(shape, dtype, max_chunk_size, dims_to_split=None,
         cur_elements = cur_elements // dim_elements[dim] * trg_size
         dim_elements[dim] = trg_size
 
-    chunks = tuple(_generate_chunks_dim(s, c) for s, c in zip(shape, dim_elements))
-    return chunks
+    return da.core.blockdims_from_blockshape(shape, dim_elements)
 
 
 def _add_offset_to_slices(func, offset):

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -75,16 +75,16 @@ class TestGenerateChunks(object):
                                  dims_to_split=(1, 0), power_of_two=True)
         assert_equal(chunks, ((10,), 60 * (512,), (144,)))
 
-    def test_max_chunk_sizes(self):
+    def test_max_dim_elements(self):
         chunks = generate_chunks(self.shape, self.dtype, 150000,
                                  dims_to_split=(0, 1), power_of_two=True,
-                                 max_chunk_sizes={1: 50})
+                                 max_dim_elements={1: 50})
         assert_equal(chunks, ((4, 4, 2), 256 * (32,), (144,)))
-        # Case where max_chunk_sizes forces chunks to be smaller than
+        # Case where max_dim_elements forces chunks to be smaller than
         # max_chunk_size.
         chunks = generate_chunks(self.shape, self.dtype, 1e6,
                                  dims_to_split=(0, 1), power_of_two=True,
-                                 max_chunk_sizes={0: 4, 1: 50})
+                                 max_dim_elements={0: 4, 1: 50})
         assert_equal(chunks, ((4, 4, 2), 256 * (32,), (144,)))
 
 

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -44,7 +44,7 @@ class TestGenerateChunks(object):
         assert_equal(chunks, (10 * (1,), (8192,), (144,)))
         # Uneven chunks in the final split
         chunks = generate_chunks(self.shape, self.dtype, 1e6)
-        assert_equal(chunks, (10 * (1,), 2 * (820,) + 8 * (819,), (144,)))
+        assert_equal(chunks, (10 * (1,), 10 * (819,) + (2,), (144,)))
 
     def test_corner_cases(self):
         # Corner case: don't select any dimensions to split -> one chunk
@@ -74,6 +74,18 @@ class TestGenerateChunks(object):
         chunks = generate_chunks(shape, self.dtype, self.nbytes / 10,
                                  dims_to_split=(1, 0), power_of_two=True)
         assert_equal(chunks, ((10,), 60 * (512,), (144,)))
+
+    def test_max_chunk_sizes(self):
+        chunks = generate_chunks(self.shape, self.dtype, 150000,
+                                 dims_to_split=(0, 1), power_of_two=True,
+                                 max_chunk_sizes={1: 50})
+        assert_equal(chunks, ((4, 4, 2), 256 * (32,), (144,)))
+        # Case where max_chunk_sizes forces chunks to be smaller than
+        # max_chunk_size.
+        chunks = generate_chunks(self.shape, self.dtype, 1e6,
+                                 dims_to_split=(0, 1), power_of_two=True,
+                                 max_chunk_sizes={0: 4, 1: 50})
+        assert_equal(chunks, ((4, 4, 2), 256 * (32,), (144,)))
 
 
 class TestChunkStore(object):

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -39,9 +39,6 @@ class TestGenerateChunks(object):
         # Basic check
         chunks = generate_chunks(self.shape, self.dtype, 3e6)
         assert_equal(chunks, (10 * (1,), 4 * (2048,), (144,)))
-        # Check that bad dims_to_split are ignored
-        chunks = generate_chunks(self.shape, self.dtype, 3e6, (0, 10))
-        assert_equal(chunks, (10 * (1,), (8192,), (144,)))
         # Uneven chunks in the final split
         chunks = generate_chunks(self.shape, self.dtype, 1e6)
         assert_equal(chunks, (10 * (1,), 10 * (819,) + (2,), (144,)))
@@ -86,6 +83,13 @@ class TestGenerateChunks(object):
                                  dims_to_split=(0, 1), power_of_two=True,
                                  max_dim_elements={0: 4, 1: 50})
         assert_equal(chunks, ((4, 4, 2), 256 * (32,), (144,)))
+
+    def test_max_dim_elements_ignore(self):
+        """Elements not in `dims_to_split` are ignored"""
+        chunks = generate_chunks(self.shape, self.dtype, 150000,
+                                 dims_to_split=(1, 17), power_of_two=True,
+                                 max_dim_elements={0: 2, 1: 50})
+        assert_equal(chunks, ((10,), 1024 * (8,), (144,)))
 
 
 class TestChunkStore(object):


### PR DESCRIPTION
This will help with the spectral vis writer, allowing the number of
channels to be limited.

The algorithm was changed to determine an (integral) chunk shape, and then
divide everything into chunks of that shape (with smaller left-overs at
the end).

The behaviour changes slightly: when not using power_of_two, the chunks
are now all the same size except the last which is smaller (like with
power_of_two), rather than having chunks of size X+1 and X. This
simplifies the code, and I don't think !power_of_two is being used much
if at all any more.