### PR TITLE
Cache combined bandpass

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -692,7 +692,8 @@ class SensorCache(dict):
         (this can be disabled on data retrieval)
     props : dict, optional
         Default properties that govern how sensor data are interpreted and
-        interpolated (this can be overridden on data retrieval)
+        interpolated (this can be overridden on data retrieval). Can use ``*``
+        as a wildcard anywhere in the key.
     virtual : dict mapping string to function, optional
         Virtual sensors, specified as a pattern matching the virtual sensor name
         and a corresponding function that will create the sensor (together with
@@ -873,8 +874,10 @@ class SensorCache(dict):
                 self.props[name] = props = self.props.get(name, {})
                 # Look up properties associated with this class of sensor
                 for key, val in self.props.items():
-                    if key[0] == '*' and name.endswith(key[1:]):
-                        props.update(val)
+                    if '*' in key:
+                        regex = '.*'.join(re.escape(part) for part in key.split('*'))
+                        if re.match('^' + regex + '$', name):
+                            props.update(val)
                 # Any properties passed directly to this method takes precedence
                 props.update(kwargs)
                 # Clean up sensor data if non-empty

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -609,7 +609,7 @@ def remove_duplicates_and_invalid_values(sensor):
     # Determine the index of the x value chosen to represent each original x value (used to pick y values too)
     replacement = unique_ind[len(unique_ind) - np.cumsum(last_of_run[::-1])[::-1]]
     # All duplicates should have the same y and z values - complain otherwise, but continue
-    y_differs = [n for (r, n) in zip(replacement, range(len(y))) if y[r] != y[n]]
+    y_differs = [n for (r, n) in zip(replacement, range(len(y))) if r != n and y[r] != y[n]]
     if y_differs:
         logger.debug("Sensor %r has duplicate timestamps with different values",
                      sensor.name)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -58,6 +58,9 @@ SENSOR_PROPS.update({
     '*_product_G': {'initial_value': INVALID_GAIN},
     '*_product_GPHASE': {'initial_value': INVALID_GAIN},
     '*_product_GAMP_PHASE': {'initial_value': INVALID_GAIN},
+    'Calibration/Products/*/G': {'initial_value': INVALID_GAIN},
+    'Calibration/Products/*/GPHASE': {'initial_value': INVALID_GAIN},
+    'Calibration/Products/*/GAMP_PHASE': {'initial_value': INVALID_GAIN}
 })
 
 SENSOR_ALIASES = {


### PR DESCRIPTION
Instead of Calibration/Products/cal/B<n> which have to be stitched
together across frequencies to form the bandpass solution, there is now
a virtual Calibration/Products/cal/B which handles the stitching
internally. This allows it to be cached once extracted.