### PR TITLE
SPR1-181: initial refactor

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -114,6 +114,7 @@ def read_array(fp):
 
 class _BearerAuth(requests.auth.AuthBase):
     """Add bearer token to authorisation request header."""
+
     def __init__(self, token):
         # Character set from RFC 6750
         if not re.match('^[A-Za-z0-9-._~+/]*$', token):
@@ -127,6 +128,7 @@ class _BearerAuth(requests.auth.AuthBase):
 
 class _AWSAuth(requests.auth.AuthBase):
     """Add AWS access + secret credentials to authorisation request header."""
+
     def __init__(self, credentials):
         credentials = botocore.credentials.ReadOnlyCredentials(
             credentials[0], credentials[1], None)
@@ -154,6 +156,8 @@ def _auth_factory(url, token=None, credentials=None):
         if not botocore:
             raise StoreUnavailable('Passing credentials requires botocore to be installed')
         return _AWSAuth(credentials)
+    else:
+        return None
 
 
 class _CacheSettingsSession(requests.Session):
@@ -288,14 +292,14 @@ class S3ChunkStore(ChunkStore):
         string type with UTF-8.
     timeout : int or float, optional
         Read / connect timeout, in seconds (set to None to leave unchanged)
-    token : str
+    token : str, optional
         Bearer token to authenticate
-    credentials: tuple of str
+    credentials: tuple of str, optional
         AWS access key and secret key to authenticate
-    public_read : bool
+    public_read : bool, optional
         If set to true, new buckets will be created with a policy that allows
         everyone (including unauthenticated users) to read the data.
-    expiry_days : int
+    expiry_days : int, optional
         If set to a value greater than 0 will set a future expiry time in days
         for any new buckets created.
     kwargs : dict

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -14,11 +14,8 @@
 # limitations under the License.
 ################################################################################
 
-"""A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API.
+"""A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API."""
 
-It does not support S3 authentication/signatures, relying instead on external
-code to provide HTTP authentication.
-"""
 from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
@@ -118,10 +115,11 @@ def read_array(fp):
 
 
 class _BearerAuth(requests.auth.AuthBase):
+    """Add bearer token to authorisation request header."""
     def __init__(self, token):
         # Character set from RFC 6750
         if not re.match('^[A-Za-z0-9-._~+/]*$', token):
-            raise ValueError('token contains invalid characters')
+            raise ValueError('Token contains invalid characters')
         self._token = token
 
     def __call__(self, r):
@@ -130,6 +128,7 @@ class _BearerAuth(requests.auth.AuthBase):
 
 
 class _AWSAuth(requests.auth.AuthBase):
+    """Add AWS access + secret credentials to authorisation request header."""
     def __init__(self, credentials):
         credentials = botocore.credentials.ReadOnlyCredentials(
             credentials[0], credentials[1], None)
@@ -180,7 +179,7 @@ class _CacheSettingsSession(requests.Session):
 
 
 class _TimeoutHTTPAdapter(_HTTPAdapter):
-    """Allow an HTTPAdapter to have a default timeout"""
+    """Allow an HTTPAdapter to have a default timeout."""
     def __init__(self, *args, **kwargs):
         self._default_timeout = kwargs.pop('timeout', None)
         super(_TimeoutHTTPAdapter, self).__init__(*args, **kwargs)
@@ -282,12 +281,6 @@ class S3ChunkStore(ChunkStore):
     expiry_days : int
         If set to a value greater than 0 will set a future expiry time in days
         for any new buckets created.
-
-
-    Raises
-    ------
-    ImportError
-        If requests is not installed (it's an optional dependency otherwise)
     """
 
     def __init__(self, session_factory, url, public_read=False, expiry_days=0):
@@ -319,11 +312,11 @@ class S3ChunkStore(ChunkStore):
             parsed = urllib.parse.urlparse(url)
             # The exception for 127.0.0.1 lets the unit test work
             if parsed.scheme != 'https' and parsed.hostname != '127.0.0.1':
-                raise StoreUnavailable('auth token may only be used with https')
+                raise StoreUnavailable('Auth token may only be used with https')
             auth = _BearerAuth(token)
         elif credentials is not None:
             if not botocore:
-                raise StoreUnavailable('passing credentials requires botocore to be installed')
+                raise StoreUnavailable('Passing credentials requires botocore to be installed')
             auth = _AWSAuth(credentials)
         else:
             auth = None

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -501,7 +501,7 @@ def infer_chunk_store(url_parts, telstate, npy_store_path=None,
     if npy_store_path:
         return NpyFileChunkStore(npy_store_path)
     if s3_endpoint_url:
-        return S3ChunkStore.from_url(s3_endpoint_url, **kwargs)
+        return S3ChunkStore(s3_endpoint_url, **kwargs)
     # NPY chunk store is an option if the dataset is an RDB file
     if url_parts.scheme == 'file':
         # Look for adjacent data directory (presumably containing NPY files)
@@ -513,7 +513,7 @@ def infer_chunk_store(url_parts, telstate, npy_store_path=None,
         data_path = os.path.join(store_path, vis_prefix)
         if os.path.isdir(data_path):
             return NpyFileChunkStore(store_path)
-    return S3ChunkStore.from_url(telstate['s3_endpoint_url'], **kwargs)
+    return S3ChunkStore(telstate['s3_endpoint_url'], **kwargs)
 
 
 def _upgrade_flags(chunk_info, telstate, capture_block_id, stream_name):
@@ -653,7 +653,7 @@ class TelstateDataSource(DataSource):
                 (url_parts.scheme, url_parts.netloc, url_parts.path, '', '', ''))
             telstate = katsdptelstate.TelescopeState()
             try:
-                rdb_store = S3ChunkStore.from_url(store_url, **kwargs)
+                rdb_store = S3ChunkStore(store_url, **kwargs)
                 with rdb_store.request('', 'GET', rdb_url) as response:
                     telstate.load_from_file(io.BytesIO(response.content))
             except ChunkStoreError as e:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -49,18 +49,11 @@ import warnings
 import numpy as np
 from nose import SkipTest
 from nose.tools import assert_raises, assert_equal, timed
-import mock
 import requests
 
 from katdal.chunkstore_s3 import S3ChunkStore, _AWSAuth, read_array
 from katdal.chunkstore import StoreUnavailable
 from katdal.test.test_chunkstore import ChunkStoreTestBase
-
-
-def gethostbyname_slow(host):
-    """Mock DNS lookup that is meant to be slow."""
-    time.sleep(30)
-    return '127.0.0.1'
 
 
 @contextlib.contextmanager
@@ -245,21 +238,12 @@ class TestS3ChunkStore(ChunkStoreTestBase):
     def test_store_unavailable_invalid_url(self):
         # Ensure that timeouts work
         assert_raises(StoreUnavailable, S3ChunkStore,
-                      'http://apparently.invalid/',
-                      timeout=0.1, extra_timeout=0)
+                      'http://apparently.invalid/', timeout=0.1)
 
     def test_token_without_https(self):
         # Don't allow users to leak their tokens by accident
         assert_raises(StoreUnavailable, S3ChunkStore,
                       'http://apparently.invalid/', token='secrettoken')
-
-    @timed(0.1 + 1 + 0.05)
-    @mock.patch('socket.gethostbyname', side_effect=gethostbyname_slow)
-    def test_store_unavailable_slow_dns(self, mock_dns_lookup):
-        # Some pathological DNS setups (sshuttle?) take forever to time out
-        assert_raises(StoreUnavailable, S3ChunkStore,
-                      'http://a-valid-domain-is-somehow-harder.kat.ac.za/',
-                      timeout=0.1, extra_timeout=1)
 
 
 class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):


### PR DESCRIPTION
I'm splitting the chunk store rework into at least four PRs to lighten your load...

1. Initial refactor to get rid of icky layers of code [THIS ONE]
2. Token checking and authorisation error reporting (done, waiting in the wings)
3. Timeout and retries rework (current activity)
4. Collect request response statistics for debugging (future work)

Some of these bits (like da08290) are reworked in the future PRs, but not by a lot.

@sratcliffe, you'll like this one because it addresses your concerns in #235 😄 