### PR TITLE
Include lifecycle policy tests

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -37,6 +37,9 @@ class ChunkStoreError(Exception):
 class StoreUnavailable(OSError, ChunkStoreError):
     """Could not access underlying storage medium (offline, auth failed, etc)."""
 
+class NotSupported(ChunkStoreError):
+    """The underlying store does not support the requested operation
+    (e.g. minio doesn't support lifecycle policies on buckets)"""
 
 class ChunkNotFound(KeyError, ChunkStoreError):
     """The store was accessible but a chunk with the given name was not found."""

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -37,9 +37,11 @@ class ChunkStoreError(Exception):
 class StoreUnavailable(OSError, ChunkStoreError):
     """Could not access underlying storage medium (offline, auth failed, etc)."""
 
+
 class NotSupported(ChunkStoreError):
     """The underlying store does not support the requested operation
     (e.g. minio doesn't support lifecycle policies on buckets)"""
+
 
 class ChunkNotFound(KeyError, ChunkStoreError):
     """The store was accessible but a chunk with the given name was not found."""

--- a/katdal/schemas/__init__.py
+++ b/katdal/schemas/__init__.py
@@ -4,22 +4,27 @@ from lxml import etree
 
 import pkg_resources
 
-#def _make_validator(schema):
-#    """Check a schema document and create a validator from it"""
-#    validator_cls = jsonschema.validators.validator_for(schema)
-#    validator_cls.check_schema(schema)
-#    return validator_cls(schema, format_checker=jsonschema.FormatChecker())
-
 
 class ValidatorWithLog(object):
     def __init__(self, validator):
         self.validator = validator
 
     def validate(self, xml_string):
-        """Validates a supplied XML string against
-        the instantiated validator.
-        Failure to validate will raise DocumentInvalid
-        with the output of the error log."""
+        """Validates a supplied XML string against the instantiated validator.
+
+        Parameters
+        ---------
+        xml_string : str
+            String representation of the XML to be turned into a document
+            and validated.
+
+        Raises
+        ------
+        etree.DocumentInvalid
+            if `xml_string` does not validate against the XSD schema
+        ValueError
+            if `xml_string` cannot be parsed into a valid XML document
+        """
         try:
             xml_doc = etree.fromstring(bytes(bytearray(xml_string, encoding='utf-8')))
         except etree.XMLSyntaxError as e:
@@ -29,11 +34,9 @@ class ValidatorWithLog(object):
             raise etree.DocumentInvalid(log.last_error)
         return True
 
+
 for name in pkg_resources.resource_listdir(__name__, '.'):
     if name.endswith('.xsd'):
-        #with open(pkg_resources.resource_stream(__name__, name)) as f:
         xmlschema_doc = etree.parse(pkg_resources.resource_stream(__name__, name))
         xml_validator = etree.XMLSchema(xmlschema_doc)
-        #reader = codecs.getreader('utf-8')(pkg_resources.resource_stream(__name__, name))
-        #schema = json.load(reader)
-        globals()[name[:-4].upper()] = ValidatorWithLog(xml_validator) #_make_validator(schema)
+        globals()[name[:-4].upper()] = ValidatorWithLog(xml_validator)

--- a/katdal/schemas/__init__.py
+++ b/katdal/schemas/__init__.py
@@ -1,0 +1,39 @@
+"""Makes packaged XSD schemas available as validators."""
+
+from lxml import etree
+
+import pkg_resources
+
+#def _make_validator(schema):
+#    """Check a schema document and create a validator from it"""
+#    validator_cls = jsonschema.validators.validator_for(schema)
+#    validator_cls.check_schema(schema)
+#    return validator_cls(schema, format_checker=jsonschema.FormatChecker())
+
+
+class ValidatorWithLog(object):
+    def __init__(self, validator):
+        self.validator = validator
+
+    def validate(self, xml_string):
+        """Validates a supplied XML string against
+        the instantiated validator.
+        Failure to validate will raise DocumentInvalid
+        with the output of the error log."""
+        try:
+            xml_doc = etree.fromstring(bytes(bytearray(xml_string, encoding='utf-8')))
+        except etree.XMLSyntaxError as e:
+            raise ValueError(e)
+        if not self.validator.validate(xml_doc):
+            log = self.validator.error_log
+            raise etree.DocumentInvalid(log.last_error)
+        return True
+
+for name in pkg_resources.resource_listdir(__name__, '.'):
+    if name.endswith('.xsd'):
+        #with open(pkg_resources.resource_stream(__name__, name)) as f:
+        xmlschema_doc = etree.parse(pkg_resources.resource_stream(__name__, name))
+        xml_validator = etree.XMLSchema(xmlschema_doc)
+        #reader = codecs.getreader('utf-8')(pkg_resources.resource_stream(__name__, name))
+        #schema = json.load(reader)
+        globals()[name[:-4].upper()] = ValidatorWithLog(xml_validator) #_make_validator(schema)

--- a/katdal/schemas/minimal_lifecycle_policy.xsd
+++ b/katdal/schemas/minimal_lifecycle_policy.xsd
@@ -1,0 +1,38 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="LifecycleConfiguration">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Rule" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="ID"/>
+              <xs:element name="Filter">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="Prefix" minOccurs="0"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element type="xs:string" name="Status"/>
+              <xs:element name="Transition" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:short" name="Days"/>
+                    <xs:element type="xs:string" name="StorageClass"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="Expiration">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:short" name="Days"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
We can't test expiry directly, firstly because minio doesn't support lifecycle polices, and secondly because the minimum expiry time is 1 day.

This basically just test the infrastructure and that the schema for the policy is created correctly.
