### PR TITLE
SPR1-181: Improve timeouts and retries

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function, division, absolute_import
 from builtins import next, zip, range, object
+from future.utils import raise_from
 
 import contextlib
 import functools
@@ -445,7 +446,7 @@ class ChunkStore(object):
                 FirstBase = next(c for c in self._error_map if isinstance(e, c))
                 StandardisedError = self._error_map[FirstBase]
             prefix = 'Chunk {!r}: '.format(chunk_name) if chunk_name else ''
-            raise StandardisedError(prefix + str(e))
+            raise_from(StandardisedError(prefix + str(e)), e)
 
     def get_dask_array(self, array_name, chunks, dtype, offset=()):
         """Get dask array from the store.

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -586,7 +586,7 @@ class S3ChunkStore(ChunkStore):
                     retries = retries.increment(method, url, response)
                 except MaxRetryError:
                     # Raise the final straw that broke the retry camel's back
-                    raise e
+                    raise_from(e, None)
                 else:
                     retries.sleep(response)
             else:

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -497,8 +497,8 @@ class S3ChunkStore(ChunkStore):
 
     def create_array(self, array_name):
         """See the docstring of :meth:`ChunkStore.create_array`."""
-        # The array name is formatted as bucket/array, but we only need to create the bucket
-        bucket = array_name.split(self.NAME_SEP)[0]
+        # Array name is formatted as bucket/array but we only need to create bucket
+        bucket, _ = self.split(array_name, 1)
         url = urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(bucket)))
         # Make bucket (409 indicates the bucket already exists, which is OK)
         with self.request('PUT', url, ignored_errors=(409,)):

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -78,22 +78,26 @@ _BUCKET_POLICY = {
 }
 
 # Fake HTTP status code associated with reset connections / truncated data
-_TRUNCATED_STATUS = 555
+_TRUNCATED_HTTP_STATUS_CODE = 555
 # These HTTP responses typically indicate temporary S3 server / proxy overload,
 # which will trigger retries terminating in a missing data response if unsuccessful.
-_DEFAULT_SERVER_GLITCHES = (500, 502, 503, 504, _TRUNCATED_STATUS)
+_DEFAULT_SERVER_GLITCHES = (500, 502, 503, 504, _TRUNCATED_HTTP_STATUS_CODE)
 
 
 class ServerGlitch(Exception):
     """S3 chunk store responded with an HTTP error deemed to be temporary."""
 
-    def __init__(self, msg, response):
+    def __init__(self, msg, status_code):
         super(ServerGlitch, self).__init__(msg)
-        self.response = response
+        self.status_code = status_code
 
 
 class TruncatedRead(ValueError):
     """HTTP request to S3 chunk store responded with fewer bytes than expected."""
+
+    def __init__(self, *args):
+        super(TruncatedRead, self).__init__(*args)
+        self.status_code = _TRUNCATED_HTTP_STATUS_CODE
 
 
 def _read_bytes_raising_truncated_read(*args, **kwargs):
@@ -143,6 +147,27 @@ def read_array(fp):
     else:
         data.shape = shape
     return data
+
+
+def _read_chunk(response):
+    """Efficiently read NumPy array in NPY format from content of HTTP response."""
+    data = response.raw
+    # Workaround for https://github.com/urllib3/urllib3/issues/1540
+    # On Python 2, http.client.HTTPResponse doesn't implement
+    # readinto. We also can't use the workaround if the content is
+    # encoded (e.g. gzip compressed) because that's decoded in
+    # urllib3, not httplib.
+    if ('Content-encoding' not in response.headers
+            and hasattr(data, '_fp')
+            and hasattr(data._fp, 'readinto')):
+        chunk = read_array(data._fp)
+    else:
+        chunk = read_array(data)
+    # This shouldn't actually read any data, but will make requests
+    # aware that we've consumed all the data and hence it can
+    # reuse the connection.
+    response.content
+    return chunk
 
 
 class AuthorisationFailed(StoreUnavailable):
@@ -499,57 +524,71 @@ class S3ChunkStore(ChunkStore):
                     # (see https://tracker.ceph.com/issues/38638 for discussion)
                     raise ChunkNotFound(msg)
                 elif self._retries.is_retry(method, status):
-                    raise ServerGlitch(msg, response)
+                    raise ServerGlitch(msg, status)
                 elif 400 <= status < 600 and status not in ignored_errors:
                     raise StoreUnavailable(msg)
                 else:
                     yield response
 
-    def _get_chunk(self, url, chunk_name=''):
-        """Download a single chunk stored at `url` as a NumPy array."""
-        # Our hacky optimisation to speed up response reading doesn't
-        # work with non-identity encodings.
-        headers = {'Accept-Encoding': 'identity'}
-        with self.request('GET', url, chunk_name,
-                          headers=headers, stream=True) as response:
-            data = response.raw
-            # Workaround for https://github.com/urllib3/urllib3/issues/1540
-            # On Python 2, http.client.HTTPResponse doesn't implement
-            # readinto. We also can't use the workaround if the content is
-            # encoded (e.g. gzip compressed) because that's decoded in
-            # urllib3, not httplib.
-            if ('Content-encoding' not in response.headers
-                    and hasattr(data, '_fp')
-                    and hasattr(data._fp, 'readinto')):
-                chunk = read_array(data._fp)
+    def complete_request(self, method, url, chunk_name='',
+                         process=lambda response: None, **kwargs):
+        """Send HTTP request to S3 server, process response and retry if needed.
+
+        This retries temporary HTTP errors, including reset connections while
+        processing a successful response.
+
+        Parameters
+        ----------
+        method, url : str
+            The standard required parameters of :meth:`requests.Session.request`
+        chunk_name : str, optional
+            Name of chunk, used for error reporting only
+        process : function, signature ``result = process(response)``, optional
+            Function that will process response (the default does nothing)
+        kwargs : optional
+            Passed on to :meth:`request` and :meth:`requests.Session.request`
+
+        Returns
+        -------
+        result : object
+            The output of the `process` function applied to a successful response
+
+        Raises
+        ------
+        AuthorisationFailed
+            If the request is not authorised by appropriate token or credentials
+        ChunkNotFound
+            If S3 object request fails because it does not exist or server glitched
+        StoreUnavailable
+            If a general HTTP error occurred that is not ignored
+        """
+        retries = self._retries.new()
+        while True:
+            try:
+                with self.request(method, url, chunk_name, **kwargs) as response:
+                    result = process(response)
+            except (ServerGlitch, TruncatedRead) as e:
+                # Retry based on status of response until we run out of retries
+                response = HTTPResponse(status=e.status_code)
+                try:
+                    retries = retries.increment(method, url, response)
+                except MaxRetryError:
+                    raise_from(ChunkNotFound(str(e)), e)
+                else:
+                    retries.sleep(response)
             else:
-                chunk = read_array(data)
-            # This shouldn't actually read any data, but will make requests
-            # aware that we've consumed all the data and hence it can
-            # reuse the connection.
-            response.content
-        return chunk
+                return result
 
     def get_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.get_chunk`."""
         dtype = np.dtype(dtype)
         chunk_name, shape = self.chunk_metadata(array_name, slices, dtype=dtype)
         url = self._chunk_url(chunk_name)
-        retries = self._retries.new()
-        while True:
-            try:
-                chunk = self._get_chunk(url, chunk_name)
-            except (ServerGlitch, TruncatedRead) as e:
-                response = getattr(e, 'response',
-                                   HTTPResponse(status=_TRUNCATED_STATUS))
-                try:
-                    retries = retries.increment('GET', url, response)
-                except MaxRetryError:
-                    raise_from(ChunkNotFound(str(e)), e)
-                else:
-                    retries.sleep(response)
-            else:
-                break
+        # Our hacky optimisation to speed up response reading doesn't
+        # work with non-identity encodings.
+        headers = {'Accept-Encoding': 'identity'}
+        chunk = self.complete_request('GET', url, chunk_name, _read_chunk,
+                                      headers=headers, stream=True)
         if chunk.shape != shape or chunk.dtype != dtype:
             raise BadChunk('Chunk {!r}: dtype {} and/or shape {} in store '
                            'differs from expected dtype {} and shape {}'
@@ -563,8 +602,7 @@ class S3ChunkStore(ChunkStore):
         bucket, _ = self.split(array_name, 1)
         url = urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(bucket)))
         # Make bucket (409 indicates the bucket already exists, which is OK)
-        with self.request('PUT', url, ignored_errors=(409,)):
-            pass
+        self.complete_request('PUT', url, ignored_errors=(409,))
 
         if self.public_read:
             policy_url = urllib.parse.urljoin(url, '?policy')
@@ -573,15 +611,14 @@ class S3ChunkStore(ChunkStore):
                 'arn:aws:s3:::{}/*'.format(bucket),
                 'arn:aws:s3:::{}'.format(bucket)
             ]
-            with self.request('PUT', policy_url, data=json.dumps(policy)):
-                pass
+            self.complete_request('PUT', policy_url, data=json.dumps(policy))
 
         if self.expiry_days > 0:
             xml_payload = _BASE_LIFECYCLE_POLICY.format(self.expiry_days)
             b64_md5 = base64.b64encode(hashlib.md5(xml_payload.encode('utf-8')).digest()).decode('utf-8')
             lifecycle_headers = {'Content-Type': 'text/xml', 'Content-MD5': b64_md5}
-            with self.request('PUT', url, params='lifecycle', data=xml_payload, headers=lifecycle_headers):
-                pass
+            self.complete_request('PUT', url, params='lifecycle',
+                                  data=xml_payload, headers=lifecycle_headers)
 
     def put_chunk(self, array_name, slices, chunk):
         """See the docstring of :meth:`ChunkStore.put_chunk`."""
@@ -599,8 +636,7 @@ class S3ChunkStore(ChunkStore):
             data = npy_header + chunk.tobytes()
         else:
             data = _Multipart([npy_header, memoryview(chunk)])
-        with self.request('PUT', url, chunk_name, headers=headers, data=data):
-            pass
+        self.complete_request('PUT', url, chunk_name, headers=headers, data=data)
 
     def has_chunk(self, array_name, slices, dtype):
         """See the docstring of :meth:`ChunkStore.has_chunk`."""
@@ -608,8 +644,7 @@ class S3ChunkStore(ChunkStore):
         chunk_name, _ = self.chunk_metadata(array_name, slices, dtype=dtype)
         url = self._chunk_url(chunk_name)
         try:
-            with self.request('HEAD', url, chunk_name):
-                pass
+            self.complete_request('HEAD', url, chunk_name)
         except ChunkNotFound:
             return False
         else:
@@ -627,11 +662,13 @@ class S3ChunkStore(ChunkStore):
             'max-keys': self.list_max_keys
         }
 
+        def _read_xml(response):
+            return defusedxml.cElementTree.fromstring(response.content)
+
         keys = []
         more = True
         while more:
-            with self.request('GET', url, params=params) as response:
-                root = defusedxml.cElementTree.fromstring(response.content)
+            root = self.complete_request('GET', url, process=_read_xml, params=params)
             keys.extend(child.text for child in root.iter(NS + 'Key'))
             truncated = root.find(NS + 'IsTruncated')
             more = (truncated is not None and truncated.text == 'true')
@@ -652,16 +689,14 @@ class S3ChunkStore(ChunkStore):
         self.create_array(array_name)
         obj_name = self.join(array_name, 'complete')
         url = urllib.parse.urljoin(self._url, obj_name)
-        with self.request('PUT', url, obj_name, data=b''):
-            pass
+        self.complete_request('PUT', url, obj_name, data=b'')
 
     def is_complete(self, array_name):
         """See the docstring of :meth:`ChunkStore.is_complete`."""
         obj_name = self.join(array_name, 'complete')
         url = urllib.parse.urljoin(self._url, obj_name)
         try:
-            with self.request('GET', url, obj_name):
-                pass
+            self.complete_request('GET', url, obj_name)
         except ChunkNotFound:
             return False
         return True

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -655,7 +655,7 @@ class TelstateDataSource(DataSource):
             telstate = katsdptelstate.TelescopeState()
             try:
                 rdb_store = S3ChunkStore(store_url, **kwargs)
-                with rdb_store.request('', 'GET', rdb_url) as response:
+                with rdb_store.request('GET', rdb_url) as response:
                     telstate.load_from_file(io.BytesIO(response.content))
             except ChunkStoreError as e:
                 raise_from(DataSourceNotFound(str(e)), e)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -57,7 +57,7 @@ import jwt
 
 from katdal.chunkstore_s3 import (S3ChunkStore, _AWSAuth, read_array,
                                   decode_jwt, InvalidToken, TruncatedRead,
-                                  _TEMPORARY_SERVER_ERRORS)
+                                  _DEFAULT_SERVER_GLITCHES)
 from katdal.chunkstore import StoreUnavailable, ChunkNotFound
 from katdal.test.test_chunkstore import ChunkStoreTestBase
 
@@ -69,7 +69,7 @@ BUCKET = 'katdal-unittest'
 # The effective status timeout is 4 * 0.4 + 0.1 * (0 + 2 + 4) = 2.2 seconds
 TIMEOUT = (0.2, 0.4)
 RETRY = Retry(connect=1, read=1, status=3, backoff_factor=0.1,
-              raise_on_status=False, status_forcelist=_TEMPORARY_SERVER_ERRORS)
+              raise_on_status=False, status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -277,17 +277,17 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         # several different buckets.
         slices = np.index_exp[0:5]
         x = np.arange(5)
-        self.store.create_array('private')
-        self.store.put_chunk('private', slices, x)
+        self.store.create_array('private/x')
+        self.store.put_chunk('private/x', slices, x)
         # Ceph RGW returns 403 for missing chunks too so we see ChunkNotFound
         with assert_raises(ChunkNotFound):
-            reader.get_chunk('private', slices, x.dtype)
+            reader.get_chunk('private/x', slices, x.dtype)
 
         # Now a public-read array
         store = self.from_url(self.url, public_read=True)
-        store.create_array('public')
-        store.put_chunk('public', slices, x)
-        y = reader.get_chunk('public', slices, x.dtype)
+        store.create_array('public/x')
+        store.put_chunk('public/x', slices, x)
+        y = reader.get_chunk('public/x', slices, x.dtype)
         np.testing.assert_array_equal(x, y)
 
     @timed(0.1 + 0.1)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -486,7 +486,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         with assert_raises(InvalidToken):
             self.store.is_complete('unauthorised_bucket')
 
-    @timed(0.9 + 0.1)
+    @timed(0.9 + 0.2)
     def test_recover_from_server_errors(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
@@ -504,7 +504,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         array_name = self.array_name('x', 'please-respond-with-500-for-0.8-seconds')
         assert_true(self.store.has_chunk(array_name, s, self.x.dtype))
 
-    @timed(1.0 + 0.1)
+    @timed(1.0 + 0.2)
     def test_persistent_server_errors(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
@@ -513,7 +513,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         array_name = self.array_name('x', 'please-respond-with-502-for-1.2-seconds')
         assert_false(self.store.has_chunk(array_name, s, self.x.dtype))
 
-    @timed(0.6 + 0.1)
+    @timed(0.6 + 0.2)
     def test_recover_from_truncated_chunks(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
@@ -529,12 +529,12 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         array_name = self.array_name('x', 'please-truncate-chunks-for-0.4-seconds')
         self.store.get_chunk(array_name, s, self.x.dtype)
 
-    @timed(0.6 + 0.1)
+    @timed(0.6 + 0.2)
     def test_persistent_truncated_chunks(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
         self.put_has_get_chunk('x', s)
         # After 0.6 seconds the client gives up
-        array_name = self.array_name('x', 'please-truncate-chunks-for-0.7-seconds')
+        array_name = self.array_name('x', 'please-truncate-chunks-for-0.8-seconds')
         with assert_raises(ChunkNotFound):
             self.store.get_chunk(array_name, s, self.x.dtype)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -290,14 +290,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         y = reader.get_chunk('public/x', slices, x.dtype)
         np.testing.assert_array_equal(x, y)
 
-    @timed(0.1 + 0.1)
-    def test_store_unavailable_invalid_url(self):
-        # Ensure that timeouts work
-        store = S3ChunkStore('http://apparently.invalid/', timeout=0.1, retries=0)
-        with assert_raises(StoreUnavailable):
-            store.is_complete('irrelevant_since_store_is_nonexistent')
-
-    @timed(0.4 + 0.1)
+    @timed(0.4 + 0.2)
     def test_store_unavailable_unresponsive_server(self):
         host = '127.0.0.1'
         with get_free_port(host) as port:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -513,20 +513,28 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         array_name = self.array_name('x', 'please-respond-with-502-for-1.2-seconds')
         assert_false(self.store.has_chunk(array_name, s, self.x.dtype))
 
-    @timed(0.4 + 0.1)
+    @timed(0.6 + 0.1)
     def test_recover_from_truncated_chunks(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
         self.put_has_get_chunk('x', s)
-        array_name = self.array_name('x', 'please-truncate-chunks-for-0.3-seconds')
+        # With the RETRY settings of 3 status retries and backoff factor of 0.1 s
+        # we get the following timeline (indexed by seconds):
+        # 0.0 - access chunk for the first time
+        # 0.0 - response is 200 but truncated, immediately try again (retry #1)
+        # 0.0 - response is 200 but truncated, back off for 2 * 0.1 seconds
+        # 0.2 - retry #2, response is 200 but truncated, back off for 4 * 0.1 seconds
+        # 0.6 - retry #3 (the final attempt) - server should now be fixed
+        # 0.6 - success!
+        array_name = self.array_name('x', 'please-truncate-chunks-for-0.4-seconds')
         self.store.get_chunk(array_name, s, self.x.dtype)
 
-    @timed(0.4 + 0.1)
+    @timed(0.6 + 0.1)
     def test_persistent_truncated_chunks(self):
         # First make sure some chunk is there
         s = (slice(3, 5),)
         self.put_has_get_chunk('x', s)
-        # After 0.4 seconds the client gives up
-        array_name = self.array_name('x', 'please-truncate-chunks-for-0.5-seconds')
+        # After 0.6 seconds the client gives up
+        array_name = self.array_name('x', 'please-truncate-chunks-for-0.7-seconds')
         with assert_raises(ChunkNotFound):
             self.store.get_chunk(array_name, s, self.x.dtype)


### PR DESCRIPTION
This is a rather large PR in three parts:
- The first two commits introduce the basic improvements and tests for it
- The next bunch (up to 24b57b6) refactors and removes quite a bit of code
- The last commits introduce a unified approach to 50x errors and reset connections via explicit retries
