### PR TITLE
Release v0.16 redux

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,7 +9,7 @@ History
 * Increase katstore search window by 600 seconds to find infrequent updates (#302)
 * Refactor SensorData to become a lazy abstract interface without caching (#292)
 * Refactor SensorCache to use MutableMapping (#300)
-* Fix rx_serial sensor use and file mode warning in HDF5v3 files (#298, #299)
+* Fix rx_serial sensor use and file mode warning in MVFv3 files (#298, #299)
 
 0.15 (2020-03-13)
 -----------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+0.16 (2020-08-28)
+-----------------
+* This is the last release that will support Python 2 (python2 maintenance branch)
+* New 'time_offset' sensor property that adjusts timestamps of any sensor (#307)
+* Fix calculation of cbf_dump_period for 'wide' / 'narrowN' instruments (#301)
+* Increase katstore search window by 600 seconds to find infrequent updates (#302)
+* Refactor SensorData to become a lazy abstract interface without caching (#292)
+* Refactor SensorCache to use MutableMapping (#300)
+* Fix rx_serial sensor use and file mode warning in HDF5v3 files (#298, #299)
+
 0.15 (2020-03-13)
 -----------------
 * Improve S3 chunk store: check tokens, improve timeouts and retries (#272 - #277)


### PR DESCRIPTION
I forgot to add the 0.16 release notes to master (it was done in the python2 branch).

Cherry-pick these in place instead of merging in order to keep the commit graph nice. It was already a belated release, so I prefer that the python2 branch remain unmerged to help find the spot on master that is the "actual" v0.16.