### PR TITLE
Prepare for v0.14

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+0.14 (2019-10-02)
+-----------------
+* Make L2 product by applying self-calibration corrections (#253 - #256)
+* Speed up uvw calculations (#252, #262)
+* Produce documentation on readthedocs.org (#244, #245, #247, #250, #261)
+* Clean up mvftoms and fix REST_FREQUENCY in SOURCE sub-table (#258)
+* Support katstore64 API (#265)
+* Improve chunk store: detect short reads and speed up lost data (#259, #260)
+* Use katpoint 0.9 and dask 1.2.1 features (#262, #243)
+
 0.13 (2019-05-09)
 -----------------
 * Load RDB files straight from archive (#233, #241)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,7 +8,7 @@ History
 * Produce documentation on readthedocs.org (#244, #245, #247, #250, #261)
 * Clean up mvftoms and fix REST_FREQUENCY in SOURCE sub-table (#258)
 * Support katstore64 API (#265)
-* Improve chunk store: detect short reads and speed up lost data (#259, #260)
+* Improve chunk store: detect short reads, speed up handling of lost data (#259, #260)
 * Use katpoint 0.9 and dask 1.2.1 features (#262, #243)
 
 0.13 (2019-05-09)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name='katdal',
       python_requires='>=2.7,!=3.0,!=3.1,!=3.2',
       setup_requires=['katversion'],
       use_katversion=True,
-      install_requires=['numpy', 'katpoint', 'h5py >= 2.3', 'numba',
+      install_requires=['numpy', 'katpoint >= 0.9', 'h5py >= 2.3', 'numba',
                         'katsdptelstate[rdb] >= 0.8', 'dask[array] >= 1.2.1',
                         'requests >= 2.18.0', 'defusedxml', 'future'],
       extras_require={


### PR DESCRIPTION
Also bump requirement on katpoint v0.9 which will be released simultaneously.

This addresses JIRA ticket [SR-1734](https://skaafrica.atlassian.net/browse/SR-1734).