### PR TITLE
Make L2: preparations

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -16,17 +16,11 @@
 
 """Utilities for applying calibration solutions to visibilities and weights."""
 from __future__ import print_function, division, absolute_import
-from builtins import range, zip
 
 import logging
-import itertools
-import operator
 
 import numpy as np
 import dask.array as da
-import dask.base
-import dask.utils
-import toolz
 import numba
 
 from .categorical import CategoricalData, ComparableArrayWrapper
@@ -397,7 +391,8 @@ def calc_correction(chunks, cache, corrprods, cal_products):
             products[product].append(data)
     params = CorrectionParams(inputs, input1_index, input2_index, products)
     name = 'corrections[{}]'.format(','.join(cal_products))
-    return da.map_blocks(_correction_block, chunks=chunks, dtype=np.complex64, params=params)
+    return da.map_blocks(_correction_block, dtype=np.complex64, chunks=chunks,
+                         name=name, params=params)
 
 
 @numba.jit(nopython=True, nogil=True)

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -109,7 +109,7 @@ def get_cal_product(cache, attrs, product_type, cal_stream='cal'):
     product_type : string
         Calibration product type (e.g. "G")
     cal_stream : string, optional
-        Name of calibration stream (e.g. "L1")
+        Name of calibration stream (e.g. "l1")
     """
     sensor_name = 'Calibration/Products/{}/{}'.format(cal_stream, product_type)
     try:
@@ -246,7 +246,7 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream='cal',
     data_freqs : array of float, shape (*F*,)
         Centre frequency of each frequency channel of visibilities, in Hz
     cal_stream : string, optional
-        Name of (possibly virtual) calibration stream (e.g. "L1")
+        Name of (possibly virtual) calibration stream (e.g. "l1")
     cal_substreams : sequence of string, optional
         Names of actual underlying calibration streams (e.g. ["cal"]),
         defaults to [`cal_stream`] itself

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -457,7 +457,7 @@ def calc_correction(chunks, cache, corrprods, cal_products,
     if not corrections:
         return None
     params = CorrectionParams(inputs, input1_index, input2_index, corrections)
-    name = 'corrections[{}]'.format(','.join(corrections.keys()))
+    name = 'corrections[{}]'.format(','.join(sorted(corrections.keys())))
     return da.map_blocks(_correction_block, dtype=np.complex64, chunks=chunks,
                          name=name, params=params)
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -205,7 +205,7 @@ def add_applycal_sensors(cache, attrs, data_freqs):
     This maps receptor inputs to the relevant indices in each calibration
     product based on the ants and pols found in `attrs`. It then registers
     a virtual sensor per input and per cal product in the SensorCache `cache`,
-    with template 'Calibration/{inp}_correction_{product}'. The virtual sensor
+    with template 'Calibration/Corrections/{product}/{inp}'. The virtual sensor
     function picks the appropriate correction calculator based on the cal
     product name, which also uses auxiliary info like the channel frequencies,
     `data_freqs`.
@@ -257,7 +257,7 @@ def add_applycal_sensors(cache, attrs, data_freqs):
         cache[name] = correction_sensor
         return correction_sensor
 
-    correction_sensor_template = 'Calibration/{inp}_correction_{product}'
+    correction_sensor_template = 'Calibration/Corrections/{product}/{inp}'
     cache.virtual[correction_sensor_template] = calc_correction_per_input
 
 
@@ -391,7 +391,7 @@ def calc_correction(chunks, cache, corrprods, cal_products,
     for product in cal_products:
         corrections_per_product = []
         for i, inp in enumerate(inputs):
-            sensor_name = 'Calibration/{}_correction_{}'.format(inp, product)
+            sensor_name = 'Calibration/Corrections/{}/{}'.format(product, inp)
             try:
                 sensor = cache.get(sensor_name)
             except KeyError:

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -367,6 +367,10 @@ class TestVirtualCorrectionSensors(object):
             self.cache.get('Calibration/Corrections/cal/K_unknown/' + known_input)
         with assert_raises(KeyError):
             self.cache.get('Calibration/Corrections/unknown/K/' + known_input)
+        with assert_raises(KeyError):
+            self.cache.get('Calibration/Products/cal/K_unknown')
+        with assert_raises(KeyError):
+            self.cache.get('Calibration/Products/unknown/K')
 
 
 class TestCalcCorrection(object):

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -377,6 +377,12 @@ class TestVirtualCorrectionSensors(object):
         with assert_raises(KeyError):
             self.cache.get('Calibration/Products/unknown/K')
 
+    def test_indirect_cal_product(self):
+        add_applycal_sensors(self.cache, ATTRS, FREQS, 'my_cal', [CAL_STREAM])
+        self.test_delay_sensors('my_cal')
+        self.test_bandpass_sensors('my_cal')
+        self.test_gain_sensors('my_cal')
+
 
 class TestCalcCorrection(object):
     """Test :func:`~katdal.applycal.calc_correction` function."""

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -238,6 +238,7 @@ class TestCalProductAccess(object):
     """Test the :func:`~katdal.applycal.*_cal_product` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
+        add_applycal_sensors(self.cache, ATTRS, FREQS)
 
     def test_get_cal_product_basic(self):
         product_sensor = get_cal_product(self.cache, ATTRS, 'K')
@@ -286,6 +287,7 @@ class TestCorrectionPerInput(object):
     """Test the :func:`~katdal.applycal.calc_*_correction` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
+        add_applycal_sensors(self.cache, ATTRS, FREQS)
 
     def test_calc_delay_correction(self):
         product_sensor = get_cal_product(self.cache, ATTRS, 'K')
@@ -337,32 +339,34 @@ class TestVirtualCorrectionSensors(object):
     def test_delay_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/K/{}{}'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/cal/K/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[10 + n], delay_corrections(m, n))
 
     def test_bandpass_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/B/{}{}'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/cal/B/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[12 + n], bandpass_corrections(m, n))
 
     def test_gain_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/G/{}{}'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/cal/G/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[:], gain_corrections(m, n))
 
     def test_unknown_inputs_and_products(self):
         known_input = '{}{}'.format(ANTS[0], POLS[0])
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/K/unknown')
+            self.cache.get('Calibration/Corrections/cal/K/unknown')
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/unknown/' + known_input)
+            self.cache.get('Calibration/Corrections/cal/unknown/' + known_input)
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/K_unknown/' + known_input)
+            self.cache.get('Calibration/Corrections/cal/K_unknown/' + known_input)
+        with assert_raises(KeyError):
+            self.cache.get('Calibration/Corrections/unknown/K/' + known_input)
 
 
 class TestCalcCorrection(object):

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -339,32 +339,32 @@ class TestVirtualCorrectionSensors(object):
     def test_delay_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/{}{}_correction_K'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/K/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[10 + n], delay_corrections(m, n))
 
     def test_bandpass_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/{}{}_correction_B'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/B/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[12 + n], bandpass_corrections(m, n))
 
     def test_gain_sensors(self):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/{}{}_correction_G'.format(ant, pol)
+                sensor_name = 'Calibration/Corrections/G/{}{}'.format(ant, pol)
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[:], gain_corrections(m, n))
 
     def test_unknown_inputs_and_products(self):
-        known_input = 'Calibration/{}{}'.format(ANTS[0], POLS[0])
+        known_input = '{}{}'.format(ANTS[0], POLS[0])
         with assert_raises(KeyError):
-            self.cache.get('Calibration/unknown_correction_K')
+            self.cache.get('Calibration/Corrections/K/unknown')
         with assert_raises(KeyError):
-            self.cache.get(known_input + '_correction_unknown')
+            self.cache.get('Calibration/Corrections/unknown/' + known_input)
         with assert_raises(KeyError):
-            self.cache.get(known_input + '_correction_K_unknown')
+            self.cache.get('Calibration/Corrections/K_unknown/' + known_input)
 
 
 class TestCalcCorrection(object):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -34,7 +34,7 @@ from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, calc_correction,
                        apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction, CAL_PRODUCTS)
+                       apply_flags_correction)
 from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
 
 
@@ -81,6 +81,8 @@ def _add_sensor_alias(cache, new_name, old_name):
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
                         'Antennas/{ant}/el': _calc_azel})
+
+DEFAULT_CAL_PRODUCTS = ('L1.K', 'L1.B', 'L1.G')
 
 # -----------------------------------------------------------------------------
 # -- CLASS :  VisibilityDataV4
@@ -359,8 +361,9 @@ class VisibilityDataV4(DataSet):
         freqs = self.spectral_windows[0].channel_freqs
         # XXX This assumes that `attrs` is a telstate and not a dict-like
         cal_attrs = attrs.view('cal', exclusive=True)
-        add_applycal_sensors(self.sensor, cal_attrs, freqs)
-        applycal_products = _selection_to_list(applycal, all=CAL_PRODUCTS)
+        add_applycal_sensors(self.sensor, cal_attrs, freqs, cal_stream='L1',
+                             cal_substreams=['cal'])
+        applycal_products = _selection_to_list(applycal, all=DEFAULT_CAL_PRODUCTS)
         skip_missing_products = (applycal == 'all')
         if not self.source.data or not applycal_products:
             self._corrections = None

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -82,7 +82,7 @@ VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
                         'Antennas/{ant}/el': _calc_azel})
 
-DEFAULT_CAL_PRODUCTS = ('L1.K', 'L1.B', 'L1.G')
+DEFAULT_CAL_PRODUCTS = ('l1.K', 'l1.B', 'l1.G')
 
 # -----------------------------------------------------------------------------
 # -- CLASS :  VisibilityDataV4
@@ -361,7 +361,7 @@ class VisibilityDataV4(DataSet):
         freqs = self.spectral_windows[0].channel_freqs
         # XXX This assumes that `attrs` is a telstate and not a dict-like
         cal_attrs = attrs.view('cal', exclusive=True)
-        add_applycal_sensors(self.sensor, cal_attrs, freqs, cal_stream='L1',
+        add_applycal_sensors(self.sensor, cal_attrs, freqs, cal_stream='l1',
                              cal_substreams=['cal'])
         applycal_products = _selection_to_list(applycal, all=DEFAULT_CAL_PRODUCTS)
         skip_missing_products = (applycal == 'all')

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -365,6 +365,9 @@ class VisibilityDataV4(DataSet):
                              cal_substreams=['cal'])
         applycal_products = _selection_to_list(applycal, all=DEFAULT_CAL_PRODUCTS)
         skip_missing_products = (applycal == 'all')
+        # Let 'l1' be the default stream if only a product type is specified
+        applycal_products = [product if '.' in product else 'l1.' + product
+                             for product in applycal_products]
         if not self.source.data or not applycal_products:
             self._corrections = None
             self._corrected = self.source.data

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -34,7 +34,7 @@ from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, calc_correction,
                        apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction, has_cal_product, CAL_PRODUCTS)
+                       apply_flags_correction, CAL_PRODUCTS)
 from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
 
 
@@ -358,27 +358,32 @@ class VisibilityDataV4(DataSet):
 
         freqs = self.spectral_windows[0].channel_freqs
         add_applycal_sensors(self.sensor, attrs, freqs)
-        available_products = [product for product in CAL_PRODUCTS
-                              if has_cal_product(self.sensor, attrs, product)]
-        self._applycal = _selection_to_list(applycal, all=available_products)
-        if not self.source.data or not self._applycal:
+        applycal_products = _selection_to_list(applycal, all=CAL_PRODUCTS)
+        skip_missing_products = (applycal == 'all')
+        if not self.source.data or not applycal_products:
             self._corrections = None
             self._corrected = self.source.data
         else:
             self._corrections = calc_correction(self.source.data.vis.chunks, self.sensor,
                                                 self.subarrays[self.subarray].corr_products,
-                                                self._applycal)
-            corrected_vis = self._make_corrected(apply_vis_correction, self.source.data.vis)
-            corrected_flags = self._make_corrected(apply_flags_correction, self.source.data.flags)
-            corrected_weights = self._make_corrected(apply_weights_correction, self.source.data.weights)
-            name = self.source.data.name
-            # Acknowledge that the applycal step is making the L1 product
-            if 'sdp_l0' in name:
-                name = name.replace('sdp_l0', 'sdp_l1')
+                                                applycal_products, skip_missing_products)
+            if self._corrections is None:
+                self._corrected = self.source.data
             else:
-                name = name + ' (corrected)'
-            self._corrected = VisFlagsWeights(corrected_vis, corrected_flags, corrected_weights,
-                                              name=name)
+                corrected_vis = self._make_corrected(apply_vis_correction,
+                                                     self.source.data.vis)
+                corrected_flags = self._make_corrected(apply_flags_correction,
+                                                       self.source.data.flags)
+                corrected_weights = self._make_corrected(apply_weights_correction,
+                                                         self.source.data.weights)
+                name = self.source.data.name
+                # Acknowledge that the applycal step is making the L1 product
+                if 'sdp_l0' in name:
+                    name = name.replace('sdp_l0', 'sdp_l1')
+                else:
+                    name = name + ' (corrected)'
+                self._corrected = VisFlagsWeights(corrected_vis, corrected_flags,
+                                                  corrected_weights, name=name)
 
         # Apply default selection and initialise all members that depend
         # on selection in the process

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -357,7 +357,9 @@ class VisibilityDataV4(DataSet):
         # ------ Register applycal virtual sensors and products ------
 
         freqs = self.spectral_windows[0].channel_freqs
-        add_applycal_sensors(self.sensor, attrs, freqs)
+        # XXX This assumes that `attrs` is a telstate and not a dict-like
+        cal_attrs = attrs.view('cal', exclusive=True)
+        add_applycal_sensors(self.sensor, cal_attrs, freqs)
         applycal_products = _selection_to_list(applycal, all=CAL_PRODUCTS)
         skip_missing_products = (applycal == 'all')
         if not self.source.data or not applycal_products:


### PR DESCRIPTION
This updates "make L1" to be closer to what we need for L2:

- Remove hard-coded `cal` stream names. Make it part of the calibration product name instead.
- Remove `has_cal_product` which will be hard to support for virtual cal product sensors.
- Rename the virtual correction sensors to improve matches to funny stream names.
- Add virtual product sensors to standardise stream names to something like `l1` and `l2`.
- Minor doc updates and refactors.

So a "cal product" is now an amalgam of a cal stream (`l1`) and a product type (`G`), with a name like `l1.G`. The streams may be actual or virtual. The `add_applycal_sensors` function operates on a single cal stream at a time.

(EDIT: renamed `L1` to `l1`)