### PR TITLE
Fix filtering of sensor events with invalid status

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -533,7 +533,10 @@ def remove_duplicates_and_invalid_values(sensor):
     z = sensor.status
     # Sort x via mergesort, as it is usually already sorted and stability is important
     sort_ind = np.argsort(x, kind='mergesort')
-    x, y = x[sort_ind], y[sort_ind]
+    x = x[sort_ind]
+    y = y[sort_ind]
+    if z is not None:
+        z = z[sort_ind]
     # Array contains True where an x value is unique or the last of a run of identical x values
     last_of_run = np.asarray(list(np.diff(x) != 0) + [True])
     # Discard the False values, as they represent duplicates - simultaneously keep last of each run of duplicates


### PR DESCRIPTION
After sorting the sensor timestamps, the values are updated accordingly but not the statuses, which is a bug. Normally this is not an issue because timestamps tend to be chronological anyway. The somewhat insidious interaction between value and sample/update timestamps may however occasionally cause a later event to be sampled before an earlier event. An example is the `cbf_1_wide_input_labelling` sensor during CBID 1588667937 which triggered this fix.

Add a test to check this corner case and also exercise the various code paths in the filter function.
