### PR TITLE
Make mark_complete work on whole bucket again

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -613,6 +613,9 @@ class S3ChunkStore(ChunkStore):
         """See the docstring of :meth:`ChunkStore.create_array`."""
         # Array name is formatted as bucket/array but we only need to create bucket
         bucket, _ = self.split(array_name, 1)
+        self._create_bucket(bucket)
+
+    def _create_bucket(self, bucket):
         url = urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(bucket)))
         # Make bucket (409 indicates the bucket already exists, which is OK)
         self.complete_request('PUT', url, ignored_errors=(409,))
@@ -699,7 +702,8 @@ class S3ChunkStore(ChunkStore):
 
     def mark_complete(self, array_name):
         """See the docstring of :meth:`ChunkStore.mark_complete`."""
-        self.create_array(array_name)
+        bucket = self.split(array_name, 1)[0]
+        self._create_bucket(bucket)
         obj_name = self.join(array_name, 'complete')
         url = urllib.parse.urljoin(self._url, obj_name)
         self.complete_request('PUT', url, obj_name, data=b'')

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -275,8 +275,7 @@ class ChunkStoreTestBase(object):
             ref_chunk_ids = [self.store.chunk_id_str(s) for s in slices]
             assert_equal(set(chunk_ids), set(ref_chunk_ids))
 
-    def test_mark_complete(self):
-        name = self.array_name('completetest')
+    def _test_mark_complete(self, name):
         try:
             assert_false(self.store.is_complete(name))
         except NotImplementedError:
@@ -284,3 +283,9 @@ class ChunkStoreTestBase(object):
         else:
             self.store.mark_complete(name)
             assert_true(self.store.is_complete(name))
+
+    def test_mark_complete_array(self):
+        self._test_mark_complete(self.array_name('completetest'))
+
+    def test_mark_complete_top_level(self):
+        self._test_mark_complete('katdal-unittest-completetest')


### PR DESCRIPTION
PR #274 broke `mark_complete` when run on a whole bucket, because it
calls `create_array` which now crashes if the "array_name" doesn't have
a separator.

This keeps the behaviour for `create_array`, but adds a backdoor
`_create_bucket` so that `mark_complete` can once again put a completion
marker at the bucket level.