### PR TITLE
Second round of applycal optimisations

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -235,15 +235,7 @@ from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2
 from .h5datav3 import H5DataV3
 from .visdatav4 import VisibilityDataV4
-
-
-# Clean up top-level namespace a bit
-_dataset, _concatdata, _sensordata = dataset, concatdata, sensordata
-_h5datav1, _h5datav2, _h5datav3 = h5datav1, h5datav2, h5datav3
-_categorical, _lazy_indexer = categorical, lazy_indexer
-_spectral_window, _visdatav4 = spectral_window, visdatav4
-del dataset, concatdata, sensordata, h5datav1, h5datav2, h5datav3
-del categorical, lazy_indexer, spectral_window, visdatav4
+from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
 
 
 # Setup library logger and add a print-like handler used when no logging is configured

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -235,7 +235,6 @@ from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2
 from .h5datav3 import H5DataV3
 from .visdatav4 import VisibilityDataV4
-from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
 
 
 # Setup library logger and add a print-like handler used when no logging is configured

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -392,7 +392,7 @@ class CorrectionParams(object):
         self.inputs = inputs
         self.input1_index = input1_index
         self.input2_index = input2_index
-        self.products = {}
+        self.products = products
 
 
 def calc_correction_per_corrprod(dump, channels, params):

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -439,14 +439,14 @@ def calc_correction_per_corrprod(dump, channels, params):
             g_per_input[n] *= g_product
     # Transpose to (channel, input) order, and ensure C ordering
     g_per_input = np.ascontiguousarray(g_per_input.T)
-    g_per_cp = np.empty((n_channels, len(params.input1_index)), np.complex64)
+    g_per_cp = np.empty((n_channels, len(params.input1_index)), dtype='complex64')
     _correction_inputs_to_corrprods(g_per_cp, g_per_input, params.input1_index, params.input2_index)
     return g_per_cp
 
 
 @numba.jit(nopython=True, nogil=True)
 def apply_vis_correction(data, correction):
-    """Clean up and apply `correction` visibility data in `data`."""
+    """Clean up and apply `correction` to visibility data in `data`."""
     out = np.empty_like(data)
     for i in range(out.shape[0]):
         for j in range(out.shape[1]):
@@ -477,7 +477,7 @@ def apply_weights_correction(data, correction):
 
 @numba.jit(nopython=True, nogil=True)
 def apply_flags_correction(data, correction):
-    """Update flag data to True wherever `correction` is invalid."""
+    """Set POSTPROC flag wherever `correction` is invalid."""
     out = np.copy(data)
     for i in range(out.shape[0]):
         for j in range(out.shape[1]):
@@ -536,7 +536,7 @@ def calc_correction(chunks, cache, corrprods, cal_products):
                 data = sensor
             products[product].append(data)
     params = CorrectionParams(inputs, input1_index, input2_index, products)
-
+    name = 'corrections[{}]'.format(','.join(cal_products))
     return from_block_function(
-        _correction_block, shape=shape, chunks=chunks, dtype=np.complex64, name='correction',
+        _correction_block, shape=shape, chunks=chunks, dtype=np.complex64, name=name,
         params=params)

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -31,6 +31,7 @@ import numba
 
 from .categorical import CategoricalData, ComparableArrayWrapper
 from .spectral_window import SpectralWindow
+from .flags import POSTPROC
 
 
 # A constant indicating invalid / absent gain (typically due to flagged data)
@@ -482,7 +483,7 @@ def apply_flags_correction(data, correction):
         for j in range(out.shape[1]):
             for k in range(out.shape[2]):
                 if np.isnan(correction[i, j, k]):
-                    out[i, j, k] |= 128      # TODO: give this flag a name
+                    out[i, j, k] |= POSTPROC
     return out
 
 

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -149,7 +149,7 @@ def weight_power_scale(block, auto_indices, index1, index2, out=None, tmp=None):
         (or any two dimensions then baseline). It must contain all the
         baselines of a stream.
     auto_indices, index1, index2 : np.ndarray
-        Arrays returned by :func:`corrprod_to_autocrr`
+        Arrays returned by :func:`corrprod_to_autocorr`
     out : np.ndarray, optional
         If specified, the output array, with same shape as `block` and dtype ``np.float32``
     tmp : np.ndarray, optional

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -35,6 +35,7 @@ import numba
 from .sensordata import TelstateSensorData, TelstateToStr
 from .chunkstore_s3 import S3ChunkStore
 from .chunkstore_npy import NpyFileChunkStore
+from .flags import DATA_LOST
 
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ def _apply_data_lost(orig_flags, lost, block_id):
         return orig_flags    # Common case - no data lost
     flags = orig_flags.copy()
     for idx in mark:
-        flags[idx] |= 8
+        flags[idx] |= DATA_LOST
     return flags
 
 

--- a/katdal/flags.py
+++ b/katdal/flags.py
@@ -16,16 +16,16 @@
 
 """Definitions of flag bits"""
 
-FLAG_NAMES = ('reserved0', 'static', 'cam', 'data_lost',
-              'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'postproc')
-FLAG_DESCRIPTIONS = ('reserved - bit 0',
-                     'predefined static flag list',
-                     'flag based on live CAM information',
-                     'no data was received',
-                     'RFI detected in ingest',
-                     'RFI predicted from space based pollutants',
-                     'RFI detected in calibration',
-                     'some correction/postprocessing step could not be applied')
+NAMES = ('reserved0', 'static', 'cam', 'data_lost',
+         'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'postproc')
+DESCRIPTIONS = ('reserved - bit 0',
+                'predefined static flag list',
+                'flag based on live CAM information',
+                'no data was received',
+                'RFI detected in ingest',
+                'RFI predicted from space based pollutants',
+                'RFI detected in calibration',
+                'some correction/postprocessing step could not be applied')
 
 STATIC_BIT = 1
 CAM_BIT = 2

--- a/katdal/flags.py
+++ b/katdal/flags.py
@@ -1,0 +1,44 @@
+################################################################################
+# Copyright (c) 2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Definitions of flag bits"""
+
+FLAG_NAMES = ('reserved0', 'static', 'cam', 'data_lost',
+              'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'postproc')
+FLAG_DESCRIPTIONS = ('reserved - bit 0',
+                     'predefined static flag list',
+                     'flag based on live CAM information',
+                     'no data was received',
+                     'RFI detected in ingest',
+                     'RFI predicted from space based pollutants',
+                     'RFI detected in calibration',
+                     'some correction/postprocessing step could not be applied')
+
+STATIC_BIT = 1
+CAM_BIT = 2
+DATA_LOST_BIT = 3
+INGEST_RFI_BIT = 4
+PREDICTED_RFI_BIT = 5
+CAL_RFI_BIT = 6
+POSTPROC_BIT = 7
+
+STATIC = 1 << STATIC_BIT
+CAM = 1 << CAM_BIT
+DATA_LOST = 1 << DATA_LOST_BIT
+INGEST_RFI = 1 << INGEST_RFI_BIT
+PREDICTED_RFI = 1 << PREDICTED_RFI_BIT
+CAL_RFI = 1 << CAL_RFI_BIT
+POSTPROC = 1 << POSTPROC_BIT

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -31,6 +31,7 @@ from .spectral_window import SpectralWindow
 from .sensordata import RecordSensorData, SensorCache, to_str
 from .categorical import CategoricalData, sensor_to_categorical
 from .lazy_indexer import LazyIndexer, LazyTransform
+from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -66,13 +67,6 @@ def _calc_azel(cache, name, ant):
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel, 'Antennas/{ant}/el': _calc_azel})
 
-FLAG_NAMES = ('reserved0', 'static', 'cam', 'reserved3', 'detected_rfi',
-              'predicted_rfi', 'reserved6', 'reserved7')
-FLAG_DESCRIPTIONS = ('reserved - bit 0', 'predefined static flag list',
-                     'flag based on live CAM information',
-                     'reserved - bit 3', 'RFI detected in the online system',
-                     'RFI predicted from space based pollutants',
-                     'reserved - bit 6', 'reserved - bit 7')
 WEIGHT_NAMES = ('precision',)
 WEIGHT_DESCRIPTIONS = ('visibility precision (inverse variance, i.e. 1 / sigma^2)',)
 

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -31,7 +31,7 @@ from .spectral_window import SpectralWindow
 from .sensordata import RecordSensorData, SensorCache, to_str
 from .categorical import CategoricalData, sensor_to_categorical
 from .lazy_indexer import LazyIndexer, LazyTransform
-from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
+from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -36,6 +36,7 @@ from .sensordata import (SensorCache, RecordSensorData,
                          H5TelstateSensorData, telstate_decode, to_str)
 from .categorical import CategoricalData
 from .lazy_indexer import LazyIndexer, LazyTransform
+from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -70,10 +71,6 @@ def _calc_azel(cache, name, ant):
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel, 'Antennas/{ant}/el': _calc_azel})
 
-FLAG_NAMES = ('reserved0', 'static', 'cam', 'data_lost', 'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'reserved7')
-FLAG_DESCRIPTIONS = ('reserved - bit 0', 'predefined static flag list', 'flag based on live CAM information',
-                     'no data was received', 'RFI detected in ingest', 'RFI predicted from space based pollutants',
-                     'RFI detected in calibration', 'reserved - bit 7')
 WEIGHT_NAMES = ('precision',)
 WEIGHT_DESCRIPTIONS = ('visibility precision (inverse variance, i.e. 1 / sigma^2)',)
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -36,7 +36,7 @@ from .sensordata import (SensorCache, RecordSensorData,
                          H5TelstateSensorData, telstate_decode, to_str)
 from .categorical import CategoricalData
 from .lazy_indexer import LazyIndexer, LazyTransform
-from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
+from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -32,6 +32,7 @@ from katdal.applycal import (complex_interp,
                              calc_gain_correction, apply_vis_correction,
                              apply_weights_correction, apply_flags_correction,
                              add_applycal_sensors, calc_correction)
+from katdal.flags import POSTPROC
 
 
 POLS = ['v', 'h']
@@ -434,5 +435,5 @@ class TestApplyCal(object):
     def test_applycal_flags(self):
         flags = np.random.randint(0, 128, (N_DUMPS, N_CHANS, N_CORRPRODS), np.uint8)
         calibrated_flags, corrections = self._applycal(flags, apply_flags_correction)
-        flags |= np.where(np.isnan(corrections), np.uint8(128), np.uint8(0))
+        flags |= np.where(np.isnan(corrections), np.uint8(POSTPROC), np.uint8(0))
         assert_array_equal(calibrated_flags, flags)

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -33,9 +33,7 @@ import katsdptelstate
 from katdal.chunkstore import generate_chunks
 from katdal.chunkstore_npy import NpyFileChunkStore
 from katdal.datasources import ChunkStoreVisFlagsWeights, TelstateDataSource, view_l0_capture_stream
-
-
-DATA_LOST = 8    # TODO: introduce katdal.flags module for these
+from katdal.flags import DATA_LOST
 
 
 def ramp(shape, offset=1.0, slope=1.0, dtype=np.float_):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -35,6 +35,7 @@ from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, calc_correction,
                        apply_vis_correction, apply_weights_correction,
                        apply_flags_correction, has_cal_product, CAL_PRODUCTS)
+from .flags import FLAG_NAMES, FLAG_DESCRIPTIONS
 
 
 logger = logging.getLogger(__name__)
@@ -80,17 +81,6 @@ def _add_sensor_alias(cache, new_name, old_name):
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
                         'Antennas/{ant}/el': _calc_azel})
-
-FLAG_NAMES = ('reserved0', 'static', 'cam', 'data_lost',
-              'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'postproc')
-FLAG_DESCRIPTIONS = ('reserved - bit 0',
-                     'predefined static flag list',
-                     'flag based on live CAM information',
-                     'no data was received',
-                     'RFI detected in ingest',
-                     'RFI predicted from space based pollutants',
-                     'RFI detected in calibration',
-                     'some correction/postprocessing step could not be applied')
 
 # -----------------------------------------------------------------------------
 # -- CLASS :  VisibilityDataV4

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -27,11 +27,12 @@ import dask.array as da
 from .dataset import (DataSet, BrokenFile, Subarray, DEFAULT_SENSOR_PROPS,
                       DEFAULT_VIRTUAL_SENSORS, _robust_target,
                       _selection_to_list)
+from .datasources import VisFlagsWeights
 from .spectral_window import SpectralWindow
 from .sensordata import SensorCache
 from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
-from .applycal import (add_applycal_sensors, add_applycal_transform,
+from .applycal import (add_applycal_sensors, calc_correction,
                        apply_vis_correction, apply_weights_correction,
                        apply_flags_correction, has_cal_product, CAL_PRODUCTS)
 
@@ -81,7 +82,7 @@ VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
                         'Antennas/{ant}/el': _calc_azel})
 
 FLAG_NAMES = ('reserved0', 'static', 'cam', 'data_lost',
-              'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'reserved7')
+              'ingest_rfi', 'predicted_rfi', 'cal_rfi', 'postproc')
 FLAG_DESCRIPTIONS = ('reserved - bit 0',
                      'predefined static flag list',
                      'flag based on live CAM information',
@@ -89,7 +90,7 @@ FLAG_DESCRIPTIONS = ('reserved - bit 0',
                      'RFI detected in ingest',
                      'RFI predicted from space based pollutants',
                      'RFI detected in calibration',
-                     'reserved - bit 7')
+                     'some correction/postprocessing step could not be applied')
 
 # -----------------------------------------------------------------------------
 # -- CLASS :  VisibilityDataV4
@@ -343,10 +344,25 @@ class VisibilityDataV4(DataSet):
         available_products = [product for product in CAL_PRODUCTS
                               if has_cal_product(self.sensor, attrs, product)]
         self._applycal = _selection_to_list(applycal, all=available_products)
+        if not self.source.data or not self._applycal:
+            self.correction = None
+            self._corrected = self.source.data
+        else:
+            self._correction = calc_correction(self.source.data.vis.chunks, self.sensor,
+                                               self.subarrays[self.subarray].corr_products,
+                                               self._applycal)
+            corrected_vis = self._make_corrected(apply_vis_correction, self.source.data.vis)
+            corrected_flags = self._make_corrected(apply_flags_correction, self.source.data.flags)
+            corrected_weights = self._make_corrected(apply_weights_correction, self.source.data.weights)
+            self._corrected = VisFlagsWeights(corrected_vis, corrected_flags, corrected_weights,
+                                              name='corrected')
 
         # Apply default selection and initialise all members that depend
         # on selection in the process
         self.select(spw=0, subarray=0, ants=obs_ants)
+
+    def _make_corrected(self, apply_correction, data):
+        return da.core.elemwise(apply_correction, data, self._correction, dtype=data.dtype)
 
     @property
     def _flags_keep(self):
@@ -411,15 +427,8 @@ class VisibilityDataV4(DataSet):
             stage1 = (self._time_keep, self._freq_keep, self._corrprod_keep)
             if update_all:
                 # Cache dask graphs for the data fields
-                self._vis = DaskLazyIndexer(self.source.data.vis, stage1)
-                self._weights = DaskLazyIndexer(self.source.data.weights, stage1)
-                if self._applycal:
-                    add_applycal_transform(self._vis, self.sensor,
-                                           self.corr_products, self._applycal,
-                                           apply_vis_correction)
-                    add_applycal_transform(self._weights, self.sensor,
-                                           self.corr_products, self._applycal,
-                                           apply_weights_correction)
+                self._vis = DaskLazyIndexer(self._corrected.vis, stage1)
+                self._weights = DaskLazyIndexer(self._corrected.weights, stage1)
             flag_transforms = []
             if ~self._flags_select != 0:
                 # Copy so that the lambda isn't affected by future changes
@@ -427,10 +436,6 @@ class VisibilityDataV4(DataSet):
                 flag_transforms.append(lambda flags: da.bitwise_and(select, flags))
             flag_transforms.append(lambda flags: flags.view(np.bool_))
             self._flags = DaskLazyIndexer(self.source.data.flags, stage1, flag_transforms)
-            if self._applycal:
-                add_applycal_transform(self._flags, self.sensor,
-                                       self.corr_products, self._applycal,
-                                       apply_flags_correction)
 
     @property
     def timestamps(self):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -345,8 +345,9 @@ class VisibilityDataV4(DataSet):
             corrected_flags = self._make_corrected(apply_flags_correction, self.source.data.flags)
             corrected_weights = self._make_corrected(apply_weights_correction, self.source.data.weights)
             name = self.source.data.name
-            if 'l0' in name:
-                name = name.replace('l0', 'l1')
+            # Acknowledge that the applycal step is making the L1 product
+            if 'sdp_l0' in name:
+                name = name.replace('sdp_l0', 'sdp_l1')
             else:
                 name = name + ' (corrected)'
             self._corrected = VisFlagsWeights(corrected_vis, corrected_flags, corrected_weights,

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -344,8 +344,13 @@ class VisibilityDataV4(DataSet):
             corrected_vis = self._make_corrected(apply_vis_correction, self.source.data.vis)
             corrected_flags = self._make_corrected(apply_flags_correction, self.source.data.flags)
             corrected_weights = self._make_corrected(apply_weights_correction, self.source.data.weights)
+            name = self.source.data.name
+            if 'l0' in name:
+                name = name.replace('l0', 'l1')
+            else:
+                name = name + ' (corrected)'
             self._corrected = VisFlagsWeights(corrected_vis, corrected_flags, corrected_weights,
-                                              name='corrected')
+                                              name=name)
 
         # Apply default selection and initialise all members that depend
         # on selection in the process
@@ -425,7 +430,7 @@ class VisibilityDataV4(DataSet):
                 select = self._flags_select.copy()
                 flag_transforms.append(lambda flags: da.bitwise_and(select, flags))
             flag_transforms.append(lambda flags: flags.view(np.bool_))
-            self._flags = DaskLazyIndexer(self._corrected_flags, stage1, flag_transforms)
+            self._flags = DaskLazyIndexer(self._corrected.flags, stage1, flag_transforms)
 
     @property
     def timestamps(self):

--- a/scripts/mvf_read_benchmark.py
+++ b/scripts/mvf_read_benchmark.py
@@ -6,9 +6,11 @@ import argparse
 import logging
 import time
 
+import dask
+import numpy as np
+
 import katdal
 from katdal.lazy_indexer import DaskLazyIndexer
-import numpy as np
 
 
 parser = argparse.ArgumentParser()
@@ -18,9 +20,12 @@ parser.add_argument('--channels', type=int, help='Number of channels to read')
 parser.add_argument('--dumps', type=int, help='Number of times to read')
 parser.add_argument('--joint', action='store_true', help='Load vis, weights, flags together')
 parser.add_argument('--applycal', help='Calibration solutions to apply')
+parser.add_argument('--workers', type=int, help='Number of dask workers')
 args = parser.parse_args()
 
 logging.basicConfig(level='INFO', format='%(asctime)s [%(levelname)s] %(message)s')
+if args.workers is not None:
+    dask.config.set(num_workers=args.workers)
 logging.info('Starting')
 kwargs = {}
 if args.applycal is not None:
@@ -31,6 +36,9 @@ if args.channels:
     f.select(channels=np.s_[:args.channels])
 if args.dumps:
     f.select(dumps=np.s_[:args.dumps])
+# Trigger creation of the dask graphs, population of sensor cache for applycal etc
+_ = (f.vis[0, 0, 0], f.weights[0, 0, 0], f.flags[0, 0, 0])
+logging.info('Selection complete')
 start = time.time()
 for st in range(0, f.shape[0], args.time):
     et = st + args.time


### PR DESCRIPTION
The main speedups come from
- Building a separate dask graph from the corrections, so that the calculations can be recycled when loading vis, flags, weights jointly.
- Expanding CategoricalData (for B and K) into Python lists of arrays, which can be indexed much faster. This does have the downside of extracting all cal sensors when the file is opened rather than lazily, but for now that's only going to happen if the user explicitly requested applycal and so it is presumably going to happen sooner or later.

A major change is that calibration solutions are now computed and applied prior to stage1 selection. This may be slower in some cases where not all the data is accessed e.g. if the user is only selecting a subset of inputs, the calibration correction will still be done on all inputs and baselines. On the other hand, it means we now have a distinct 'postproc' flag bit that can be selected.

I also implemented SR-1214, creating a katdal.flags module.