### PR TITLE
Make L2: the Turn

### DIFF
--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -96,7 +96,9 @@ def create_bandpass(pol, ant):
 def create_gain(pol, ant, multi_channel=False, targets=False):
     """Synthesise a gain time series from `pol`, `ant` indices and events.
 
-    The gain can also vary with frequency a la GPHASE if `multi_channel` is True.
+    The gain can also vary with frequency a la GPHASE if `multi_channel` is
+    True, in which case all valid gains are also normalised to magnitude 1 to
+    resemble GPHASE.
     """
     events = np.array(GAIN_EVENTS)
     gains = np.ones_like(events, dtype=np.complex64)
@@ -106,7 +108,6 @@ def create_gain(pol, ant, multi_channel=False, targets=False):
         gains *= (-1) ** np.arange(len(GAIN_EVENTS))
     if multi_channel:
         gains = np.outer(gains, create_bandpass(pol, ant))
-        # Make it phase-only for kicks
         gains /= np.abs(gains)
     if ant == BAD_GAIN_ANT:
         gains[:] = INVALID_GAIN
@@ -214,7 +215,8 @@ def corrections_per_corrprod(dumps, channels, cal_products):
                                                            targets=True)[dumps]
                                           for inp in INPUTS]
                                          ).transpose(1, 2, 0)[:, DATA_TO_CAL_CHANNEL]}
-    # Apply (K, B, G, GPHASE) corrections in correct order
+    # Apply (K, B, G, GPHASE) corrections in the same order
+    # used by the system under test to get bit-exact results
     for cal_product in cal_products:
         gains_per_input *= corrections[cal_product]
     gains_per_input = gains_per_input[:, channels, :]

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -102,7 +102,10 @@ def create_gain(pol, ant, multi_channel=False, targets=False):
     """
     events = np.array(GAIN_EVENTS)
     gains = np.ones_like(events, dtype=np.complex64)
+    # The gain magnitude reflects the input or (ant, pol) index
     factor = len(POLS) * ant + pol + 1
+    # The gain phase drifts as a function of time but over a limited range
+    # so that the target index can be reflected in the sign of the gain
     gains *= factor * np.exp(2j * np.pi * events / N_DUMPS / 12)
     if targets:
         gains *= (-1) ** np.arange(len(GAIN_EVENTS))

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -361,8 +361,9 @@ class VisibilityDataV4(DataSet):
         freqs = self.spectral_windows[0].channel_freqs
         # XXX This assumes that `attrs` is a telstate and not a dict-like
         cal_attrs = attrs.view('cal', exclusive=True)
-        add_applycal_sensors(self.sensor, cal_attrs, freqs, cal_stream='l1',
-                             cal_substreams=['cal'])
+        cal_freqs = {'l1': add_applycal_sensors(self.sensor, cal_attrs,
+                                                freqs, cal_stream='l1',
+                                                cal_substreams=['cal'])}
         applycal_products = _selection_to_list(applycal, all=DEFAULT_CAL_PRODUCTS)
         skip_missing_products = (applycal == 'all')
         # Let 'l1' be the default stream if only a product type is specified
@@ -374,7 +375,8 @@ class VisibilityDataV4(DataSet):
         else:
             self._corrections = calc_correction(self.source.data.vis.chunks, self.sensor,
                                                 self.subarrays[self.subarray].corr_products,
-                                                applycal_products, skip_missing_products)
+                                                applycal_products, freqs, cal_freqs,
+                                                skip_missing_products)
             if self._corrections is None:
                 self._corrected = self.source.data
             else:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -373,10 +373,10 @@ class VisibilityDataV4(DataSet):
             self._corrections = None
             self._corrected = self.source.data
         else:
-            self._corrections = calc_correction(self.source.data.vis.chunks, self.sensor,
-                                                self.subarrays[self.subarray].corr_products,
-                                                applycal_products, freqs, cal_freqs,
-                                                skip_missing_products)
+            self._applycal_products, self._corrections = calc_correction(
+                self.source.data.vis.chunks, self.sensor,
+                self.subarrays[self.subarray].corr_products, applycal_products,
+                freqs, cal_freqs, skip_missing_products)
             if self._corrections is None:
                 self._corrected = self.source.data
             else:


### PR DESCRIPTION
- Introduce multi-channel gain products for the L2 stream. These perform linear interpolation along the time axis, while picking the closest cal channel for a given vis channel along the frequency axis.
- Self-cal solutions are obtained on a specific source and should only be interpolated to other data points of the same source. The gain correction routine therefore needs to be aware of the target associated with each dump in this case.

Both these behaviours are implemented for the new `GPHASE` and `GAMP_PHASE` product types.
There is some hackiness to get each stream's channel mapping to its point of application in `calc_correction`, but hopefully I'll clean this up as part of SR-1937.