### PR TITLE
Datasource unit tests

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -42,6 +42,10 @@ class StoreUnavailable(OSError, ChunkStoreError):
 class ChunkNotFound(KeyError, ChunkStoreError):
     """The store was accessible but a chunk with the given name was not found."""
 
+    def __str__(self):
+        """Avoid the implicit repr() of KeyError since we'll have explanatory text."""
+        return ChunkStoreError.__str__(self)
+
 
 class BadChunk(ValueError, ChunkStoreError):
     """The chunk is malformed, e.g. bad dtype or slices, wrong buffer size."""

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -33,7 +33,6 @@ import base64
 import copy
 import json
 import time
-import xml.dom.minidom
 
 import numpy as np
 import requests
@@ -530,11 +529,7 @@ class S3ChunkStore(ChunkStore):
                         prefix, status, response.reason, response.request.method, response.url)
                     content_type = response.headers.get('Content-Type')
                     if content_type in ('application/xml', 'text/xml', 'text/plain'):
-                        msg += '\nDetails of server response:\n'
-                        if content_type.endswith('xml'):
-                            msg += xml.dom.minidom.parseString(response.content).toprettyxml()
-                        else:
-                            msg += response.text
+                        msg += '\nDetails of server response: {}'.format(response.text)
                     # Raise the appropriate exception
                     if status == 401:
                         raise AuthorisationFailed(msg)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -414,7 +414,9 @@ class S3ChunkStore(ChunkStore):
     url : str
         Endpoint of S3 service, e.g. 'http://127.0.0.1:9000'. It can be
         specified as either bytes or unicode, and is converted to the native
-        string type with UTF-8.
+        string type with UTF-8. The URL may also contain a path if this store is
+        relative to an existing bucket, in which case the chunk name is a relative
+        path (useful for unit tests).
     timeout : float or tuple of 2 floats, optional
         Connect / read timeout, in seconds, either a single value for both or
         custom values as (connect, read) tuple (set to None to leave unchanged)
@@ -474,8 +476,9 @@ class S3ChunkStore(ChunkStore):
         self.public_read = public_read
         self.expiry_days = int(expiry_days)
 
-    def _chunk_url(self, chunk_name):
-        return urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(chunk_name + '.npy')))
+    def _chunk_url(self, chunk_name, extension='.npy'):
+        """Assemble URL corresponding to chunk (or array) name."""
+        return urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(chunk_name + extension)))
 
     @contextlib.contextmanager
     def request(self, method, url, chunk_name='', ignored_errors=(), timeout=(), **kwargs):
@@ -624,11 +627,15 @@ class S3ChunkStore(ChunkStore):
     def create_array(self, array_name):
         """See the docstring of :meth:`ChunkStore.create_array`."""
         # Array name is formatted as bucket/array but we only need to create bucket
-        bucket, _ = self.split(array_name, 1)
-        self._create_bucket(bucket)
+        url = self._chunk_url(array_name, extension='')
+        split_url = urllib.parse.urlsplit(url)
+        # Only keep first path component as this references S3 bucket (may be part of store URL)
+        bucket_name = split_url.path.lstrip('/').split('/')[0]
+        # Note to self: namedtuple._replace is not a private method, despite the underscore!
+        bucket_url = split_url._replace(path=bucket_name).geturl()
+        self._create_bucket(bucket_name, bucket_url)
 
-    def _create_bucket(self, bucket):
-        url = urllib.parse.urljoin(self._url, to_str(urllib.parse.quote(bucket)))
+    def _create_bucket(self, bucket, url):
         # Make bucket (409 indicates the bucket already exists, which is OK)
         self.complete_request('PUT', url, ignored_errors=(409,))
 
@@ -668,8 +675,7 @@ class S3ChunkStore(ChunkStore):
 
     def mark_complete(self, array_name):
         """See the docstring of :meth:`ChunkStore.mark_complete`."""
-        bucket = self.split(array_name, 1)[0]
-        self._create_bucket(bucket)
+        self.create_array(array_name)
         obj_name = self.join(array_name, 'complete')
         url = urllib.parse.urljoin(self._url, obj_name)
         self.complete_request('PUT', url, obj_name, data=b'')

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -266,6 +266,3 @@ class ChunkStoreTestBase(object):
 
     def test_mark_complete_array(self):
         self._test_mark_complete(self.array_name('completetest'))
-
-    def test_mark_complete_top_level(self):
-        self._test_mark_complete('katdal-unittest-completetest')

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -429,7 +429,8 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
         # XXX Could also use args[0] instead of requestline, not sure which is best
         key = self.requestline
         now = time.time()
-        initial_time = self.server.initial_request_time.get(key, now)
+        # Print 0.0 for a fresh suggestion and -1.0 for a stale / absent suggestion (no key found)
+        initial_time = self.server.initial_request_time.get(key, now + 1.0)
         time_offset = now - initial_time
         # Print to stdout instead of stderr so that it doesn't spew all over
         # the screen in normal operation.
@@ -558,10 +559,10 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
         assert_array_equal(chunk_retrieved, chunk, 'Truncated read not recovered')
 
-    @timed(0.6 + 0.2)
+    @timed(0.6 + 0.4)
     def test_persistent_truncated_reads(self):
         chunk, slices, array_name = self.prepare(
-            'please-truncate-read-after-60-bytes-for-0.8-seconds')
+            'please-truncate-read-after-60-bytes-for-1.0-seconds')
         # After 0.6 seconds the client gives up
         with assert_raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -62,7 +62,7 @@ from katdal.chunkstore import StoreUnavailable, ChunkNotFound
 from katdal.test.test_chunkstore import ChunkStoreTestBase
 from katdal.test.s3_utils import S3User, S3Server, MissingProgram
 from katdal.datasources import TelstateDataSource
-from katdal.test.test_datasources import make_fake_datasource, assert_telstate_data_source_equal
+from katdal.test.test_datasources import make_fake_data_source, assert_telstate_data_source_equal
 
 
 BUCKET = 'katdal-unittest'
@@ -284,7 +284,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
 
     def test_rdb_support(self):
         telstate = katsdptelstate.TelescopeState()
-        view, cbid, sn, _, _ = make_fake_datasource(telstate, self.store, (5, 16, 40))
+        view, cbid, sn, _, _ = make_fake_data_source(telstate, self.store, (5, 16, 40))
         telstate['capture_block_id'] = cbid
         telstate['stream_name'] = sn
         # Save telstate to temp RDB file since RDBWriter needs a filename and not a handle

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -284,6 +284,9 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         with assert_raises(StoreUnavailable):
             S3ChunkStore('http://apparently.invalid/', token='secrettoken')
 
+    def test_mark_complete_top_level(self):
+        self._test_mark_complete(PREFIX + '-completetest')
+
     def test_rdb_support(self):
         telstate = katsdptelstate.TelescopeState()
         view, cbid, sn, _, _ = make_fake_data_source(telstate, self.store, (5, 16, 40), PREFIX)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -397,8 +397,8 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
         time_offset = now - initial_time
         # Print to stdout instead of stderr so that it doesn't spew all over
         # the screen in normal operation.
-        print("%s (%.3f) %s" % (self.log_date_time_string(),
-                                time_offset, format % args))
+        print("Token proxy: %s (%.3f) %s" % (self.log_date_time_string(),
+                                             time_offset, format % args))
 
 
 class _TokenHTTPProxyServer(http.server.HTTPServer):

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -77,7 +77,7 @@ def _make_fake_stream(telstate, store, cbid, stream, shape,
     return data, cs_view, s_view
 
 
-def make_fake_datasource(telstate, store, l0_shape, cbid='cb', l1_flags_shape=None,
+def make_fake_data_source(telstate, store, l0_shape, cbid='cb', l1_flags_shape=None,
                          l0_chunk_overrides=None, l1_flags_chunk_overrides=None,
                          l0_array_overrides=None, l1_flags_array_overrides=None):
     """Create a complete fake data source.
@@ -131,7 +131,7 @@ class TestTelstateDataSource(object):
     def test_basic_timestamps(self):
         # Add a sensor to telstate to exercise the relevant code paths in TelstateDataSource
         self.telstate.add('obs_script_log', 'Digitisers synced', ts=123456789., immutable=False)
-        view, cbid, sn, _, _ = make_fake_datasource(self.telstate, self.store, (20, 64, 40))
+        view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         data_source = TelstateDataSource(view, cbid, sn, chunk_store=None, source_name='hello')
         assert 'hello' in data_source.name
         assert data_source.data is None
@@ -140,7 +140,7 @@ class TestTelstateDataSource(object):
 
     def test_upgrade_flags(self):
         shape = (20, 16, 40)
-        view, cbid, sn, l0_data, l1_flags_data = make_fake_datasource(
+        view, cbid, sn, l0_data, l1_flags_data = make_fake_data_source(
             self.telstate, self.store, shape)
         data_source = TelstateDataSource(view, cbid, sn, self.store)
         np.testing.assert_array_equal(data_source.data.vis.compute(), l0_data['correlator_data'])
@@ -154,7 +154,7 @@ class TestTelstateDataSource(object):
         """L1 flags has fewer dumps than L0"""
         l0_shape = (20, 16, 40)
         l1_flags_shape = (18, 16, 40)
-        view, cbid, sn, l0_data, l1_flags_data = make_fake_datasource(
+        view, cbid, sn, l0_data, l1_flags_data = make_fake_data_source(
             self.telstate, self.store, l0_shape, l1_flags_shape=l1_flags_shape,
             l0_chunk_overrides=l0_chunk_overrides,
             l1_flags_chunk_overrides=l1_flags_chunk_overrides)
@@ -183,7 +183,7 @@ class TestTelstateDataSource(object):
         """L1 flags has more dumps than L0"""
         l0_shape = (18, 16, 40)
         l1_flags_shape = (20, 16, 40)
-        view, cbid, sn, l0_data, l1_flags_data = make_fake_datasource(
+        view, cbid, sn, l0_data, l1_flags_data = make_fake_data_source(
             self.telstate, self.store, l0_shape, l1_flags_shape=l1_flags_shape,
             l0_chunk_overrides=l0_chunk_overrides,
             l1_flags_chunk_overrides=l1_flags_chunk_overrides)
@@ -214,14 +214,14 @@ class TestTelstateDataSource(object):
         """L1 flags shape is incompatible with L0"""
         l0_shape = (18, 16, 40)
         l1_flags_shape = (20, 8, 40)
-        view, cbid, sn, _, _ = make_fake_datasource(self.telstate, self.store, l0_shape,
+        view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, l0_shape,
                                                     l1_flags_shape=l1_flags_shape)
         with assert_raises(ValueError):
             TelstateDataSource(view, cbid, sn, self.store)
 
     def test_van_vleck(self):
         shape = (20, 16, 40)
-        view, cbid, sn, l0_data, _ = make_fake_datasource(self.telstate, self.store, shape)
+        view, cbid, sn, l0_data, _ = make_fake_data_source(self.telstate, self.store, shape)
         # Uncorrected visibilities
         data_source = TelstateDataSource(view, cbid, sn, self.store, van_vleck='off')
         raw_vis = data_source.data.vis
@@ -236,7 +236,7 @@ class TestTelstateDataSource(object):
             TelstateDataSource(view, cbid, sn, self.store, van_vleck='blah')
 
     def test_construction_from_url(self):
-        view, cbid, sn, _, _ = make_fake_datasource(self.telstate, self.store, (20, 16, 40))
+        view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, (20, 16, 40))
         source_direct = TelstateDataSource(view, cbid, sn, self.store)
         # Save RDB file to e.g. 'tempdir/cb/cb_sdp_l0.rdb', as if 'tempdir' is a real S3 bucket
         rdb_dir = os.path.join(self.tempdir, cbid)

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -20,13 +20,15 @@ from builtins import object
 
 import tempfile
 import shutil
+import os
 
 import numpy as np
 from nose.tools import assert_raises
 import katsdptelstate
+from katsdptelstate.rdb_writer import RDBWriter
 
 from katdal.chunkstore_npy import NpyFileChunkStore
-from katdal.datasources import TelstateDataSource, view_l0_capture_stream
+from katdal.datasources import TelstateDataSource, view_l0_capture_stream, open_data_source
 from katdal.flags import DATA_LOST
 from katdal.vis_flags_weights import correct_autocorr_quantisation
 from katdal.test.test_vis_flags_weights import put_fake_dataset
@@ -37,7 +39,8 @@ def _make_fake_stream(telstate, store, cbid, stream, shape,
     telstate_prefix = telstate.join(cbid, stream)
     store_prefix = telstate_prefix.replace('_', '-')
     data, chunk_info = put_fake_dataset(store, store_prefix, shape,
-                                        chunk_overrides=chunk_overrides, array_overrides=array_overrides,
+                                        chunk_overrides=chunk_overrides,
+                                        array_overrides=array_overrides,
                                         flags_only=flags_only)
     cs_view = telstate.view(telstate_prefix)
     s_view = telstate.view(stream)
@@ -96,6 +99,22 @@ def make_fake_datasource(telstate, store, l0_shape, cbid='cb', l1_flags_shape=No
     l1_flags_s_view['src_streams'] = ['sdp_l0']
     telstate['sdp_archived_streams'] = ['sdp_l0', 'sdp_l1_flags']
     return view_l0_capture_stream(telstate, cbid, 'sdp_l0') + (l0_data, l1_flags_data)
+
+
+def assert_telstate_data_source_equal(source1, source2):
+    """Assert that two :class:`~katdal.datasources.TelstateDataSource`s are equal."""
+    # Check attributes
+    keys = source1.telstate.keys()
+    assert set(source2.telstate.keys()) == set(keys)
+    for key in keys:
+        np.testing.assert_array_equal(source1.telstate[key], source2.telstate[key])
+    # Check that we also have the same telstate view in both sources
+    assert source1.telstate.prefixes == source2.telstate.prefixes
+    # Check data arrays
+    np.testing.assert_array_equal(source1.timestamps, source2.timestamps)
+    np.testing.assert_array_equal(source1.data.vis.compute(), source2.data.vis.compute())
+    np.testing.assert_array_equal(source1.data.flags.compute(), source2.data.flags.compute())
+    np.testing.assert_array_equal(source1.data.weights.compute(), source2.data.weights.compute())
 
 
 class TestTelstateDataSource(object):
@@ -209,3 +228,19 @@ class TestTelstateDataSource(object):
         # Check parameter validation
         with assert_raises(ValueError):
             TelstateDataSource(view, cbid, sn, self.store, van_vleck='blah')
+
+    def test_construction_from_url(self):
+        view, cbid, sn, _, _ = make_fake_datasource(self.telstate, self.store, (20, 16, 40))
+        source_direct = TelstateDataSource(view, cbid, sn, self.store)
+        # Save RDB file to e.g. 'tempdir/cb/cb_sdp_l0.rdb', as if 'tempdir' is a real S3 bucket
+        rdb_dir = os.path.join(self.tempdir, cbid)
+        os.mkdir(rdb_dir)
+        rdb_filename = os.path.join(rdb_dir, '{}_{}.rdb'.format(cbid, sn))
+        # Insert CBID and stream name at the top level, just like metawriter does
+        self.telstate['capture_block_id'] = cbid
+        self.telstate['stream_name'] = sn
+        with RDBWriter(rdb_filename) as rdbw:
+            rdbw.save(self.telstate)
+        # Check that we can open RDB file and automatically infer the chunk store
+        source_from_file = open_data_source(rdb_filename)
+        assert_telstate_data_source_equal(source_from_file, source_direct)

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -130,7 +130,7 @@ class TestTelstateDataSource(object):
 
     def test_basic_timestamps(self):
         # Add a sensor to telstate to exercise the relevant code paths in TelstateDataSource
-        self.telstate.add('obs_script_log', 'Digitisers synced', ts=123456789., immutable=False)
+        self.telstate.add('obs_script_log', 'Digitisers synced', ts=123456789.)
         view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         data_source = TelstateDataSource(view, cbid, sn, chunk_store=None, source_name='hello')
         assert 'hello' in data_source.name

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -18,6 +18,7 @@
 from __future__ import print_function, division, absolute_import
 from builtins import object
 
+import urllib.parse
 import tempfile
 import shutil
 import os
@@ -244,3 +245,7 @@ class TestTelstateDataSource(object):
         # Check that we can open RDB file and automatically infer the chunk store
         source_from_file = open_data_source(rdb_filename)
         assert_telstate_data_source_equal(source_from_file, source_direct)
+        query = urllib.parse.urlencode({'capture_block_id': cbid, 'stream_name': sn})
+        url = urllib.parse.urlunparse(('file', '', rdb_filename, '', query, ''))
+        source_from_url = TelstateDataSource.from_url(url, chunk_store=self.store)
+        assert_telstate_data_source_equal(source_from_url, source_direct)


### PR DESCRIPTION
I managed to push the test coverage of this critical module from 59% to 91%, hopefully avoiding the kinds of errors introduced by #316 in future.

In the process I also improved general S3 error reporting and extended `S3ChunkStore` to accept store URLs with paths (mostly a bucket creation issue).
