### PR TITLE
Improve error message for expired tokens

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -33,6 +33,7 @@ import base64
 import warnings
 import copy
 import json
+import time
 
 import defusedxml.ElementTree
 import defusedxml.cElementTree
@@ -244,6 +245,11 @@ def decode_jwt(token):
         # This covers e.g. bad characters in the signature or non-JSON-dict payload
         raise_from(InvalidToken(token, "Could not decode token - maybe it's truncated "
                                        "or corrupted? ({})".format(err)), err)
+    except jwt.exceptions.ExpiredSignatureError as err:
+        claims = jwt.decode(token, verify=False)
+        exp_time = time.strftime('%d-%b-%Y %H:%M:%S', time.gmtime(claims['exp']))
+        raise_from(InvalidToken(token, 'Token has expired on {} UTC, please '
+                                'obtain a new one'.format(exp_time)), err)
     except jwt.exceptions.InvalidTokenError as err:
         raise_from(InvalidToken(token, str(err)), err)
     return claims

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -248,7 +248,7 @@ def decode_jwt(token):
     except jwt.exceptions.ExpiredSignatureError as err:
         claims = jwt.decode(token, verify=False)
         exp_time = time.strftime('%d-%b-%Y %H:%M:%S', time.gmtime(claims['exp']))
-        raise_from(InvalidToken(token, 'Token has expired on {} UTC, please '
+        raise_from(InvalidToken(token, 'Token expired at {} UTC, please '
                                 'obtain a new one'.format(exp_time)), err)
     except jwt.exceptions.InvalidTokenError as err:
         raise_from(InvalidToken(token, str(err)), err)


### PR DESCRIPTION
The current error message is the default one provided by PyJWT which
reads "Signature has expired" - but what is a "signature"? To help the
end user, call it a token instead and include the expiry date/time for
handy reference. Also mention that the correct course of action is to
obtain a new one (thanks Ruby!).

This addresses JIRA ticket SR-1971.