### PR TITLE
Load RDB files straight from archive

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -646,8 +646,9 @@ class TelstateDataSource(DataSource):
             except katsdptelstate.ConnectionError as e:
                 raise DataSourceNotFound(str(e))
         elif u.scheme in {'http', 'https'}:
-            # Treat endpoint as an S3 object store (with auth info in kwargs)
-            store_url = (u.scheme, u.netloc, '', '', '', '')
+            # Treat URL prefix as an S3 object store (with auth info in kwargs)
+            store_path = os.path.dirname(os.path.dirname(u.path))
+            store_url = (u.scheme, u.netloc, store_path, '', '', '')
             store_url = urllib.parse.urlunparse(store_url)
             # Strip off parameters, query strings and fragments to get basic URL
             rdb_url = (u.scheme, u.netloc, u.path, '', '', '')

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -36,7 +36,7 @@ import numba
 from .sensordata import TelstateSensorData, TelstateToStr
 from .chunkstore_s3 import S3ChunkStore
 from .chunkstore_npy import NpyFileChunkStore
-from .chunkstore import StoreUnavailable
+from .chunkstore import StoreUnavailable, ChunkNotFound
 from .flags import DATA_LOST
 
 
@@ -622,49 +622,49 @@ class TelstateDataSource(DataSource):
         kwargs : dict, optional
             Extra keyword arguments passed to telstate view and chunk store init
         """
-        u = urllib.parse.urlparse(url, scheme='file')
+        url_parts = urllib.parse.urlparse(url, scheme='file')
         # Merge key-value pairs from URL query with keyword arguments
         # of function (the latter takes precedence)
-        url_kwargs = dict(urllib.parse.parse_qsl(u.query))
+        url_kwargs = dict(urllib.parse.parse_qsl(url_parts.query))
         url_kwargs.update(kwargs)
         kwargs = url_kwargs
         # Extract Redis database number if provided
         db = int(kwargs.pop('db', '0'))
-        if u.scheme == 'file':
+        if url_parts.scheme == 'file':
             # RDB dump file
             telstate = katsdptelstate.TelescopeState(katsdptelstate.memory.MemoryBackend())
             try:
-                telstate.load_from_file(u.path)
+                telstate.load_from_file(url_parts.path)
             except OSError as e:
                 raise DataSourceNotFound(str(e))
-        elif u.scheme == 'redis':
+        elif url_parts.scheme == 'redis':
             # Redis server
             try:
-                telstate = katsdptelstate.TelescopeState(u.netloc, db)
+                telstate = katsdptelstate.TelescopeState(url_parts.netloc, db)
             except katsdptelstate.ConnectionError as e:
                 raise DataSourceNotFound(str(e))
-        elif u.scheme in {'http', 'https'}:
+        elif url_parts.scheme in {'http', 'https'}:
             # Treat URL prefix as an S3 object store (with auth info in kwargs)
-            store_path = os.path.dirname(os.path.dirname(u.path))
-            store_url = (u.scheme, u.netloc, store_path, '', '', '')
+            store_path = os.path.dirname(os.path.dirname(url_parts.path))
+            store_url = (url_parts.scheme, url_parts.netloc, store_path, '', '', '')
             store_url = urllib.parse.urlunparse(store_url)
             # Strip off parameters, query strings and fragments to get basic URL
-            rdb_url = (u.scheme, u.netloc, u.path, '', '', '')
+            rdb_url = (url_parts.scheme, url_parts.netloc, url_parts.path, '', '', '')
             rdb_url = urllib.parse.urlunparse(rdb_url)
             telstate = katsdptelstate.TelescopeState(katsdptelstate.memory.MemoryBackend())
             try:
                 rdb_store = S3ChunkStore.from_url(store_url, **kwargs)
                 with rdb_store.request('', 'GET', rdb_url) as response:
                     telstate.load_from_file(io.BytesIO(response.content))
-            except StoreUnavailable as e:
+            except (StoreUnavailable, ChunkNotFound) as e:
                 raise DataSourceNotFound(str(e))
             if chunk_store == 'auto' and not kwargs.get('s3_endpoint_url'):
                 chunk_store = rdb_store
         telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate, **kwargs)
         if chunk_store == 'auto':
-            chunk_store = infer_chunk_store(u, telstate, **kwargs)
+            chunk_store = infer_chunk_store(url_parts, telstate, **kwargs)
         return cls(telstate, capture_block_id, stream_name, chunk_store,
-                   source_name=u.geturl(), upgrade_flags=upgrade_flags)
+                   source_name=url_parts.geturl(), upgrade_flags=upgrade_flags)
 
 
 def open_data_source(url, **kwargs):

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -633,7 +633,7 @@ class TelstateDataSource(DataSource):
         db = int(kwargs.pop('db', '0'))
         if url_parts.scheme == 'file':
             # RDB dump file
-            telstate = katsdptelstate.TelescopeState()
+            telstate = katsdptelstate.TelescopeState(katsdptelstate.memory.MemoryBackend())
             try:
                 telstate.load_from_file(url_parts.path)
             except OSError as err:
@@ -649,7 +649,7 @@ class TelstateDataSource(DataSource):
             endpoint = urllib.parse.urlunparse(url_parts[:2] + 4 * ('',))
             rdb_store = S3ChunkStore.from_url(endpoint, **kwargs)
             rdb_path = urllib.parse.urlunparse(url_parts[:3] + 3 * ('',))
-            telstate = katsdptelstate.TelescopeState()
+            telstate = katsdptelstate.TelescopeState(katsdptelstate.memory.MemoryBackend())
             with rdb_store.request('RDB', 'GET', rdb_path) as response:
                 telstate.load_from_file(io.BytesIO(response.content))
             if chunk_store == 'auto' and not kwargs.get('s3_endpoint_url'):

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -21,7 +21,7 @@ standard_library.install_aliases()  # noqa: 402
 from builtins import zip, object
 
 import urllib.parse
-import os
+import os.path
 import io
 import logging
 from collections import defaultdict
@@ -645,12 +645,10 @@ class TelstateDataSource(DataSource):
                 raise DataSourceNotFound(str(e))
         elif url_parts.scheme in {'http', 'https'}:
             # Treat URL prefix as an S3 object store (with auth info in kwargs)
-            store_path = os.path.dirname(os.path.dirname(url_parts.path))
-            store_url = (url_parts.scheme, url_parts.netloc, store_path, '', '', '')
-            store_url = urllib.parse.urlunparse(store_url)
+            store_url = urllib.parse.urljoin(url, '..')
             # Strip off parameters, query strings and fragments to get basic URL
-            rdb_url = (url_parts.scheme, url_parts.netloc, url_parts.path, '', '', '')
-            rdb_url = urllib.parse.urlunparse(rdb_url)
+            rdb_url = urllib.parse.urlunparse(
+                (url_parts.scheme, url_parts.netloc, url_parts.path, '', '', ''))
             telstate = katsdptelstate.TelescopeState(katsdptelstate.memory.MemoryBackend())
             try:
                 rdb_store = S3ChunkStore.from_url(store_url, **kwargs)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -450,12 +450,10 @@ def _upgrade_chunk_info(chunk_info, improved_chunk_info):
 def _align_chunk_info(chunk_info):
     """Inject phantom chunks to ensure all arrays have same number of dumps"""
     max_dumps = max(info['shape'][0] for info in chunk_info.values())
-    fill = False
     for key, info in chunk_info.items():
         shape = info['shape']
         n_dumps = shape[0]
         if n_dumps < max_dumps:
-            fill = True
             info['shape'] = (max_dumps,) + shape[1:]
             # We could just add a single new chunk, but that could cause an
             # inconveniently large chunk if there is a big difference between


### PR DESCRIPTION
If given an HTTP URL, interpret it as the location of an RDB dump file in an S3 object store. Use (or abuse) an S3ChunkStore object to access it, which handles the necessary authorization. Download the RDB object as a binary blob into memory and open it directly using the latest katsdptelstate. Then also use this S3ChunkStore as the actual chunk store in the absence of any overrides.

To enable the (ab)use of `S3ChunkStore`, upgrade the `_request` method to its public API by dropping the underscore.

This addresses JIRA ticket [SR-1443](https://skaafrica.atlassian.net/browse/SR-1443).