### PR TITLE
Fix flux calibration

### DIFF
--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -251,8 +251,8 @@ def calibrate_flux(sensor, targets, gaincal_flux):
 
     Given the gain calibration solution `sensor`, this identifies the target
     associated with each set of solutions by looking up the gain events in the
-    `targets` sensor, and then scales the gains by the square root of the
-    relevant flux if a valid match is found in the `gaincal_flux` dict. This
+    `targets` sensor, and then scales the gains by the inverse square root of
+    the relevant flux if a valid match is found in the `gaincal_flux` dict. This
     is equivalent to the final step of the AIPS GETJY and CASA fluxscale tasks.
     """
     # If no calibration info is available, do nothing
@@ -270,7 +270,7 @@ def calibrate_flux(sensor, targets, gaincal_flux):
             flux = gaincal_flux.get(name, np.nan)
             # Scale the gains if a valid flux density was found for this target
             if flux > 0.0:
-                calibrated_gains.append(ComparableArrayWrapper(gains * np.sqrt(flux)))
+                calibrated_gains.append(ComparableArrayWrapper(gains / np.sqrt(flux)))
                 break
         else:
             calibrated_gains.append(ComparableArrayWrapper(gains))

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -75,7 +75,7 @@ TARGETS = np.array([katpoint.Target('gaincal1, radec, 0, -90'),
                     katpoint.Target('other | gaincal2, radec, 0, -80')])
 TARGET_INDICES = np.arange(len(GAIN_EVENTS)) % 2
 FLUX_VALUES = np.array([16.0, 4.0])
-FLUX_SCALE_FACTORS = np.sqrt(FLUX_VALUES[TARGET_INDICES])
+FLUX_SCALE_FACTORS = 1.0 / np.sqrt(FLUX_VALUES[TARGET_INDICES])
 FLUXES = {'gaincal1': FLUX_VALUES[0], 'gaincal2': FLUX_VALUES[1]}
 # The measured flux for gaincal1 is wrong on purpose so that we have to
 # override it. There is also an extra unknown gain calibrator in the mix.

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -91,7 +91,7 @@ def _relative_view(telstate, name):
 
 
 def _normalise_cal_products(products, cal_streams):
-    """"""
+    """Expand user-supplied list of cal products into fully qualified versions."""
     requested_cal_products = _selection_to_list(products, all=cal_streams,
                                                 default=DEFAULT_CAL_PRODUCTS)
     skip_missing_products = products in ('all', 'default') or any(

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -458,15 +458,14 @@ class VisibilityDataV4(DataSet):
         freqs = self.spectral_windows[0].channel_freqs
         cal_freqs = {}
         l1_attrs = _relative_view(attrs, l1_stream)
-        l1_freqs = add_applycal_sensors(self.sensor, l1_attrs, freqs,
-                                        cal_stream='l1', cal_substreams=[l1_stream],
-                                        gaincal_flux=gaincal_flux)
+        l1_freqs = add_applycal_sensors(self.sensor, l1_attrs, freqs, cal_stream='l1',
+                                        cal_substreams=[l1_stream], gaincal_flux=gaincal_flux)
         if l1_freqs is not None:
             cal_freqs['l1'] = l1_freqs
         if l2_streams:
             l2_attrs = _relative_view(attrs, l2_streams[0])
-            l2_freqs = add_applycal_sensors(self.sensor, l2_attrs, freqs,
-                                            cal_stream='l2', cal_substreams=l2_streams)
+            l2_freqs = add_applycal_sensors(self.sensor, l2_attrs, freqs, cal_stream='l2',
+                                            cal_substreams=l2_streams, gaincal_flux=None)
             if l2_freqs is not None:
                 cal_freqs['l2'] = l2_freqs
         return cal_freqs


### PR DESCRIPTION
- Look for `measured_flux` in the right place by adding relative telstate views to access `cb_cal` namespace
- Divide gains by flux instead of multiplying it

There is also a slight rework of `_register_standard_cal_streams` to use the new relative views.