### PR TITLE
Speed up (u, v, w) calculations

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -238,8 +238,8 @@ def _calc_uvw_basis(cache, name, ant):
     for segm, target in targets.segments():
         basis = target.uvw_basis(cache.timestamps[segm], antenna)
         u[segm], v[segm], w[segm] = basis.transpose(0, 2, 1)
-    new_sensors = {ant_group + 'u_basis': u, ant_group + 'v_basis': v,
-                   ant_group + 'w_basis': w}
+    new_sensors = {ant_group + 'basis_u': u, ant_group + 'basis_v': v,
+                   ant_group + 'basis_w': w}
     cache.update(new_sensors)
     return new_sensors[name]
 
@@ -249,7 +249,7 @@ def _calc_uvw_per_ant(cache, name, ant):
     array_ant_group = 'Antennas/array/'
     array_antenna = cache.get(array_ant_group + 'antenna')[0]
     antenna = cache.get('Antennas/%s/antenna' % (ant,))[0]
-    basis = cache.get('%s%s_basis' % (array_ant_group, name[-1]))
+    basis = cache.get('%sbasis_%s' % (array_ant_group, name[-1]))
     # Obtain baseline vector from array reference to specified antenna
     baseline_m = array_antenna.baseline_toward(antenna)
     coord = np.tensordot(basis, baseline_m, ([1], [0]))
@@ -271,7 +271,7 @@ DEFAULT_VIRTUAL_SENSORS = {
     'Antennas/{ant}/ra': _calc_radec, 'Antennas/{ant}/dec': _calc_radec,
     'Antennas/{ant}/parangle': _calc_parangle,
     'Antennas/{ant}/target_[xy]_{projection}_{coordsys}': _calc_target_coords,
-    'Antennas/{ant}/[uvw]_basis': _calc_uvw_basis,
+    'Antennas/{ant}/basis_[uvw]': _calc_uvw_basis,
     'Antennas/{ant}/[uvw]': _calc_uvw_per_ant,
     'Corrprods/{antA}/{antB}/[uvw]': _calc_uvw_per_corrprod,
 }

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -1036,8 +1036,13 @@ class DataSet(object):
         return np.column_stack([sensor_data(ant.name) for ant in self.ants]) \
             if self.ants else np.zeros((self.shape[0], 0))
 
-    def _sensor_per_corrprod(self, base_name):
-        """Extract a single sensor per corrprod and safely stack the results."""
+    def _delta_sensor_per_corrprod(self, base_name):
+        """Extract a single sensor per corrprod and safely stack the results.
+
+        The sensor is specialised to return the difference between the sensors
+        of the two antennas making up the correlation product, since that is
+        what (u, v, w) sensors need.
+        """
         def difference(antA, antB):
             coord1 = self.sensor['Antennas/%s/%s' % (antA, base_name)]
             coord2 = self.sensor['Antennas/%s/%s' % (antB, base_name)]
@@ -1139,7 +1144,7 @@ class DataSet(object):
         convention is :math:`u_1 - u_2` for baseline (ant1, ant2).
 
         """
-        return self._sensor_per_corrprod('u')
+        return self._delta_sensor_per_corrprod('u')
 
     @property
     def v(self):
@@ -1151,7 +1156,7 @@ class DataSet(object):
         convention is :math:`v_1 - v_2` for baseline (ant1, ant2).
 
         """
-        return self._sensor_per_corrprod('v')
+        return self._delta_sensor_per_corrprod('v')
 
     @property
     def w(self):
@@ -1163,4 +1168,4 @@ class DataSet(object):
         convention is :math:`w_1 - w_2` for baseline (ant1, ant2).
 
         """
-        return self._sensor_per_corrprod('w')
+        return self._delta_sensor_per_corrprod('w')

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -246,10 +246,9 @@ def _calc_uvw_basis(cache, name, ant):
 
 def _calc_uvw_per_ant(cache, name, ant):
     """Calculate (u,v,w) coordinates per antenna using sensor cache contents."""
-    array_ant_group = 'Antennas/array/'
-    array_antenna = cache.get(array_ant_group + 'antenna')[0]
+    array_antenna = cache.get('Antennas/array/antenna')[0]
     antenna = cache.get('Antennas/%s/antenna' % (ant,))[0]
-    basis = cache.get('%sbasis_%s' % (array_ant_group, name[-1]))
+    basis = cache.get('Antennas/array/basis_' + name[-1])
     # Obtain baseline vector from array reference to specified antenna
     baseline_m = array_antenna.baseline_toward(antenna)
     coord = np.tensordot(basis, baseline_m, ([1], [0]))

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -236,7 +236,9 @@ def _calc_uvw_basis(cache, name, ant):
     w = np.empty((len(cache.timestamps), 3))
     targets = cache.get('Observation/target')
     for segm, target in targets.segments():
+        # The basis is a series of 3x3 matrices converting ENU to UVW
         basis = target.uvw_basis(cache.timestamps[segm], antenna)
+        # Basis has shape (3, 3, T) which we split into 3 sensors of shape (T, 3)
         u[segm], v[segm], w[segm] = basis.transpose(0, 2, 1)
     new_sensors = {ant_group + 'basis_u': u, ant_group + 'basis_v': v,
                    ant_group + 'basis_w': w}
@@ -251,7 +253,7 @@ def _calc_uvw_per_ant(cache, name, ant):
     basis = cache.get('Antennas/array/basis_' + name[-1])
     # Obtain baseline vector from array reference to specified antenna
     baseline_m = array_antenna.baseline_toward(antenna)
-    coord = np.tensordot(basis, baseline_m, ([1], [0]))
+    coord = basis.dot(baseline_m)
     cache[name] = coord
     return coord
 

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -198,6 +198,10 @@ class H5DataV1(DataSet):
         # Store antenna objects in sensor cache too, for use in virtual sensor calculations
         for ant in ants:
             self.sensor['Antennas/%s/antenna' % (ant.name,)] = CategoricalData([ant], [0, len(data_timestamps)])
+        # Extract array reference from first antenna (first 5 fields of description)
+        array_ant_fields = ['array'] + ants[0].description.split(',')[1:5]
+        array_ant = katpoint.Antenna(','.join(array_ant_fields))
+        self.sensor['Antennas/array/antenna'] = CategoricalData([array_ant], [0, len(data_timestamps)])
 
         # ------ Extract spectral windows / frequencies ------
 

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -297,6 +297,10 @@ class H5DataV2(DataSet):
         # Store antenna objects in sensor cache too, for use in virtual sensor calculations
         for ant in ants:
             self.sensor['Antennas/%s/antenna' % (ant.name,)] = CategoricalData([ant], [0, len(data_timestamps)])
+        # Extract array reference from first antenna (first 5 fields of description)
+        array_ant_fields = ['array'] + ants[0].description.split(',')[1:5]
+        array_ant = katpoint.Antenna(','.join(array_ant_fields))
+        self.sensor['Antennas/array/antenna'] = CategoricalData([array_ant], [0, len(data_timestamps)])
 
         # ------ Extract spectral windows / frequencies ------
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -422,6 +422,10 @@ class H5DataV3(DataSet):
         # Store antenna objects in sensor cache too, for use in virtual sensor calculations
         for ant in ants:
             self.sensor['Antennas/%s/antenna' % (ant.name,)] = CategoricalData([ant], [0, num_dumps])
+        # Extract array reference from first antenna (first 5 fields of description)
+        array_ant_fields = ['array'] + ants[0].description.split(',')[1:5]
+        array_ant = katpoint.Antenna(','.join(array_ant_fields))
+        self.sensor['Antennas/array/antenna'] = CategoricalData([array_ant], [0, num_dumps])
 
         # ------ Extract spectral windows / frequencies ------
 

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -139,10 +139,13 @@ class TestVirtualSensors(object):
     def test_uvw(self):
         u, v, w = self.target.uvw(self.antennas[0], self.timestamps,
                                   self.antennas[1])
-        assert_array_equal(self.dataset.u[:, 4], u)
-        assert_array_equal(self.dataset.v[:, 4], v)
-        assert_array_equal(self.dataset.w[:, 4], w)
+        # The answers now differ because the target direction is calculated once
+        # from the array reference instead of from one of the dishes in each
+        # correlation product pair (the whole reason for the speed-up!)
+        assert_array_almost_equal(self.dataset.u[:, 4], u, decimal=2)
+        assert_array_almost_equal(self.dataset.v[:, 4], v, decimal=2)
+        assert_array_almost_equal(self.dataset.w[:, 4], w, decimal=2)
         # Check that both H and V polarisations have the same (u, v, w)
-        assert_array_equal(self.dataset.u[:, 5], u)
-        assert_array_equal(self.dataset.v[:, 5], v)
-        assert_array_equal(self.dataset.w[:, 5], w)
+        assert_array_almost_equal(self.dataset.u[:, 5], u, decimal=2)
+        assert_array_almost_equal(self.dataset.v[:, 5], v, decimal=2)
+        assert_array_almost_equal(self.dataset.w[:, 5], w, decimal=2)

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -137,15 +137,15 @@ class TestVirtualSensors(object):
         assert_array_equal(self.dataset.target_y[:, 1], rad2deg(y))
 
     def test_uvw(self):
-        u, v, w = self.target.uvw(self.antennas[0], self.timestamps,
-                                  self.antennas[1])
-        # The answers now differ because the target direction is calculated once
-        # from the array reference instead of from one of the dishes in each
-        # correlation product pair (the whole reason for the speed-up!)
-        assert_array_almost_equal(self.dataset.u[:, 4], u, decimal=2)
-        assert_array_almost_equal(self.dataset.v[:, 4], v, decimal=2)
-        assert_array_almost_equal(self.dataset.w[:, 4], w, decimal=2)
+        u0, v0, w0 = self.target.uvw(self.antennas[0], self.timestamps, self.array_ant)
+        u1, v1, w1 = self.target.uvw(self.antennas[1], self.timestamps, self.array_ant)
+        u = u0 - u1
+        v = v0 - v1
+        w = w0 - w1
+        assert_array_equal(self.dataset.u[:, 4], u)
+        assert_array_equal(self.dataset.v[:, 4], v)
+        assert_array_equal(self.dataset.w[:, 4], w)
         # Check that both H and V polarisations have the same (u, v, w)
-        assert_array_almost_equal(self.dataset.u[:, 5], u, decimal=2)
-        assert_array_almost_equal(self.dataset.v[:, 5], v, decimal=2)
-        assert_array_almost_equal(self.dataset.w[:, 5], w, decimal=2)
+        assert_array_equal(self.dataset.u[:, 5], u)
+        assert_array_equal(self.dataset.v[:, 5], v)
+        assert_array_equal(self.dataset.w[:, 5], w)


### PR DESCRIPTION
This brings the `katdal.DataSet` (u, v, w) calculations in line with the rest of the ecosystem (`mvftoms`, `katsdpcal`, `katsdpimager`, ... thanks @bmerry!).

The speed-up is on the order of the number of baselines, measuring about 500x on a dataset with 60 antennas (1542913317). The accuracy was still to be verified in JIRA SR-1883, but since this has been in use since at least April 2018 in MSes produced by katdal and verified by Tom on PKS 1934-638, we can lay that part to rest.

One caveat is that this will break (u, v, w) on older MVF formats before v4 that do not yet define an 'array' antenna. We'll need to remedy that still.

This addresses JIRA ticket SR-1509 (and SR-1640).
