### PR TITLE
 Set initial value of gain sensors to INVALID_GAIN

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -232,14 +232,15 @@ def calc_gain_correction(sensor, index, targets=None):
     # Assume all dumps have the same target by default, i.e. interpolate freely
     if targets is None:
         targets = CategoricalData([0], [0, len(dumps)])
-    smooth_gains = np.empty((len(dumps), gains.shape[0]), dtype=gains.dtype)
+    smooth_gains = np.full((len(dumps), gains.shape[0]), INVALID_GAIN)
     # Iterate over number of channels / "IFs" / subbands in gain product
     for chan, gains_per_chan in enumerate(gains):
         for target in set(targets):
             on_target = (targets == target)
             valid = np.isfinite(gains_per_chan) & on_target[events]
-            smooth_gains[on_target, chan] = INVALID_GAIN if not valid.any() else \
-                complex_interp(dumps[on_target], events[valid], gains_per_chan[valid])
+            if valid.any():
+                smooth_gains[on_target, chan] = complex_interp(
+                    dumps[on_target], events[valid], gains_per_chan[valid])
     return np.reciprocal(smooth_gains)
 
 

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -66,7 +66,7 @@ BAD_CHANNELS = np.full(CAL_N_CHANS, False)
 BAD_CHANNELS[30:40] = True
 BAD_CHANNELS[50] = True
 BANDPASS_PARTS = 4
-GAIN_EVENTS = list(range(0, N_DUMPS, 10))
+GAIN_EVENTS = list(range(10, N_DUMPS, 10))
 BAD_GAIN_ANT = 3
 BAD_GAIN_DUMPS = [20, 40]
 
@@ -159,11 +159,11 @@ def create_sensor_cache(bandpass_parts=BANDPASS_PARTS):
         cache[CAL_STREAM + '_product_B' + str(part)] = sensor
     # Add gain product (one value for entire band)
     gains = create_product(create_gain)
-    sensor = create_categorical_sensor(GAIN_EVENTS, gains)
+    sensor = create_categorical_sensor(GAIN_EVENTS, gains, INVALID_GAIN)
     cache[CAL_STREAM + '_product_G'] = sensor
     # Add gain product (varying across frequency and time)
     gains = create_product(partial(create_gain, multi_channel=True, targets=True))
-    sensor = create_categorical_sensor(GAIN_EVENTS, gains)
+    sensor = create_categorical_sensor(GAIN_EVENTS, gains, INVALID_GAIN)
     cache[CAL_STREAM + '_product_GPHASE'] = sensor
     # Construct sensor cache
     return SensorCache(cache, timestamps=np.arange(N_DUMPS, dtype=float),

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -34,7 +34,7 @@ from .categorical import CategoricalData
 from .lazy_indexer import DaskLazyIndexer
 from .applycal import (add_applycal_sensors, calc_correction,
                        apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction, CAL_PRODUCT_TYPES)
+                       apply_flags_correction, CAL_PRODUCT_TYPES, INVALID_GAIN)
 from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
 
 
@@ -55,6 +55,9 @@ SENSOR_PROPS.update({
     '*serial_number': {'initial_value': 0},
     '*target': {'initial_value': '', 'transform': _robust_target},
     'obs_label': {'initial_value': '', 'allow_repeats': True},
+    '*_product_G': {'initial_value': INVALID_GAIN},
+    '*_product_GPHASE': {'initial_value': INVALID_GAIN},
+    '*_product_GAMP_PHASE': {'initial_value': INVALID_GAIN},
 })
 
 SENSOR_ALIASES = {


### PR DESCRIPTION
The gain sensors are unlikely to have a gain solution at dump 0, so the categorical sensor extraction shifts the first proper gain solution back to dump 0 to fill this void.

We want to avoid this for two reasons:
  - Linear interpolation of gains over time will be compromised.
  - The first gains will most likely land on a different target than intended, and this association can propagate it further in error.

One solution is to duplicate the first gain event at dump 0, but this requires `allow_repeats=True` and a manual duplication process. Instead, we set the initial value to `INVALID_GAIN`. When the gains are turned into corrections, discard this initial placeholder and let the usual extrapolation fill in the void instead. The placeholder is incommensurate with the usual sensor values that are arrays, so we have to strip it out up front. Also note that we have to check the identity of the value since `INVALID_GAIN` contains NaNs (plus it's a singleton anyway).