### PR TITLE
Use features introduced in katsdptelstate v0.8

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -296,11 +296,11 @@ class TelstateToStr(object):
         return TelstateToStr(self._telstate.root())
 
     def keys(self, filter='*'):
-        return to_str(self._telstate.keys(filter))
+        return self._telstate.keys(filter)
 
     @property
     def prefixes(self):
-        return to_str(self._telstate.prefixes)
+        return self._telstate.prefixes
 
     def __getattr__(self, key):
         # __getattr__ can be used for item access or to get a property of the

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -295,16 +295,8 @@ class TelstateToStr(object):
     def root(self):
         return TelstateToStr(self._telstate.root())
 
-    def keys(self, filter='*'):
-        return self._telstate.keys(filter)
-
-    @property
-    def prefixes(self):
-        return self._telstate.prefixes
-
     def __getattr__(self, key):
-        # __getattr__ can be used for item access or to get a property of the
-        # class.
+        # __getattr__ can be used for item access or to get attributes of _telstate
         if hasattr(self._telstate.__class__, key):
             return getattr(self._telstate, key)
         else:
@@ -313,6 +305,13 @@ class TelstateToStr(object):
     def __contains__(self, key):
         # Needed because __getattr__ won't pick it up from child
         return key in self._telstate
+
+    def __dir__(self):
+        # Include public attributes of _telstate that are reachable via __getattr__
+        basic = super(TelstateToStr, self).__dir__()
+        extra = [d for d in dir(self._telstate)
+                 if d not in basic and not d.startswith('_')]
+        return basic + extra
 
     def __getitem__(self, key):
         return to_str(self._telstate[key])

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -308,7 +308,7 @@ class TelstateToStr(object):
 
     def __dir__(self):
         # Include public attributes of _telstate that are reachable via __getattr__
-        basic = super(TelstateToStr, self).__dir__()
+        basic = dir(super(TelstateToStr, self))
         extra = [d for d in dir(self._telstate)
                  if d not in basic and not d.startswith('_')]
         return basic + extra

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -85,7 +85,7 @@ def put_fake_dataset(store, prefix, shape, chunk_overrides=None, array_overrides
 
 def _make_fake_stream(telstate, store, cbid, stream, shape,
                       chunk_overrides=None, array_overrides=None, flags_only=False):
-    telstate_prefix = telstate.SEPARATOR.join((cbid, stream))
+    telstate_prefix = telstate.join(cbid, stream)
     store_prefix = telstate_prefix.replace('_', '-')
     data, chunk_info = put_fake_dataset(store, store_prefix, shape,
                                         chunk_overrides=chunk_overrides, array_overrides=array_overrides,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ docutils
 enum34
 funcsigs
 jmespath
-fakeredis
 future
 h5py
 idna

--- a/scripts/mvf_rechunk.py
+++ b/scripts/mvf_rechunk.py
@@ -20,7 +20,6 @@ import dask
 import dask.array as da
 
 from katdal.chunkstore import ChunkStoreError
-from katdal.chunkstore_s3 import S3ChunkStore
 from katdal.chunkstore_npy import NpyFileChunkStore
 from katdal.datasources import TelstateDataSource, view_capture_stream, infer_chunk_store
 from katdal.flags import DATA_LOST
@@ -214,8 +213,8 @@ def main():
     url_parts = urllib.parse.urlparse(args.source, scheme='file')
     dest_file = os.path.join(args.dest, args.new_prefix or cbid, os.path.basename(url_parts.path))
     os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-    writer = RDBWriter(client=telstate.backend)
-    writer.save(dest_file)
+    with RDBWriter(dest_file) as writer:
+        writer.save(telstate)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'h5py >= 2.3', 'numba',
-                        'katsdptelstate[rdb] >= 0.7', 'dask[array] >= 1.1.0',
+                        'katsdptelstate[rdb] >= 0.8', 'dask[array] >= 1.1.0',
                         'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
The memory backend is now the default - no need to specify it.
Use the `TelescopeState.join` helper method instead of invoking the
namespace separator itself. Catch RdbParseError to improve error
reporting. Since `keys` and `prefixes` already return native strings
there is no need to override them in `TelstateToStr`. The RDBWriter
has been reworked. Remove fakeredis from package requirements.