### PR TITLE
Remove Python 2 relics

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -16,15 +16,8 @@
 
 """Data access library for data sets in the MeerKAT Visibility Format (MVF)."""
 
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()  # noqa: E402
-import future.utils
-from past.builtins import basestring
-
 import logging as _logging
 import urllib.parse
-import warnings
 
 from .datasources import open_data_source
 from .dataset import DataSet, WrongVersion
@@ -50,14 +43,6 @@ _no_config_handler.setFormatter(_logging.Formatter(_logging.BASIC_FORMAT))
 _no_config_handler.addFilter(_NoConfigFilter())
 logger = _logging.getLogger(__name__)
 logger.addHandler(_no_config_handler)
-
-if future.utils.PY2:
-    _PY2_WARNING = (
-        "Python 2 has reached End-of-Life, and a future version of katdal "
-        "will remove support for it. Please update your scripts to Python 3 "
-        "as soon as possible."
-    )
-    warnings.warn(_PY2_WARNING, FutureWarning)
 
 # BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install
@@ -134,7 +119,7 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
         Object providing :class:`DataSet` interface to file(s)
 
     """
-    filenames = [filename] if isinstance(filename, basestring) else filename
+    filenames = [filename] if isinstance(filename, str) else filename
     datasets = []
     for f in filenames:
         # V4 RDB file or live telstate with optional URL-style query string
@@ -145,8 +130,7 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
         else:
             dataset = _file_action('__call__', f, ref_ant, time_offset, **kwargs)
         datasets.append(dataset)
-    return datasets[0] if isinstance(filename, basestring) else \
-        ConcatenatedDataSet(datasets)
+    return datasets[0] if isinstance(filename, str) else ConcatenatedDataSet(datasets)
 
 
 def get_ants(filename):

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -15,7 +15,6 @@
 ###############################################################################
 
 """Utilities for applying calibration solutions to visibilities and weights."""
-from __future__ import print_function, division, absolute_import
 
 import logging
 

--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 ################################################################################
 
-from __future__ import print_function, division, absolute_import
-from builtins import range
-
 import numpy as np
 import numba
 

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Container for categorical (i.e. non-numerical) sensor data and related tools."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range, object
 
 import collections
 

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -16,10 +16,6 @@
 
 """Base class for accessing a store of chunks (i.e. N-dimensional arrays)."""
 
-from __future__ import print_function, division, absolute_import
-from builtins import next, zip, range, object
-from future.utils import raise_from
-
 import contextlib
 import functools
 import uuid
@@ -426,7 +422,7 @@ class ChunkStore(object):
                 FirstBase = next(c for c in self._error_map if isinstance(e, c))
                 StandardisedError = self._error_map[FirstBase]
             prefix = 'Chunk {!r}: '.format(chunk_name) if chunk_name else ''
-            raise_from(StandardisedError(prefix + str(e)), e)
+            raise StandardisedError(prefix + str(e)) from e
 
     def get_dask_array(self, array_name, chunks, dtype, offset=(), errors=0):
         """Get dask array from the store.

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays."""
-from __future__ import print_function, division, absolute_import
 
 from .chunkstore import ChunkStore, ChunkNotFound, BadChunk
 

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 """A store of chunks (i.e. N-dimensional arrays) based on NPY files."""
-from __future__ import print_function, division, absolute_import
 
 import os
 import errno

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -154,12 +154,10 @@ def _read_chunk(response):
     """Efficiently read NumPy array in NPY format from content of HTTP response."""
     data = response.raw
     # Workaround for https://github.com/urllib3/urllib3/issues/1540
-    # On Python 2, http.client.HTTPResponse doesn't implement readinto.
     # We also can't use the workaround if the content is encoded (e.g.
     # gzip compressed) because that's decoded in urllib3, not httplib.
     if ('Content-encoding' not in response.headers
-            and hasattr(data, '_fp')
-            and hasattr(data._fp, 'readinto')):
+            and hasattr(data, '_fp')):
         chunk = read_array(data._fp)
     else:
         chunk = read_array(data)

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -157,7 +157,8 @@ def _read_chunk(response):
     # We also can't use the workaround if the content is encoded (e.g.
     # gzip compressed) because that's decoded in urllib3, not httplib.
     if ('Content-encoding' not in response.headers
-            and hasattr(data, '_fp')):
+            and hasattr(data, '_fp')
+            and hasattr(data._fp, 'readinto')):
         chunk = read_array(data._fp)
     else:
         chunk = read_array(data)

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Class for concatenating visibility data sets."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range
 
 import os.path
 import itertools

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -15,9 +15,6 @@
 ################################################################################
 
 """Base class for accessing a visibility data set."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, object
-from past.builtins import basestring
 
 import time
 import logging
@@ -135,7 +132,7 @@ def _selection_to_list(names, **groups):
     list : list of strings / objects
         List of names / objects
     """
-    if isinstance(names, basestring):
+    if isinstance(names, str):
         if not names:
             return []
         elif names in groups:
@@ -442,7 +439,7 @@ class DataSet(object):
         descr += ['-------------------------------------------------------------------------------',
                   'Data selected according to the following criteria:']
         for k, v in sorted(self._selection.items()):
-            descr.append('  %s=%s' % (k, ("'%s'" % (v,)) if isinstance(v, basestring) else v))
+            descr.append('  %s=%s' % (k, ("'%s'" % (v,)) if isinstance(v, str) else v))
         descr.append('-------------------------------------------------------------------------------')
         descr.append('Shape: (%d dumps, %d channels, %d correlation products) => Size: %s' %
                      tuple(list(self.shape) + ['%.3f %s' % ((self.size / 1e9, 'GB') if self.size > 1e9 else
@@ -749,7 +746,7 @@ class DataSet(object):
                     try:
                         if isinstance(t, numbers.Integral):
                             target_index = t
-                        elif isinstance(t, katpoint.Target) or isinstance(t, basestring) and ',' in t:
+                        elif isinstance(t, katpoint.Target) or isinstance(t, str) and ',' in t:
                             target_index = self.catalogue.targets.index(t)
                         else:
                             target_index = self.catalogue.targets.index(self.catalogue[t])

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Data accessor class for HDF5 files produced by Fringe Finder correlator."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range
 
 import logging
 import re

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Data accessor class for HDF5 files produced by KAT-7 correlator."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range
 
 import logging
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -15,10 +15,6 @@
 ################################################################################
 
 """Data accessor class for HDF5 files produced by RTS correlator."""
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()    # noqa: E402
-from builtins import zip, range
 
 import logging
 from collections import Counter

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Two-stage deferred indexer for objects with expensive __getitem__ calls."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range, object
 
 import copy
 import threading

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -24,8 +24,6 @@ This is largely an implementation detail of the mvftoms.py script, and might
 not be suited to other use cases. It is put into a separate module as a
 workaround for https://bugs.python.org/issue9914.
 """
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 from collections import namedtuple
 import contextlib

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -19,8 +19,6 @@
 # Ludwig Schwardt
 # 25 March 2008
 #
-from __future__ import print_function, division, absolute_import
-from builtins import range
 
 import os
 import os.path

--- a/katdal/spectral_window.py
+++ b/katdal/spectral_window.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 ################################################################################
 
-from __future__ import print_function, division, absolute_import
-from builtins import object
-
 import threading
 
 import numpy as np

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -15,8 +15,7 @@
 ###############################################################################
 
 """Tests for :py:mod:`katdal.applycal`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object, range
+
 from functools import partial
 
 import katpoint

--- a/katdal/test/test_categorical.py
+++ b/katdal/test/test_categorical.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.categorical`."""
-from __future__ import print_function, division, absolute_import
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.chunkstore`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.chunkstore_dict`."""
-from __future__ import print_function, division, absolute_import
 
 from katdal.chunkstore_dict import DictChunkStore
 from katdal.test.test_chunkstore import ChunkStoreTestBase

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.chunkstore_npy`."""
-from __future__ import print_function, division, absolute_import
 
 import tempfile
 import shutil

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -26,10 +26,6 @@ an older version is detected, the test will be skipped.
 .. _minio: https://github.com/minio/minio
 .. _race condition: https://github.com/minio/minio/issues/6324
 """
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()     # noqa: E402
-from future.utils import bytes_to_native_str
 
 import tempfile
 import shutil
@@ -161,7 +157,7 @@ def encode_jwt(header, payload, signature=86 * 'x'):
     """Generate JWT token with encoded signature (dummy ES256 one by default)."""
     # Don't specify algorithm='ES256' here since that needs cryptography package
     token_bytes = jwt.encode(payload, '', algorithm='none', headers=header)
-    return bytes_to_native_str(token_bytes) + signature
+    return token_bytes.decode() + signature
 
 
 class TestTokenUtils(object):

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -442,8 +442,7 @@ class _TokenHTTPProxyServer(http.server.HTTPServer):
     """
     def server_bind(self):
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        # In Python 2.7 it's an old-style class, so super doesn't work
-        http.server.HTTPServer.server_bind(self)
+        super().server_bind()
 
 
 class TestS3ChunkStoreToken(TestS3ChunkStore):

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -17,8 +17,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.concatdata`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 import numpy as np
 from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -16,8 +16,6 @@
 
 """Tests for :py:mod:`katdal.dataset`."""
 
-from __future__ import print_function, division, absolute_import
-
 from nose.tools import assert_equal
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.datasources`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 import urllib.parse
 import tempfile

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.lazy_indexer`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object, range
 
 from numbers import Integral
 from functools import partial

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -17,8 +17,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.sensordata`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 from collections import OrderedDict
 

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -22,7 +22,7 @@ from collections import OrderedDict
 
 import numpy as np
 from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises, assert_is_instance
-import mock
+from unittest.mock import Mock
 
 from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter, to_str,
                                remove_duplicates_and_invalid_values)
@@ -131,7 +131,7 @@ class TestSensorCache(object):
         np.testing.assert_array_equal(data, [3.0, 3.0, 3.0, 3.0, 4.0, 5.0, 6.0, 6.0, 6.0, 6.0])
 
     def test_virtual_sensors(self):
-        calculate_value = mock.Mock()
+        calculate_value = Mock()
 
         def _check_sensor(cache, name, **kwargs):
             """Check that virtual sensor function gets the expected parameters."""

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -16,9 +16,6 @@
 
 """Tests for :py:mod:`katdal.spectral_window`."""
 
-from __future__ import print_function, division, absolute_import
-from builtins import object
-
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_equal

--- a/katdal/test/test_van_vleck.py
+++ b/katdal/test/test_van_vleck.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 ################################################################################
 
-from __future__ import print_function, division, absolute_import
-from builtins import zip
-
 import numpy as np
 
 from katdal.van_vleck import norm0_cdf, autocorr_lookup_table

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Tests for :py:mod:`katdal.vis_flags_weights`."""
-from __future__ import print_function, division, absolute_import
-from builtins import object
 
 import tempfile
 import shutil

--- a/katdal/van_vleck.py
+++ b/katdal/van_vleck.py
@@ -16,8 +16,6 @@
 
 """Routines for performing quantisation (Van Vleck) correction."""
 
-from __future__ import print_function, division, absolute_import
-
 import math
 
 import numpy as np

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -15,10 +15,6 @@
 ################################################################################
 
 """A (lazy) container for the triplet of visibilities, flags and weights."""
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()  # noqa: 402
-from builtins import zip, object
 
 import itertools
 import logging

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -15,8 +15,6 @@
 ################################################################################
 
 """Data accessor class for data and metadata from various sources in v4 format."""
-from __future__ import print_function, division, absolute_import
-from builtins import zip, range
 
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ dask
 docutils
 ephem
 jmespath
+future
 h5py
 idna
 katversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ dask
 docutils
 ephem
 jmespath
-future
 h5py
 idna
 katversion

--- a/scripts/ff_holo_to_h5v1.py
+++ b/scripts/ff_holo_to_h5v1.py
@@ -24,8 +24,6 @@
 # 29 July 2013
 #
 
-from __future__ import print_function, division, absolute_import
-
 from optparse import OptionParser
 
 import h5py

--- a/scripts/fix_ant_positions.py
+++ b/scripts/fix_ant_positions.py
@@ -18,8 +18,6 @@
 
 # Update the antenna positions in the specified HDF5 file.
 
-from __future__ import print_function, division, absolute_import
-
 import h5py
 import sys
 

--- a/scripts/h5list.py
+++ b/scripts/h5list.py
@@ -23,8 +23,6 @@
 # 19 December 2011
 #
 
-from __future__ import print_function, division, absolute_import
-
 import os
 import optparse
 import glob

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-from __future__ import print_function, division, absolute_import
-
 import mvftoms
 
 

--- a/scripts/mvf_read_benchmark.py
+++ b/scripts/mvf_read_benchmark.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, division, absolute_import
-from builtins import range
 import argparse
 import logging
 import time

--- a/scripts/mvf_rechunk.py
+++ b/scripts/mvf_rechunk.py
@@ -2,11 +2,6 @@
 
 """Rechunk an existing MVF dataset"""
 
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()  # noqa: 402
-from builtins import object
-
 import sys
 import os
 import re

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -19,12 +19,6 @@
 # Produce a CASA-compatible MeasurementSet from a MeerKAT Visibility Format
 # (MVF) dataset using casacore.
 
-from __future__ import print_function, division, absolute_import
-from future import standard_library
-standard_library.install_aliases()    # noqa: E402
-from builtins import zip
-from builtins import range
-
 from collections import namedtuple
 import os
 import tarfile

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -24,10 +24,6 @@
 # 26 June 2012
 #
 
-from __future__ import print_function, division, absolute_import
-
-from builtins import range
-from builtins import object
 import optparse
 import time
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-from __future__ import print_function, division, absolute_import
-
 import os.path
 
 from setuptools import setup, find_packages
@@ -58,8 +56,7 @@ setup(name='katdal',
       use_katversion=True,
       install_requires=['numpy >= 1.12.0', 'katpoint >= 0.9', 'h5py >= 2.3', 'numba',
                         'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 1.2.1',
-                        'requests >= 2.18.0', 'pyjwt < 2', 'future',
-                        'cityhash >= 0.2.2'],
+                        'requests >= 2.18.0', 'pyjwt < 2', 'cityhash >= 0.2.2'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],
           's3': [],

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,4 @@ setup(name='katdal',
           's3': [],
           's3credentials': ['botocore']
       },
-      tests_require=['mock', 'nose', 'subprocess32'])
+      tests_require=['mock', 'nose'])

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,4 @@ setup(name='katdal',
           's3': [],
           's3credentials': ['botocore']
       },
-      tests_require=['mock', 'nose'])
+      tests_require=['nose'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 coverage
 mock==4.0.2
 nose
-subprocess32==3.5.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 coverage
-mock==4.0.2
 nose


### PR DESCRIPTION
Strip out `future` and all its ramifications, along with `subprocess32` and `mock`. Remove Python 2 workarounds.

This is probably best checked commit by commit. The first commit is big but reasonably straightforward.