### PR TITLE
Use MutableMapping for SensorCache

### DIFF
--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -451,7 +451,7 @@ class ConcatenatedSensorCache(SensorCache):
             except KeyError:
                 pass
         if not found:
-            raise KeyError
+            raise KeyError(name)
 
     def __contains__(self, name):
         return any(name in cache for cache in self.caches)

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -301,11 +301,9 @@ class ConcatenatedSensorCache(SensorCache):
 
     def __init__(self, caches, keep=None):
         self.caches = caches
-        # Collect all actual and virtual sensors in caches as well as properties
-        # The main point is to discover the name and dtype of each known sensor
-        actual, virtual, self.props = {}, {}, {}
+        # Collect all virtual sensors in caches as well as properties.
+        virtual, self.props = {}, {}
         for cache in caches:
-            actual.update(cache.items())
             virtual.update(cache.virtual)
             self.props.update(cache.props)
         self.virtual = virtual
@@ -444,10 +442,31 @@ class ConcatenatedSensorCache(SensorCache):
             for n, cache in enumerate(self.caches):
                 cache[name] = data[self._segments[n]:self._segments[n + 1]]
 
-    def iterkeys(self):
+    def __delitem__(self, name):
+        found = False
+        for cache in self.caches:
+            try:
+                del cache[name]
+                found = True
+            except KeyError:
+                pass
+        if not found:
+            raise KeyError
+
+    def __contains__(self, name):
+        return any(name in cache for cache in self.caches)
+
+    def __len__(self):
+        return sum(1 for _ in self)
+
+    def __iter__(self):
         """Key iterator that iterates through sensor names."""
-        # Run through first cache's keys, as they should all be identical
-        return self.caches[0].iterkeys()
+        seen = set()
+        for cache in self.caches:
+            for key in cache:
+                if key not in seen:
+                    seen.add(key)
+                    yield key
 
 # -------------------------------------------------------------------------------------------------
 # -- CLASS :  ConcatenatedDataSet

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -25,7 +25,10 @@ from past.builtins import unicode
 import logging
 import re
 import threading
-import collections.abc
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 import numpy as np
 import katpoint
@@ -561,7 +564,7 @@ def remove_duplicates_and_invalid_values(sensor):
 # -------------------------------------------------------------------------------------------------
 
 
-class SensorCache(collections.abc.MutableMapping):
+class SensorCache(MutableMapping):
     """Container for sensor data providing name lookup, interpolation and caching.
 
     *Sensor data* is defined as a one-dimensional time series of values. The

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -21,7 +21,7 @@ from __future__ import print_function, division, absolute_import
 from builtins import object
 
 import numpy as np
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises
 
 from katdal.categorical import CategoricalData
 from katdal.sensordata import SensorCache, SimpleSensorGetter
@@ -127,3 +127,16 @@ class TestConcatenatedSensorCache(object):
         self.cache['fib'] = data
         ans = self.cache.get('fib')
         np.testing.assert_array_equal(data, ans)
+
+    def test_len(self):
+        assert_equal(len(self.cache), 4)
+
+    def test_keys(self):
+        assert_equal(sorted(self.cache.keys()), ['cat', 'float_missing', 'foo', 'int_missing'])
+
+    def test_contains(self):
+        assert_in('cat', self.cache)
+        assert_in('float_missing', self.cache)
+        assert_in('int_missing', self.cache)
+        assert_not_in('dog', self.cache)
+        assert_not_in('', self.cache)


### PR DESCRIPTION
This provides more predictable/controllable behaviour compared to
inheriting directly from dict. I also made some fixes to
ConcatenatedSensorCache regarding iteration and length (previously it
implemented iterkeys, which didn't work at all in Python 3 and also made
the assumption that the underlying caches had exactly the same keys).

Querying a sensor cache can cause new keys to appear in the underlying
dict (as virtuals are expanded), so it was necessary to make some
choices). I decided that __contains__ will only consider instantiated
keys, not virtuals, making it consistent with `keys()` and `len` (and
the previous implementation of SensorCache), but inconsistent with
`__getitem__`.

One user-visible change in SensorCache is that `items()` and `.values()`
will now return extracted data, because MutableMapping implements them
in terms of `__getitem__`.

Closes SPR1-445.