### PR TITLE
Allow an expiration time for new buckets to be set

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -63,7 +63,7 @@ from .sensordata import to_str
 # ID at the same time).
 _BASE_LIFECYCLE_POLICY = """<?xml version="1.0" encoding="UTF-8"?>
 <LifecycleConfiguration><Rule>
-<ID>katdal_expiry_{0}_days</ID><Prefix></Prefix><Status>Enabled</Status>
+<ID>katdal_expiry_{0}_days</ID><Filter></Filter><Status>Enabled</Status>
 <Expiration><Days>{0}</Days></Expiration>
 </Rule></LifecycleConfiguration>"""
 

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -60,7 +60,7 @@ from .sensordata import to_str
 # Lifecycle policies unfortunately use XML encoding rather than JSON
 # Following path of least resistance we simply .format() this string
 # with the number of days for the expiry (and produced a sanitised
-# ID at the same time.
+# ID at the same time).
 _BASE_LIFECYCLE_POLICY = """<?xml version="1.0" encoding="UTF-8"?>
 <LifecycleConfiguration><Rule>
 <ID>katdal_expiry_{0}_days</ID><Prefix></Prefix><Status>Enabled</Status>
@@ -466,12 +466,10 @@ class S3ChunkStore(ChunkStore):
                 pass
 
         if self.expiry_days > 0:
-            lifecycle_url = urllib.parse.urljoin(url, '?lifecycle')
-            lifecycle = copy.deepcopy(_BASE_LIFECYCLE_POLICY)
-            xml_payload = lifecycle.format(self.expiry_days)
-            b64_md5 = base64.encodestring(hashlib.md5(xml_payload.encode('utf-8')).digest()).decode('utf-8')[:-1]
-            lifecycle_headers = {'Content-Type':'text/xml', 'Content-MD5': b64_md5}
-            with self.request(None, 'PUT', lifecycle_url, data=xml_payload, headers=lifecycle_headers):
+            xml_payload = _BASE_LIFECYCLE_POLICY.format(self.expiry_days)
+            b64_md5 = base64.b64encode(hashlib.md5(xml_payload.encode('utf-8')).digest()).decode('utf-8')
+            lifecycle_headers = {'Content-Type': 'text/xml', 'Content-MD5': b64_md5}
+            with self.request(None, 'PUT', url, params='lifecycle', data=xml_payload, headers=lifecycle_headers):
                 pass
 
     def put_chunk(self, array_name, slices, chunk):


### PR DESCRIPTION
This add an expiry_days parameter to the chunk store that is used
to create lifecycle policies for any new buckets the chunk store
makes.

Only allows integer days.