### PR TITLE
Eliminate use of deprecated dask constructs

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -262,9 +262,9 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             if len(weights.chunks[2]) > 1:
                 weights = weights.rechunk({2: weights.shape[2]})
             auto_indices, index1, index2 = corrprod_to_autocorr(corrprods)
-            weights = da.atop(weight_power_scale, 'ijk', vis, 'ijk', weights, 'ijk',
-                              dtype=np.float32,
-                              auto_indices=auto_indices, index1=index1, index2=index2)
+            weights = da.blockwise(weight_power_scale, 'ijk', vis, 'ijk', weights, 'ijk',
+                                   dtype=np.float32,
+                                   auto_indices=auto_indices, index1=index1, index2=index2)
 
         VisFlagsWeights.__init__(self, vis, flags, weights, self.vis_prefix)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ redis
 requests
 singledispatch
 six
-subprocess32==3.5.2     # katsdpdockerbase version refuses to install on Python 3
+subprocess32
 toolz
 urllib3
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py >= 2.3', 'numba',
-                        'katsdptelstate[rdb] >= 0.7', 'dask[array] >= 0.18.2',
+                        'katsdptelstate[rdb] >= 0.7', 'dask[array] >= 1.1.0',
                         'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
- Replace ShareDict with HighLevelGraph
- Replace da.atop with da.blockwise
- Unpin subprocess32 (not directly related)

This will first need dask>=1.1.0 to be put into katsdpdockerbase
defaults before it'll work.