### PR TITLE
Prepare for v0.17

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,7 +4,7 @@ History
 0.17 (2021-01-27)
 -----------------
 * This is the last release that will support Python 3.5
-* Pin PyJWT version to 1.x to avoid breaking API changes and Python 3.6 (#320)
+* Pin PyJWT version to 1.x to avoid breaking API changes (#320)
 * Van Vleck correction! (autocorrelations only, though) (#316)
 * Expose excision, aka raw weights (#308)
 * Better unit testing of DataSource and S3ChunkStore in general (#319)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+0.17 (2021-01-27)
+-----------------
+* This is the last release that will support Python 3.5
+* Van Vleck correction! (autocorrelations only, though) (#316)
+* Expose excision, aka raw weights (#308)
+* Better unit testing of DataSource and S3ChunkStore in general (#319)
+* Support indexed telstate keys (the 1000th cut that killed Python 2) (#304)
+* Split out separate utility classes for Minio (#310)
+* Fix filtering of sensor events with invalid status (#306)
+
 0.16 (2020-08-28)
 -----------------
 * This is the last release that will support Python 2 (python2 maintenance branch)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,6 +4,7 @@ History
 0.17 (2021-01-27)
 -----------------
 * This is the last release that will support Python 3.5
+* Pin PyJWT version to 1.x to avoid breaking API changes and Python 3.6 (#320)
 * Van Vleck correction! (autocorrelations only, though) (#316)
 * Expose excision, aka raw weights (#308)
 * Better unit testing of DataSource and S3ChunkStore in general (#319)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name='katdal',
       use_katversion=True,
       install_requires=['numpy >= 1.12.0', 'katpoint >= 0.9', 'h5py >= 2.3', 'numba',
                         'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 1.2.1',
-                        'requests >= 2.18.0', 'pyjwt', 'future',
+                        'requests >= 2.18.0', 'pyjwt < 2', 'future',
                         'cityhash >= 0.2.2'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
This reverts PyJWT to 1.x in order to support Python 3.5 one last time.