### PR TITLE
 Rework reference antenna to fix LST and ConcatenatedDataSet

### DIFF
--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -215,14 +215,9 @@ class VisibilityDataV4(DataSet):
             self.sensor[prefix + 'antenna'] = CategoricalData([ant], all_dumps)
             _add_sensor_alias(self.sensor, prefix + 'activity', ant.name + '_activity')
             _add_sensor_alias(self.sensor, prefix + 'target', ant.name + '_target')
-        # Extract array reference antenna from first antenna
-        array_ant = katpoint.Antenna(ants[0])
-        # Modify a copy of the first antenna in-place (don't trash ants[0])
-        array_ant.name = 'array'
-        array_ant.delay_model.set(None)
-        array_ant.pointing_model.set(None)
-        # Reconstitute the Antenna object to ensure internal consistency
-        array_ant = katpoint.Antenna(array_ant)
+        # Extract array reference from first antenna (first 5 fields of description)
+        array_ant_fields = ['array'] + ants[0].description.split(',')[1:5]
+        array_ant = katpoint.Antenna(','.join(array_ant_fields))
         # Cobble together "array" antenna sensors from various sources
         self.sensor['Antennas/array/antenna'] = CategoricalData(
             [array_ant], all_dumps)


### PR DESCRIPTION
This is a slight rework of the reference antenna machinery to fix
issues with DataSet.lst and a broken ConcatenatedDataSet.

Instead of leaving the `ref_ant` attribute empty in the default case,
explicitly set it to "array". This creates a fake antenna called "array"
with its own katpoint.Antenna object, target sensor and activity sensor.
The rest of the katdal sensor machinery in the base class can then
access the reference antenna properties (such as local sidereal time, or
LST) via the usual mechanisms. It also fixes the bug reported in
SR-1587. In the process, also set up target and activity sensor aliases
for the rest of the antennas to have a consistent view on these.

In the process, also fix a bug in the extraction of the array reference antenna
object, which ended up being just the first antenna in disguise.

This addresses JIRA ticket SR-1587.