### PR TITLE
 Add flux calibration to applycal

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -206,10 +206,12 @@ def calc_gain_correction(sensor, index, targets=None):
     series of gains for the input specified by `index` (in the form (pol, ant))
     and interpolates them over time to get the corresponding complex correction
     terms. The optional `targets` parameter is a :class:`CategoricalData` or
-    array of target indices, i.e. a sensor indicating the target associated with
-    each dump. If provided, interpolate solutions derived from one target only
-    at dumps associated with that target, which is what you want for
-    self-calibration solutions and flux calibration.
+    array of targets, i.e. a sensor indicating the target associated with each
+    dump. The targets can be actual :class:`katpoint.Target` objects or indices,
+    as long as they uniquely identify the target. If provided, interpolate
+    solutions derived from one target only at dumps associated with that target,
+    which is what you want for self-calibration solutions (but not for standard
+    calibration based on gain calibrator sources).
 
     Invalid solutions (NaNs) are replaced by linear interpolations over time
     (separately for magnitude and phase), as long as some dumps have valid
@@ -299,6 +301,7 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
         logger.warning("Disabling cal stream '%s' due to missing "
                        "spectral attributes", cal_stream)
         return
+    targets = cache.get('Observation/target')
 
     def indirect_cal_product(cache, name, product_type):
         # XXX The first underscore below is actually a telstate separator...
@@ -341,7 +344,6 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
         elif product_type == 'G':
             correction_sensor = calc_gain_correction(product_sensor, index)
         elif product_type in ('GPHASE', 'GAMP_PHASE'):
-            targets = cache.get('Observation/target_index')
             correction_sensor = calc_gain_correction(product_sensor, index, targets)
         else:
             raise KeyError("Unknown calibration product type '{}' - available "

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -313,7 +313,7 @@ class TestCalProductAccess(object):
     """Test the :func:`~katdal.applycal.*_cal_product` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
-        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
     def test_get_cal_product_basic(self):
         product_sensor = get_cal_product(self.cache, ATTRS, CAL_STREAM, 'K')
@@ -367,7 +367,7 @@ class TestCorrectionPerInput(object):
     """Test the :func:`~katdal.applycal.calc_*_correction` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
-        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
     def test_calc_delay_correction(self):
         product_sensor = get_cal_product(self.cache, ATTRS, CAL_STREAM, 'K')
@@ -411,17 +411,17 @@ class TestVirtualCorrectionSensors(object):
     """Test :func:`~katdal.applycal.add_applycal_sensors` function."""
     def setup(self):
         self.cache = create_sensor_cache()
-        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
     def test_add_sensors_does_nothing_if_no_ants_pols_or_spw(self):
         cache = create_sensor_cache()
         n_virtuals_before = len(cache.virtual)
-        add_applycal_sensors(cache, {}, [], CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(cache, {}, [], CAL_STREAM, gaincal_flux=None)
         n_virtuals_after = len(cache.virtual)
         assert_equal(n_virtuals_after, n_virtuals_before)
         attrs = ATTRS.copy()
         del attrs['center_freq']
-        add_applycal_sensors(self.cache, attrs, FREQS, CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(self.cache, attrs, FREQS, CAL_STREAM, gaincal_flux=None)
         n_virtuals_after = len(cache.virtual)
         assert_equal(n_virtuals_after, n_virtuals_before)
 
@@ -473,7 +473,7 @@ class TestVirtualCorrectionSensors(object):
 
     def test_indirect_cal_product(self):
         add_applycal_sensors(self.cache, ATTRS, FREQS, 'my_cal', [CAL_STREAM],
-                             gaincal_fluxes=None)
+                             gaincal_flux=None)
         self.test_delay_sensors('my_cal')
         self.test_bandpass_sensors('my_cal')
         self.test_gain_sensors('my_cal')
@@ -514,7 +514,7 @@ class TestCalcCorrection(object):
         self.cache = create_sensor_cache()
         # Include fluxcal, which is also done in corrections_per_corrprod
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM,
-                             gaincal_fluxes=FLUX_OVERRIDES)
+                             gaincal_flux=FLUX_OVERRIDES)
 
     def test_calc_correction(self):
         dump = 15
@@ -565,7 +565,7 @@ class TestApplyCal(object):
     """Test :func:`~katdal.applycal.apply_vis_correction` and friends"""
     def setup(self):
         self.cache = create_sensor_cache()
-        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_fluxes=None)
+        add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
     def _applycal(self, array, apply_correction):
         """Calibrate `array` with `apply_correction` and return all factors."""

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -19,6 +19,7 @@ from __future__ import print_function, division, absolute_import
 from builtins import object, range
 from functools import partial
 
+import katpoint
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 from nose.tools import assert_raises, assert_equal
@@ -140,14 +141,16 @@ def create_categorical_sensor(timestamps, values, initial_value=None):
                                  1.0, initial_value=initial_value)
 
 
-TARGET_SENSOR = create_categorical_sensor(GAIN_EVENTS,
-                                          np.arange(len(GAIN_EVENTS)) % 2)
+TARGETS = np.array([katpoint.Target('gaincal1, radec, 0, -90'),
+                    katpoint.Target('other | gaincal2, radec, 0, -80')])
+TARGET_INDICES = np.arange(len(GAIN_EVENTS)) % 2
+TARGET_SENSOR = create_categorical_sensor(GAIN_EVENTS, TARGETS[TARGET_INDICES])
 
 
 def create_sensor_cache(bandpass_parts=BANDPASS_PARTS):
     """Create a SensorCache for testing applycal sensors."""
     cache = {}
-    cache['Observation/target_index'] = TARGET_SENSOR
+    cache['Observation/target'] = TARGET_SENSOR
     # Add delay product
     delays = create_product(create_delay)
     sensor = create_categorical_sensor([3., 10.], [np.zeros_like(delays), delays])
@@ -374,7 +377,7 @@ class TestCorrectionPerInput(object):
 
     def test_calc_selfcal_gain_correction(self):
         product_sensor = get_cal_product(self.cache, ATTRS, CAL_STREAM, 'GPHASE')
-        target_sensor = self.cache.get('Observation/target_index')
+        target_sensor = self.cache.get('Observation/target')
         for n in range(len(ANTS)):
             for m in range(len(POLS)):
                 sensor = calc_gain_correction(product_sensor, (m, n), target_sensor)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -456,8 +456,7 @@ class VisibilityDataV4(DataSet):
             for prefix in reversed(attrs.prefixes):
                 l2_attrs = l2_attrs.view(prefix + l2_streams[0])
             l2_freqs = add_applycal_sensors(self.sensor, l2_attrs, freqs,
-                                            cal_stream='l2', cal_substreams=l2_streams,
-                                            gaincal_fluxes=gaincal_fluxes)
+                                            cal_stream='l2', cal_substreams=l2_streams)
             if l2_freqs is not None:
                 cal_freqs['l2'] = l2_freqs
         return cal_freqs

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -142,7 +142,7 @@ class VisibilityDataV4(DataSet):
         while the keyword 'all' means all available products will be applied.
         *NB* In future the default will probably change to 'all'.
         *NB* This is still very much an experimental feature...
-    gaincal_fluxes : dict mapping string to float, optional
+    gaincal_flux : dict mapping string to float, optional
         Flux density (in Jy) per gaincal target name, used to flux calibrate
         the "G" product, overriding the measured flux produced by cal pipeline
         (if available). A value of None disables flux calibration.
@@ -153,7 +153,7 @@ class VisibilityDataV4(DataSet):
 
     """
     def __init__(self, source, ref_ant='', time_offset=0.0, applycal='',
-                 gaincal_fluxes={}, sensor_store=None, **kwargs):
+                 gaincal_flux={}, sensor_store=None, **kwargs):
         DataSet.__init__(self, source.name, ref_ant, time_offset)
         attrs = source.metadata.attrs
 
@@ -391,7 +391,7 @@ class VisibilityDataV4(DataSet):
 
         # ------ Register applycal virtual sensors and products ------
 
-        cal_freqs = self._register_standard_cal_streams(gaincal_fluxes)
+        cal_freqs = self._register_standard_cal_streams(gaincal_flux)
         normalised_cal_products, skip_missing_products = _normalise_cal_products(
             applycal, cal_freqs.keys())
         if not self.source.data or not normalised_cal_products:
@@ -425,7 +425,7 @@ class VisibilityDataV4(DataSet):
         # on selection in the process
         self.select(spw=0, subarray=0, ants=obs_ants)
 
-    def _register_standard_cal_streams(self, gaincal_fluxes):
+    def _register_standard_cal_streams(self, gaincal_flux):
         freqs = self.spectral_windows[0].channel_freqs
         attrs = self.source.metadata.attrs
         archived_streams = attrs.get('sdp_archived_streams', [])
@@ -447,7 +447,7 @@ class VisibilityDataV4(DataSet):
         l1_attrs = attrs.view(l1_stream, exclusive=True)
         l1_freqs = add_applycal_sensors(self.sensor, l1_attrs, freqs,
                                         cal_stream='l1', cal_substreams=[l1_stream],
-                                        gaincal_fluxes=gaincal_fluxes)
+                                        gaincal_flux=gaincal_flux)
         if l1_freqs is not None:
             cal_freqs['l1'] = l1_freqs
         if l2_streams:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -144,8 +144,8 @@ class VisibilityDataV4(DataSet):
         *NB* This is still very much an experimental feature...
     gaincal_fluxes : dict mapping string to float, optional
         Flux density (in Jy) per gaincal target name, used to flux calibrate
-        the "G" product, defaults to the measured flux produced by cal pipeline
-        (if available). An empty dict will disable flux calibration.
+        the "G" product, overriding the measured flux produced by cal pipeline
+        (if available). A value of None disables flux calibration.
     sensor_store : string, optional
         Hostname / endpoint of katstore webserver to access additional sensors
     kwargs : dict, optional
@@ -153,7 +153,7 @@ class VisibilityDataV4(DataSet):
 
     """
     def __init__(self, source, ref_ant='', time_offset=0.0, applycal='',
-                 gaincal_fluxes=None, sensor_store=None, **kwargs):
+                 gaincal_fluxes={}, sensor_store=None, **kwargs):
         DataSet.__init__(self, source.name, ref_ant, time_offset)
         attrs = source.metadata.attrs
 


### PR DESCRIPTION
This applies a flux scale to those gains of the "G" calibration product that are associated with gain calibrator targets with a valid flux density in the `gaincal_fluxes` dict. More specifically, the gains are multiplied by the square root of the flux, which turns the default flux model value of 1.0 into the appropriate flux for the gain calibrator. The fluxes are obtained from the `measured_flux` telstate key produced by the cal pipeline but it can also be overridden via `katdal.open` or disabled by specifying an empty dict.

This is equivalent to the final step of the AIPS GETJY and CASA fluxscale tasks.

This addresses JIRA tickets SPR1-67 and SPAZA-27.