### PR TITLE
Various fixes and improvements to MVFtoMS

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -343,6 +343,8 @@ class DataSet(object):
         Shape of selected visibility data array, as (*T*, *F*, *B*)
     size : int
         Size of selected visibility data array, in bytes
+    applycal_products : list of string
+        List of calibration products that will be applied to data
 
     """
 
@@ -383,6 +385,7 @@ class DataSet(object):
         self.target_coordsys = 'azel'
         self.shape = (0, 0, 0)
         self.size = 0
+        self.applycal_products = []
 
         self._selection = {}
         self._time_keep = []

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -108,7 +108,7 @@ def ms_writer_process(
         tdiff = vis_arrays.shape[1]
         nbl = vis_arrays.shape[2]
 
-        main_table = ms_extra.open_main(ms_name, verbose=options.verbose)
+        main_table = ms_extra.open_table(ms_name, verbose=options.verbose)
         with contextlib.closing(main_table):
             array_centre = katpoint.Antenna('', *antennas[0].ref_position_wgs84)
             baseline_vectors = np.array([array_centre.baseline_toward(antenna)

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -94,7 +94,7 @@ def define_hypercolumn(desc):
                                          for k, v in desc.items() if v['dataManagerType'] == 'TiledShapeStMan'])
 
 
-# Map Measurement Set string types to numpy types
+# Map MeasurementSet string types to numpy types
 MS_TO_NP_TYPE_MAP = {
     'INT': np.int32,
     'FLOAT': np.float32,
@@ -107,7 +107,7 @@ MS_TO_NP_TYPE_MAP = {
 
 def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
     """
-    Creates Table Description and Data Manager Information objecs that
+    Creates Table Description and Data Manager Information objects that
     describe a MeasurementSet suitable for holding MeerKAT data.
 
     Creates additional DATA, IMAGING_WEIGHT and possibly
@@ -117,7 +117,7 @@ def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
 
     :param nbl: Number of baselines.
     :param nchan: Number of channels.
-    :param ncorr: Number of correlations.
+    :param ncorr: Number of correlation products.
     :param model_data: Boolean indicated whether MODEL_DATA and CORRECTED_DATA
                         should be added to the Measurement Set.
     :return: Returns a tuple containing a table description describing

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -981,18 +981,21 @@ def write_rows(t, row_dict, verbose=True):
     if verbose:
         print("  added %d rows" % (num_rows,))
     for col_name, col_data in row_dict.items():
-        if col_name in t.colnames():
-            if col_data.dtype.kind == 'U':
-                col_data = np.char.encode(col_data, encoding='utf-8')
-            try:
-                t.putcol(col_name, col_data, startrow)
-                if verbose:
-                    print("  wrote column '%s' with shape %s" % (col_name, col_data.shape))
-            except RuntimeError as err:
-                print("  error writing column '%s' with shape %s (%s)" % (col_name, col_data.shape, err))
-        else:
+        if col_name not in t.colnames():
             if verbose:
                 print("  column '%s' not in table" % (col_name,))
+            continue
+        if col_data.dtype.kind == 'U':
+            col_data = np.char.encode(col_data, encoding='utf-8')
+        try:
+            t.putcol(col_name, col_data, startrow)
+        except RuntimeError as err:
+            print("  error writing column '%s' with shape %s (%s)" %
+                  (col_name, col_data.shape, err))
+        else:
+            if verbose:
+                print("  wrote column '%s' with shape %s" %
+                      (col_name, col_data.shape))
 
 
 def write_dict(ms_dict, ms_name, verbose=True):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -22,7 +22,6 @@
 from __future__ import print_function, division, absolute_import
 from builtins import range
 
-import sys
 import os
 import os.path
 from copy import deepcopy
@@ -41,10 +40,9 @@ if not pyc_ver >= req_ver:
                       % (req_ver, pyc_ver, req_ver))
 
 
-def open_table(filename, readonly=False, ack=False, **kwargs):
+def open_table(name, readonly=False, verbose=False, **kwargs):
     """Open casacore Table."""
-    t = tables.table(filename, readonly=readonly, ack=ack, **kwargs)
-    return t if type(t) == tables.table else None
+    return tables.table(name, readonly=readonly, ack=verbose, **kwargs)
 
 
 def create_ms(filename, table_desc=None, dm_info=None):
@@ -974,14 +972,6 @@ def populate_ms_dict(uvw_coordinates, vis_data, timestamps, antenna1_index, ante
 # ----------------- Write completed dictionary to MS file --------------------
 
 
-def open_main(ms_name, verbose=True):
-    t = open_table(ms_name, ack=verbose)
-    if t is None:
-        print("Failed to open main table for writing.")
-        sys.exit(1)
-    return t
-
-
 def write_rows(t, row_dict, verbose=True):
     num_rows = list(row_dict.values())[0].shape[0]
     # Append rows to the table by starting after the last row in table
@@ -1017,14 +1007,11 @@ def write_dict(ms_dict, ms_name, verbose=True):
                 print("Table %s:" % (sub_table_name,))
             # Open main table or sub-table
             if sub_table_name == 'MAIN':
-                t = open_table(ms_name, ack=verbose)
+                t = open_table(ms_name, verbose=verbose)
             else:
-                t = open_table(os.path.join(ms_name, sub_table_name))
-            if verbose and t is not None:
+                t = open_table('::'.join((ms_name, sub_table_name)))
+            if verbose:
                 print("  opened successfully")
-            if t is None:
-                print("  could not open table!")
-                break
             write_rows(t, row_dict, verbose)
             t.close()
             if verbose:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -388,13 +388,12 @@ class VisibilityDataV4(DataSet):
         normalised_cal_products, skip_missing_products = _normalise_cal_products(
             applycal, cal_freqs.keys())
         if not self.source.data or not normalised_cal_products:
-            self._applycal_products = []
             self._corrections = None
             self._corrected = self.source.data
         else:
             freqs = self.spectral_windows[0].channel_freqs
             corrprods = self.subarrays[self.subarray].corr_products
-            self._applycal_products, self._corrections = calc_correction(
+            self.applycal_products, self._corrections = calc_correction(
                 self.source.data.vis.chunks, self.sensor, corrprods,
                 normalised_cal_products, freqs, cal_freqs, skip_missing_products)
             if self._corrections is None:

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -16,10 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-# Produce a CASA compatible Measurement Set from a KAT-7 HDF5 file (versions
-# 1 and 2) or MeerKAT HDF5 file (version 3) using the casapy table tools
-# in the ms_extra module (or pyrap/casacore if casapy is not available).
-
 from __future__ import print_function, division, absolute_import
 
 import mvftoms

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -273,9 +273,9 @@ def main():
     open_args = args[0] if len(args) == 1 else args
     # katdal can handle a list of datasets, which get virtually concatenated internally
     dataset = katdal.open(open_args, ref_ant=options.ref_ant, applycal=options.applycal)
-    applycal_products = ', '.join(getattr(dataset, '_applycal_products', []))
-    if applycal_products:
-        print('The following calibration products will be applied:', applycal_products)
+    if dataset.applycal_products:
+        print('The following calibration products will be applied:',
+              ', '.join(dataset.applycal_products))
     else:
         print('No calibration products will be applied')
 

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -635,7 +635,7 @@ def main():
             field_centers, field_times, field_names)
         ms_dict['STATE'] = ms_extra.populate_state_dict(obs_modes)
         ms_dict['SOURCE'] = ms_extra.populate_source_dict(
-            field_centers, field_times, out_freqs, field_names)
+            field_centers, field_times, field_names)
 
         print("\nWriting dynamic fields to disk....\n")
         # Finally we write the MS as per our created dicts

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -173,7 +173,11 @@ def main():
                       help="Create calibration tables from gain solutions in the dataset (if present).")
     parser.add_option("--quack", type=int, default=1, metavar='N',
                       help="Discard the first N dumps (which are frequently incomplete).")
-
+    parser.add_option("--applycal", default="",
+                      help="List of calibration solutions to apply to data as "
+                           "a string of comma-separated names, e.g. 'l1' or "
+                           "'K,B,G'. Use 'default' for L1 + L2 and 'all' for "
+                           "all available products.")
     (options, args) = parser.parse_args()
 
     # Loading is I/O-bound, so give more threads than CPUs
@@ -243,7 +247,12 @@ def main():
     # Open dataset
     open_args = args[0] if len(args) == 1 else args
     # katdal can handle a list of files, which get virtually concatenated internally
-    dataset = katdal.open(open_args, ref_ant=options.ref_ant)
+    dataset = katdal.open(open_args, ref_ant=options.ref_ant, applycal=options.applycal)
+    applycal_products = ', '.join(getattr(dataset, '_applycal_products', []))
+    if applycal_products:
+        print('The following calibration products will be applied:', applycal_products)
+    else:
+        print('No calibration products will be applied')
 
     # Get list of unique polarisation products in the file
     pols_in_file = np.unique([(cp[0][-1] + cp[1][-1]).upper() for cp in dataset.corr_products])

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -51,7 +51,7 @@ from katdal.lazy_indexer import DaskLazyIndexer
 SLOTS = 4    # Controls overlap between loading and writing
 
 
-def default_ms_name(args, freq_MHz=None):
+def default_ms_name(args, centre_freq=None):
     """Infer default MS name from argument list and optional frequency label."""
     # Use the first dataset in the list to generate the base part of the MS name
     url_parts = urllib.parse.urlparse(args[0], scheme='file')
@@ -64,10 +64,10 @@ def default_ms_name(args, freq_MHz=None):
     else:
         dataset_basename = os.path.splitext(dataset_filename)[0]
     # Add frequency to name to disambiguate multiple spectral windows
-    if freq_MHz:
-        dataset_basename += '_{:d}MHz'.format(int(freq_MHz))
+    if centre_freq:
+        dataset_basename += '_%dHz' % (int(centre_freq),)
     # Add ".et_al" as reminder that we concatenated multiple datasets
-    return '{}{}.ms'.format(dataset_basename, "" if len(args) == 1 else ".et_al")
+    return '%s%s.ms' % (dataset_basename, "" if len(args) == 1 else ".et_al")
 
 
 def load(dataset, indices, vis, weights, flags):
@@ -303,14 +303,15 @@ def main():
     for win in range(len(dataset.spectral_windows)):
         dataset.select(reset='T')
 
-        freq_MHz = dataset.spectral_windows[win].centre_freq / 1e6
-        print('Extract MS for spw %d: central frequency %.2f MHz' % (win, freq_MHz))
+        centre_freq = dataset.spectral_windows[win].centre_freq
+        print('Extract MS for spw %d: centre frequency %d Hz'
+              % (win, int(centre_freq)))
 
         # If no output MS directory name supplied, infer it from dataset(s)
         if options.output_ms is None:
             if len(dataset.spectral_windows) > 1:
                 # Use frequency label to disambiguate multiple spectral windows
-                ms_name = default_ms_name(args, freq_MHz)
+                ms_name = default_ms_name(args, centre_freq)
             else:
                 ms_name = default_ms_name(args)
         else:

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-# Produce a CASA-compatible Measurement Set from a MeerKAT Visibility Format
-# (MVF) dataset using casapy or casacore.
+# Produce a CASA-compatible MeasurementSet from a MeerKAT Visibility Format
+# (MVF) dataset using casacore.
 
 from __future__ import print_function, division, absolute_import
 from future import standard_library
@@ -124,7 +124,7 @@ def main():
                      'target': 'TARGET'}
 
     usage = "%prog [options] <dataset> [<dataset2>]*"
-    description = "Convert MVF dataset(s) to MeasurementSet. The datasets may " \
+    description = "Convert MVF dataset(s) to CASA MeasurementSet. The datasets may " \
                   "be local filenames or archive URLs (including access tokens). " \
                   "If there are multiple datasets they will be concatenated via " \
                   "katdal before conversion."
@@ -206,13 +206,6 @@ def main():
 
     if len(args) > 1:
         print("Concatenating multiple datasets into single MS.")
-
-    if not ms_extra.casacore_binding:
-        raise RuntimeError("Failed to find casacore binding. You need to install both "
-                           "casacore and python-casacore, or run the script from within "
-                           "a modified casapy containing h5py and katpoint.")
-    else:
-        print("Using '%s' casacore binding to produce MS" % (ms_extra.casacore_binding,))
 
     def antenna_indices(na, no_auto_corr):
         """Get default antenna1 and antenna2 arrays."""

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -660,7 +660,7 @@ def main():
         #   (can't extract telstate params from contatenated katdal file as it
         #    uses the hdf5 file directly)
         first_dataset = katdal.open(args[0], ref_ant=options.ref_ant)
-        main_table = ms_extra.open_main(ms_name, verbose=options.verbose)
+        main_table = ms_extra.open_table(ms_name, verbose=options.verbose)
 
         if options.caltables:
             # copy extra subtable dictionary values necessary for caltable


### PR DESCRIPTION
This addresses a slew of recent tickets:

  - [SR-1828](https://skaafrica.atlassian.net/browse/SR-1828): let `mvftoms` open RDB URLs, including access tokens. It turns out that this is already possible, thereby removing the need for #249... I only needed to fix the construction of a default output MS name. One thing to note is that the MS now goes into the working directory as always promised, instead of next to the RDB file.

  - [SR-1811](https://skaafrica.atlassian.net/browse/SR-1811): Fix the optional REST_FREQUENCY column in optional SOURCE table. It is not optional for UVFITS export in CASA... Clean up the whole SOURCE sub-table. @sjperkins should have a good look at this.

  - [SR-1948](https://skaafrica.atlassian.net/browse/SR-1948): Add `--applycal` option to pass through to `katdal.open`. This allows MS data to be calibrated up front.

  - [SR-1654](https://skaafrica.atlassian.net/browse/SR-1654): Fix various help strings to reflect the MVFv4 reality (@bmerry was the original reporter).

  - Strip out casapy support for good measure.