### PR TITLE
Run tests against Python 3 only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 #!groovy
 
-@Library('katsdpjenkins@python2') _
+@Library('katsdpjenkins') _
 katsdp.killOldJobs()
 katsdp.setDependencies([
-    'ska-sa/katsdpdockerbase/python2',
+    'ska-sa/katsdpdockerbase/master',
     'ska-sa/katpoint/master',
     'ska-sa/katsdptelstate/master'])
-katsdp.standardBuild(python3: true, katsdpdockerbase_ref: 'python2')
+katsdp.standardBuild()
 katsdp.mail('ludwig@ska.ac.za')

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,6 +13,12 @@ requests
 snowballstemmer
 sphinx
 sphinx-rtd-theme
+sphinxcontrib-applehelp
+sphinxcontrib-devhelp
+sphinxcontrib-htmlhelp
+sphinxcontrib-jsmath
+sphinxcontrib-qthelp
+sphinxcontrib-serializinghtml
 sphinxcontrib-websupport
 typing; python_version<'3'
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cityhash
 dask
 docutils
 ephem
-funcsigs
 jmespath
 future
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
 botocore
 certifi
 chardet
-cityhash==0.2.3.post9
+cityhash
 dask
 docutils
-enum34
+ephem
 funcsigs
 jmespath
 future
 h5py
 idna
-ipaddress
 katversion
 llvmlite
 msgpack
@@ -24,9 +23,7 @@ python-lzf
 rdbtools
 redis
 requests
-singledispatch
 six
-subprocess32
 toolz
 urllib3
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
 coverage
-funcsigs
-mock
+mock==4.0.2
 nose
-pbr

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coverage
 mock==4.0.2
 nose
+subprocess32==3.5.4


### PR DESCRIPTION
Now that katsdptelstate is Python 3 only, the Python 2 unit tests are
failing.