### PR TITLE
Retrieve raw sensor data from CAM katstore

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -505,8 +505,10 @@ def get_sensor_from_katstore(store, name, start_time, end_time):
             raise_from(err, exc)
         with response:
             try:
+                response.raise_for_status()
                 sensor_info = {rec[0]: rec[2] for rec in response.json()}
-            except (ValueError, IndexError, TypeError, KeyError) as exc:
+            except (ValueError, IndexError, TypeError, KeyError,
+                    requests.exceptions.RequestException) as exc:
                 err = RuntimeError("Could not retrieve sensor info from '%s' (%d: %s)" %
                                    (url, response.status_code, response.reason))
                 raise_from(err, exc)
@@ -526,9 +528,11 @@ def get_sensor_from_katstore(store, name, start_time, end_time):
             raise_from(err, exc)
         with response:
             try:
+                response.raise_for_status()
                 samples = [(rec[1], decode(rec[3]), rec[5])
                            for rec in response.json() if rec[4] == name]
-            except (ValueError, IndexError, TypeError, KeyError) as exc:
+            except (ValueError, IndexError, TypeError, KeyError,
+                    requests.exceptions.RequestException) as exc:
                 err = RuntimeError("Could not retrieve samples from '%s' (%d: %s)" %
                                    (url, response.status_code, response.reason))
                 raise_from(err, exc)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -44,6 +44,7 @@ import http.server
 import urllib.parse
 import contextlib
 import io
+import warnings
 
 import numpy as np
 from nose import SkipTest
@@ -101,7 +102,10 @@ class TestReadArray(object):
     def testV2(self):
         # Make dtype that needs more than 64K to store, forcing .npy version 2.0
         dtype = np.dtype([('a' * 70000, np.float32), ('b', np.float32)])
-        self._test(np.zeros(100, dtype))
+        with warnings.catch_warnings():
+            # Suppress warning that V2 files can only be read by numpy >= 1.9
+            warnings.simplefilter('ignore', category=UserWarning)
+            self._test(np.zeros(100, dtype))
 
     def testBadVersion(self):
         data = b'\x93NUMPY\x03\x04'     # Version 3.4

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -116,7 +116,7 @@ class VisibilityDataV4(DataSet):
 
     """
     def __init__(self, source, ref_ant='', time_offset=0.0, applycal='',
-                 **kwargs):
+                 sensor_store=None, **kwargs):
         DataSet.__init__(self, source.name, ref_ant, time_offset)
         attrs = source.metadata.attrs
 
@@ -140,7 +140,8 @@ class VisibilityDataV4(DataSet):
         # Assemble sensor cache
         self.sensor = SensorCache(source.metadata.sensors, source.timestamps,
                                   self.dump_period, self._time_keep,
-                                  SENSOR_PROPS, VIRTUAL_SENSORS, SENSOR_ALIASES)
+                                  SENSOR_PROPS, VIRTUAL_SENSORS, SENSOR_ALIASES,
+                                  sensor_store)
 
         # ------ Extract flags ------
 

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -111,6 +111,8 @@ class VisibilityDataV4(DataSet):
         while the keyword 'all' means all available products will be applied.
         *NB* In future the default will probably change to 'all'.
         *NB* This is still very much an experimental feature...
+    sensor_store : string, optional
+        Hostname / endpoint of katstore webserver to access additional sensors
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
 


### PR DESCRIPTION
If a sensor is not found in the `SensorCache`, look it up in the katstore central database if a store address is provided. Retrieve the historical sensor values in the time range of the data set.

I've only enabled v4 support for now as I don't know if earlier sensor data is still available with the same REST API.

Usage:

```Python
f = katdal.open('1543151779_sdp_l0.full.rdb', sensor_store='portal.mkat.karoo.kat.ac.za')
#  or: f.sensor.store = 'portal.mkat.karoo.kat.ac.za'
f.sensor.get('cbf_1_target')
```

This addresses JIRA ticket SR-1710.