### PR TITLE
Fix kwargs bug introduced by #316

### DIFF
--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -459,6 +459,9 @@ class TelstateDataSource(DataSource):
         telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate, **kwargs)
         if chunk_store == 'auto':
             chunk_store = infer_chunk_store(url_parts, telstate, **kwargs)
+        # Remove these from kwargs since they have already been extracted by view_l0_capture_stream
+        kwargs.pop('capture_block_id', None)
+        kwargs.pop('stream_name', None)
         return cls(telstate, capture_block_id, stream_name, chunk_store,
                    source_name=url_parts.geturl(), **kwargs)
 


### PR DESCRIPTION
Kwargs now flow to `TelstateDataSource.__init__` too, but if the CBID and/or stream name are specified in kwargs, they clash with the explicit versions passed to the constructor. The solution is to clear them out of kwargs after `view_l0_capture_stream` picked them up.

I've postponed the unit test improvements to a later PR since that part has grown quite a bit.