### PR TITLE
Fix formatting of ValueError

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -108,8 +108,8 @@ def read_array(fp):
     # isn't expecting a numpy array
     bytes_read = fp.readinto(memoryview(data.view(np.uint8)))
     if bytes_read != data.nbytes:
-        raise ValueError('Error reading numpy array from S3: expected {} bytes, got {}',
-                         data.nbytes, bytes_read)
+        raise ValueError('Error reading numpy array from S3: expected {} bytes, got {}'
+                         .format(data.nbytes, bytes_read))
     if fortran_order:
         data.shape = shape[::-1]
         data = data.transpose()


### PR DESCRIPTION
The fix in #260 forgot to use `.format`, so the ValueError ends up with
a tuple instead of an argument.