### PR TITLE
Allow DecodeError to propagate in v3

### DIFF
--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -609,7 +609,7 @@ class H5DataV3(DataSet):
             # needs to stay binary
             value = self.file['TelescopeState'].attrs[key]
             return telstate_decode(value, no_decode)
-        except (KeyError, katsdptelstate.DecodeError):
+        except KeyError:
             # In some cases the value is placed in a sensor instead. Return
             # the most recent value.
             try:


### PR DESCRIPTION
A likely cause of such errors is pickled encoding, which triggers an
error unless the user has set the appropriate environment variable to
allow it (unsafe).

This may cause some files that have invalid encoding (e.g. from the
early days where telescope state just used `repr`) to fail, but that's
probably better than just ignoring data in the file and using a default
instead. If users complain we can then fix katdal to handle such files.

The approach of treating decoding errors the same as missing data seems
to date back to 645a5e2, where it was applied just to the band (and
would at least lead to a warning that the receiver band couldn't be
determined).

Closes SPR1-446.