### PR TITLE
Avoid using has_array in ChunkStoreVisFlagsWeights

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -237,13 +237,13 @@ class ChunkStore(object):
         """
         raise NotImplementedError
 
-    def get_chunk_or_default(self, array_name, slices, dtype, fill_value=0):
+    def get_chunk_or_default(self, array_name, slices, dtype, default_value=0):
         """Get chunk from the store but return default value if it is missing."""
         try:
             return self.get_chunk(array_name, slices, dtype)
         except ChunkNotFound:
             chunk_name, shape = self.chunk_metadata(array_name, slices)
-            return np.full(shape, fill_value, dtype)
+            return np.full(shape, default_value, dtype)
 
     def get_chunk_or_none(self, array_name, slices, dtype):
         """Get chunk from the store but return ``None`` if it is missing."""
@@ -495,7 +495,7 @@ class ChunkStore(object):
             get_func = self.get_chunk
         else:
             get_func = self.get_chunk_or_default
-            kwargs['fill_value'] = errors
+            kwargs['default_value'] = errors
         getter = functools.partial(get_func, **kwargs)
         if offset:
             getter = _add_offset_to_slices(getter, offset)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -237,20 +237,17 @@ class ChunkStore(object):
         """
         raise NotImplementedError
 
-    def get_chunk_or_default(self, array_name, slices, dtype, fill_value=0):
-        """Get chunk from the store but return default value if it is missing."""
+    def get_chunk_or_default(self, array_name, slices, dtype, default_value=0):
+        """Get chunk from the store but return default value if it is missing.
+
+        If a default value is returned, it is guaranteed to have all-zero
+        strides. This can be used to distinguish it from a real chunk.
+        """
         try:
             return self.get_chunk(array_name, slices, dtype)
         except ChunkNotFound:
             chunk_name, shape = self.chunk_metadata(array_name, slices)
-            return np.full(shape, fill_value, dtype)
-
-    def get_chunk_or_none(self, array_name, slices, dtype):
-        """Get chunk from the store but return ``None`` if it is missing."""
-        try:
-            return self.get_chunk(array_name, slices, dtype)
-        except ChunkNotFound:
-            return None
+            return np.broadcast_to(np.full((), default_value, dtype), shape)
 
     def create_array(self, array_name):
         """Create a new array if it does not already exist.
@@ -471,17 +468,10 @@ class ChunkStore(object):
             Data type of array
         offset : tuple of int, optional
             Offset to add to each dimension when addressing chunks in store
-        errors : number or 'raise' or 'none', optional
+        errors : number or 'raise', optional
             Error handling. If 'raise', exceptions are passed through,
-            causing the evaluation to fail.
-
-            If 'none', returns ``None`` in
-            place of missing chunks. Note that such an array cannot be used
-            as-is, because an ndarray is expected, but it can be used as raw
-            material for building new graphs via functions like
-            :func:`da.map_blocks`.
-
-            If a numeric value, it is used as a default value.
+            causing the evaluation to fail. Otherwise, it is used as a default
+            value (see :meth:`get_chunk_or_default`).
 
         Returns
         -------
@@ -489,13 +479,11 @@ class ChunkStore(object):
             Dask array of given dtype
         """
         kwargs = {'dtype': dtype}
-        if errors == 'none':
-            get_func = self.get_chunk_or_none
-        elif errors == 'raise':
+        if errors == 'raise':
             get_func = self.get_chunk
         else:
             get_func = self.get_chunk_or_default
-            kwargs['fill_value'] = errors
+            kwargs['default_value'] = errors
         getter = functools.partial(get_func, **kwargs)
         if offset:
             getter = _add_offset_to_slices(getter, offset)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -289,6 +289,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
                          chunks=darray['flags'].chunks,
                          shape=darray['flags'].shape,
                          dtype=darray['flags'].dtype)
+        darray['flags'] = flags
 
         # Turn missing blocks in the other arrays into zeros to make them
         # valid dask arrays.

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -99,13 +99,19 @@ class VisFlagsWeights(object):
         return self.vis.shape
 
 
+def _default_zero(array, shape, dtype):
+    if array is None:
+        return np.zeros(shape, dtype)
+    else:
+        return array
+
+
 def _apply_data_lost(orig_flags, lost):
     if not lost:
         return orig_flags
     flags = orig_flags
     for chunk, slices in toolz.partition(2, lost):
-        if all(stride == 0 for stride in chunk.strides):
-            # It's a singleton default value that's been broadcast
+        if chunk is None:
             if flags is orig_flags:
                 flags = orig_flags.copy()
             flags[slices] |= DATA_LOST
@@ -237,7 +243,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
         for array, info in chunk_info.items():
             array_name = store.join(info['prefix'], array)
             chunk_args = (array_name, info['chunks'], info['dtype'])
-            errors = DATA_LOST if array == 'flags' else 0
+            errors = DATA_LOST if array == 'flags' else 'none'
             darray[array] = store.get_dask_array(*chunk_args, errors=errors)
         flags_orig_name = darray['flags'].name
         flags_raw_name = store.join(chunk_info['flags']['prefix'], 'flags_raw')
@@ -284,6 +290,27 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
                          shape=darray['flags'].shape,
                          dtype=darray['flags'].dtype)
         darray['flags'] = flags
+
+        # Turn missing blocks in the other arrays into zeros to make them
+        # valid dask arrays.
+        for array_name, array in darray.items():
+            if array_name == 'flags':
+                continue
+            new_name = 'filled-' + array.name
+            indices = itertools.product(*(range(len(c)) for c in array.chunks))
+            dsk = {
+                (new_name,) + index: (
+                    _default_zero,
+                    (array.name,) + index,
+                    shape,
+                    array.dtype
+                ) for index, shape in zip(indices, itertools.product(*array.chunks))
+            }
+            dsk = HighLevelGraph.from_collections(new_name, dsk, dependencies=[array])
+            darray[array_name] = da.Array(dsk, new_name,
+                                          chunks=array.chunks,
+                                          shape=array.shape,
+                                          dtype=array.dtype)
 
         vis = darray['correlator_data']
         # Combine low-resolution weights and high-resolution weights_channel

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -261,7 +261,7 @@ class ChunkStoreTestBase(object):
             assert_equal(array_retrieved.shape, dask_array.shape)
             assert_equal(array_retrieved.dtype, dask_array.dtype)
             assert_array_equal(array_retrieved[np.s_[3:8, 30:60, 0:2]], 17,
-                               "Missing chunk in {} not replaced by zeros"
+                               "Missing chunk in {} not replaced by default value"
                                .format(array_name))
         # Now store the last quarter and check that complete array is correct
         self.put_dask_array('big_y2', np.s_[3:8, 30:60, 0:2])

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -208,9 +208,8 @@ class ChunkStoreTestBase(object):
         zeros = self.store.get_chunk_or_default(*args)
         assert_array_equal(zeros, np.zeros(shape, dtype))
         assert_equal(zeros.dtype, dtype)
-        ones = self.store.get_chunk_or_default(*args, fill_value=1)
+        ones = self.store.get_chunk_or_default(*args, default_value=1)
         assert_array_equal(ones, np.ones(shape, dtype))
-        assert_is_none(self.store.get_chunk_or_none(*args))
 
     def test_chunk_bool_1dim_and_too_small(self):
         # Check basic put + get on 1-D bool

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -208,7 +208,7 @@ class ChunkStoreTestBase(object):
         zeros = self.store.get_chunk_or_default(*args)
         assert_array_equal(zeros, np.zeros(shape, dtype))
         assert_equal(zeros.dtype, dtype)
-        ones = self.store.get_chunk_or_default(*args, fill_value=1)
+        ones = self.store.get_chunk_or_default(*args, default_value=1)
         assert_array_equal(ones, np.ones(shape, dtype))
         assert_is_none(self.store.get_chunk_or_none(*args))
 

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -208,8 +208,9 @@ class ChunkStoreTestBase(object):
         zeros = self.store.get_chunk_or_default(*args)
         assert_array_equal(zeros, np.zeros(shape, dtype))
         assert_equal(zeros.dtype, dtype)
-        ones = self.store.get_chunk_or_default(*args, default_value=1)
+        ones = self.store.get_chunk_or_default(*args, fill_value=1)
         assert_array_equal(ones, np.ones(shape, dtype))
+        assert_is_none(self.store.get_chunk_or_none(*args))
 
     def test_chunk_bool_1dim_and_too_small(self):
         # Check basic put + get on 1-D bool


### PR DESCRIPTION
Instead, just try to load things, and if any of them fail, apply flags.
This has a few advantages:

1. chunkstore_s3 is non-deterministic, because it will treat a 403 or
50x error as a missing chunk even if the bucket listing included the
chunk. This meant that even when loading vis, flags, weights jointly,
the vis/weights could be missing and the flags wouldn't reflect this (or
if the flags got a 50x, it would return zero flags). With this change,
joint loading should always return consistent results.

2. Getting the list of all chunks could add a lot of time to
`katdal.open`, which now disappears.

A synthetic benchmark (with no applycal) shows that loading drops from
about 3.3GB/s to about 3GB/s, but that's still faster than the 25Gb/s
network can deliver the data.

This is part 1, which just removes the calls to has_array. Part 2 will
remove all the has_array interfaces and the dependence on defusedxml.