### PR TITLE
Make L2: the Prestige

### DIFF
--- a/doc/mvf_v4.rst
+++ b/doc/mvf_v4.rst
@@ -170,7 +170,7 @@ appear either in the capture-stream namespace or the stream namespace.
     than the SDP.
 
 ``n_chans`` (int)
-    Number of channels in a channelised product
+    Number of channels in a channelised product.
 
 ``n_chans_per_substream`` (int)
     Number of channels in each SPEAD heap. Not relevant when loading
@@ -242,7 +242,8 @@ Streams of type ``sdp.cal`` have the following keys.
     Parameters used to configure the calibration.
 
 ``product_G`` (2D array) — sensor
-    Phase gain solutions, indexed by antenna and polarisation.
+    Gain solutions (derived e.g. on a phase calibrator), indexed by antenna
+    and polarisation. The complex values in the array apply to the entire band.
 
 ``product_K`` (2D array) — sensor
     Delay solutions (in seconds), indexed by antenna and polarisation. To
@@ -358,10 +359,37 @@ katsdptelstate for this database):
         names are arbitrary. This describes the **perceived** sky i.e., are
         modulated by the primary beam.
 
+Each sub-namespace per target contains a further sub-sub-namespace called
+``selfcal`` that contains the self-calibration solutions. It behaves like
+an ``sdp.cal`` stream namespace and has the following keys:
 
-TODO
-    Self-calibration solutions will be stored, but the format is still in
-    discussion.
+``antlist`` (list of string)
+    List of antenna names. Arrays of self-calibration solutions use this
+    order along the antenna axis.
+
+``pol_ordering`` (list of string)
+    List of polarisations (from ``v`` and ``h``). Arrays of self-calibration
+    solutions use this order along the polarisation axis.
+
+``n_chans`` (int)
+    Number of channels in the self-calibration solutions, which corresponds to
+    the number of "IFs" or sub-bands in the continuum imager.
+
+``bandwidth`` (float, Hz)
+    Bandwidth of the self-calibration solutions.
+
+``center_freq`` (float, Hz)
+    Middle of the central channel. Note that if the number of channels
+    is even, this is actually half a channel higher than the middle of
+    the band.
+
+``product_GPHASE`` (3D array) — sensor
+    Phase-only self-calibration solutions, indexed by channel, antenna and
+    polarisation.
+
+``product_GAMP_PHASE`` (3D array) — sensor
+    Amplitude + phase self-calibration solutions, indexed by channel, antenna
+    and polarisation.
 
 .. _linking-streams:
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -523,8 +523,11 @@ def calc_correction(chunks, cache, corrprods, cal_products, data_freqs,
                 # Scalar values will be broadcast by NumPy - no slicing required
                 channel_maps[cal_product] = lambda g, channels: g
             elif correction_n_chans == len(data_freqs) and (
+                    # This test indicates that correction frequencies either differ
+                    # from those of cal stream (i.e. already interpolated), or the
+                    # cal stream matches the data freqs to within 1 mHz anyway.
                     len(cal_stream_freqs) != len(data_freqs)
-                    or np.array_almost_equal(cal_stream_freqs, data_freqs)):
+                    or np.allclose(cal_stream_freqs, data_freqs, rtol=0, atol=1e-3)):
                 # Corrections are already lined up with data - slice directly
                 channel_maps[cal_product] = lambda g, channels: g[channels]
             else:

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -569,7 +569,7 @@ def apply_weights_correction(data, correction):
         for j in range(out.shape[1]):
             for k in range(out.shape[2]):
                 cc = correction[i, j, k]
-                c = cc.real**2 + cc.imag**2
+                c = cc.real * cc.real + cc.imag * cc.imag
                 if c > 0:   # Will be false if c is NaN
                     out[i, j, k] = data[i, j, k] / c
                 else:


### PR DESCRIPTION
Hook up the L2 stream to applycal:

- Synthesise the indirect L2 products (GPHASE and GAMP_PHASE) by merging the raw sensor data of the underlying cal substreams. Do this by interleaving the timestamps of each sensor to form a combined raw `RecordSensorData` object.

- Register sensors for the standard "l1" and "l2" cal streams, if found. The "l1" stream is the first "sdp.cal" stream found in the list of archived streams (or "cal"), and the "l2" stream is derived from the first "sdp.continuum_image" stream in the list.

- Parse the string supplied to the `applycal` parameter of `katdal.open` and turn it into a list of fully qualified cal stream names. Both product types and cal streams may be specified independently. Also add a "default" grouping (which should eventually become the default value for the parameter) that applies L1 and phase-only selfcal for L2, if found. It's a ValueError if the cal product can't be normalised. And allow missing products to be skipped if any product in the applycal string is incomplete or a grouping.
