### PR TITLE
Explicitly pass file mode to h5py.File

### DIFF
--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -128,7 +128,7 @@ def dummy_dataset(name, shape, dtype, value):
     # It is important to randomise the filename as h5py does not allow two writable file objects with the same name
     # Without this randomness katdal can only open one file requiring a dummy dataset
     random_string = ''.join(['%02x' % (x,) for x in np.random.randint(256, size=8)])
-    dummy_file = h5py.File('%s_%s.h5' % (name, random_string), driver='core', backing_store=False)
+    dummy_file = h5py.File('%s_%s.h5' % (name, random_string), 'x', driver='core', backing_store=False)
     return dummy_file.create_dataset(name, shape=shape, maxshape=shape,
                                      dtype=dtype, fillvalue=value, compression='gzip')
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -108,7 +108,7 @@ def dummy_dataset(name, shape, dtype, value):
     # It is important to randomise the filename as h5py does not allow two writable file objects with the same name
     # Without this randomness katdal can only open one file requiring a dummy dataset
     random_string = ''.join(['%02x' % (x,) for x in np.random.randint(256, size=8)])
-    dummy_file = h5py.File('%s_%s.h5' % (name, random_string), driver='core', backing_store=False)
+    dummy_file = h5py.File('%s_%s.h5' % (name, random_string), 'x', driver='core', backing_store=False)
     return dummy_file.create_dataset(name, shape=shape, maxshape=shape,
                                      dtype=dtype, fillvalue=value, compression='gzip')
 


### PR DESCRIPTION
For dummy_dataset (the real file already does it). This avoids a
deprecation warning from h5py that the default mode will change to 'r'.