### PR TITLE
Restore chunk store inference from RDB URL

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -655,6 +655,10 @@ class TelstateDataSource(DataSource):
                     telstate.load_from_file(io.BytesIO(response.content))
             except ChunkStoreError as e:
                 raise DataSourceNotFound(str(e))
+            # If the RDB file is opened via archive URL, use that URL and
+            # corresponding S3 credentials or token to access the chunk store
+            if chunk_store == 'auto' and not kwargs.get('s3_endpoint_url'):
+                chunk_store = rdb_store
         else:
             raise DataSourceNotFound("Unknown URL scheme '{}' - telstate expects "
                                      "file, redis, or http(s)".format(url_parts.scheme))


### PR DESCRIPTION
If the RDB file is opened via archive URL, use that URL and
corresponding S3 credentials or token to access the chunk store. This
has been decreed since it is the expected behaviour 99% of the time.
On-site chunk stores will be accessed via whitelists only, thereby not
requiring credentials or tokens, which removes the concern that
prevented this shortcut. Overrides are still possible via URL parameters
(and separate RDB retrieval) for custom use cases.

This reverts the change in commit 98cbc8a and addresses JIRA ticket
[SR-1443](https://skaafrica.atlassian.net/browse/SR-1443).