### PR TITLE
Python 3.6 cleanup

### DIFF
--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -50,7 +50,7 @@ try:
     import katversion as _katversion
 except ImportError:
     import time as _time
-    __version__ = "0.0+unknown.%s" % (_time.strftime('%Y%m%d%H%M'),)
+    __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
 else:
     __version__ = _katversion.get_version(__path__[0])
 # END VERSION CHECK

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -86,8 +86,7 @@ def _file_action(action, filename, *args, **kwargs):
         except WrongVersion:
             continue
     else:
-        raise WrongVersion("File '%s' has unknown data file format or version"
-                           % (filename,))
+        raise WrongVersion(f"File '{filename}' has unknown data file format or version")
     return result
 
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -90,8 +90,8 @@ def _parse_cal_product(cal_product):
     """Split `cal_product` into `cal_stream` and `product_type` parts."""
     fields = cal_product.rsplit('.', 1)
     if len(fields) != 2:
-        raise ValueError('Calibration product {} is not in the format '
-                         '<cal_stream>.<product_type>'.format(cal_product))
+        raise ValueError(f'Calibration product {cal_product} is not in the format '
+                         '<cal_stream>.<product_type>')
     return fields[0], fields[1]
 
 
@@ -376,8 +376,7 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
                     part_indices[i] += 1
                     part_timestamps[i] = ts[part_indices[i]] if part_indices[i] < len(ts) else np.inf
         if not timestamps:
-            raise KeyError("No cal product '{}' parts found (expected {})"
-                           .format(name, n_parts))
+            raise KeyError(f"No cal product '{name}' parts found (expected {n_parts})")
         return SimpleSensorGetter(indirect_cal_product_name(name, product_type),
                                   np.array(timestamps), np.array(values))
 
@@ -387,9 +386,8 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
         try:
             index = cal_input_map[inp]
         except KeyError:
-            raise KeyError("No calibration solutions available for input "
-                           "'{}' - available ones are {}"
-                           .format(inp, sorted(cal_input_map.keys())))
+            raise KeyError(f"No calibration solutions available for input '{inp}' - "
+                           f'available ones are {sorted(cal_input_map.keys())}')
         if product_type == 'K':
             correction_sensor = calc_delay_correction(product_sensor, index,
                                                       data_freqs)
@@ -402,8 +400,8 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
         elif product_type in ('GPHASE', 'GAMP_PHASE'):
             correction_sensor = calc_gain_correction(product_sensor, index, targets)
         else:
-            raise KeyError("Unknown calibration product type '{}' - available "
-                           "ones are {}".format(product_type, CAL_PRODUCT_TYPES))
+            raise KeyError(f"Unknown calibration product type '{product_type}' - "
+                           f'available ones are {CAL_PRODUCT_TYPES}')
         cache[name] = correction_sensor
         return correction_sensor
 

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -107,7 +107,7 @@ def get_cal_product(cache, cal_stream, product_type):
     product_type : string
         Calibration product type (e.g. "G")
     """
-    sensor_name = 'Calibration/Products/{}/{}'.format(cal_stream, product_type)
+    sensor_name = f'Calibration/Products/{cal_stream}/{product_type}'
     return cache.get(sensor_name)
 
 
@@ -331,7 +331,7 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
 
     def indirect_cal_product(cache, name, product_type):
         try:
-            n_parts = int(attrs['product_{}_parts'.format(product_type)])
+            n_parts = int(attrs[f'product_{product_type}_parts'])
         except KeyError:
             return indirect_cal_product_raw(cache, name, product_type)
         # Handle multi-part cal product (as produced by "split cal")
@@ -407,9 +407,9 @@ def add_applycal_sensors(cache, attrs, data_freqs, cal_stream, cal_substreams=No
         cache[name] = correction_sensor
         return correction_sensor
 
-    template = 'Calibration/Products/{}/{{product_type}}'.format(cal_stream)
+    template = f'Calibration/Products/{cal_stream}/{{product_type}}'
     cache.virtual[template] = indirect_cal_product
-    template = 'Calibration/Corrections/{}/{{product_type}}/{{inp}}'.format(cal_stream)
+    template = f'Calibration/Corrections/{cal_stream}/{{product_type}}/{{inp}}'
     cache.virtual[template] = calc_correction_per_input
     return cal_freqs
 
@@ -423,7 +423,7 @@ def _correction_inputs_to_corrprods(g_per_cp, g_per_input, input1_index, input2_
                               * np.conj(g_per_input[i, input2_index[j]]))
 
 
-class CorrectionParams(object):
+class CorrectionParams:
     """Data needed to compute corrections in :func:`calc_correction_per_corrprod`.
 
     Once constructed, the data in this class must not be modified, as it will
@@ -557,7 +557,7 @@ def calc_correction(chunks, cache, corrprods, cal_products, data_freqs,
     channel_maps = {}
     for cal_product in cal_products:
         cal_stream, product_type = _parse_cal_product(cal_product)
-        sensor_prefix = 'Calibration/Corrections/{}/{}/'.format(cal_stream, product_type)
+        sensor_prefix = f'Calibration/Corrections/{cal_stream}/{product_type}/'
         corrections_per_product = []
         for i, inp in enumerate(inputs):
             try:

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -50,8 +50,8 @@ class ComparableArrayWrapper:
 
     def __repr__(self):
         """Short human-friendly string representation of wrapper object."""
-        return "<katdal.%s { %r } at 0x%x>" % \
-               (self.__class__.__name__, self.unwrapped, id(self))
+        class_name = self.__class__.__name__
+        return f"<katdal.{class_name} {self.unwrapped!r} at 0x{id(self):x}>"
 
     def __str__(self):
         """Longer human-friendly string representation of wrapped object."""
@@ -336,8 +336,8 @@ class CategoricalData:
 
     def __repr__(self):
         """Short human-friendly string representation of categorical data object."""
-        return "<katdal.CategoricalData events=%d values=%d type=%s at 0x%x>" % \
-               (len(self.indices), len(self.unique_values), self.dtype, id(self))
+        return "<katdal.CategoricalData events={} values={} type={} at 0x{:x}>".format(
+               len(self.indices), len(self.unique_values), self.dtype, id(self))
 
     def __str__(self):
         """Long human-friendly string representation of categorical data object."""

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -51,7 +51,7 @@ class ComparableArrayWrapper:
     def __repr__(self):
         """Short human-friendly string representation of wrapper object."""
         class_name = self.__class__.__name__
-        return f"<katdal.{class_name} {self.unwrapped!r} at 0x{id(self):x}>"
+        return f"<katdal.{class_name} {self.unwrapped!r} at {id(self):#x}>"
 
     def __str__(self):
         """Longer human-friendly string representation of wrapped object."""
@@ -336,7 +336,7 @@ class CategoricalData:
 
     def __repr__(self):
         """Short human-friendly string representation of categorical data object."""
-        return "<katdal.CategoricalData events={} values={} type={} at 0x{:x}>".format(
+        return "<katdal.CategoricalData events={} values={} type={} at {:#x}>".format(
                len(self.indices), len(self.unique_values), self.dtype, id(self))
 
     def __str__(self):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -22,7 +22,7 @@ import numpy as np
 from dask.base import tokenize
 
 
-class ComparableArrayWrapper(object):
+class ComparableArrayWrapper:
     """Wrapper that improves comparison of array objects.
 
     This wrapper class has two main benefits:
@@ -206,7 +206,7 @@ def unique_in_order(elements, return_inverse=False):
 # -------------------------------------------------------------------------------------------------
 
 
-class CategoricalData(object):
+class CategoricalData:
     """Container for categorical (i.e. non-numerical) sensor data.
 
     This container allows simple manipulation and interpolation of a time series

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -166,7 +166,7 @@ def npy_header_and_body(chunk):
     return header, chunk
 
 
-class ChunkStore(object):
+class ChunkStore:
     r"""Base class for accessing a store of chunks (i.e. N-dimensional arrays).
 
     A *chunk* is a simple (i.e. unit-stride) slice of an N-dimensional array
@@ -421,7 +421,7 @@ class ChunkStore(object):
                 # keys, so pick the first one found
                 FirstBase = next(c for c in self._error_map if isinstance(e, c))
                 StandardisedError = self._error_map[FirstBase]
-            prefix = 'Chunk {!r}: '.format(chunk_name) if chunk_name else ''
+            prefix = f'Chunk {chunk_name!r}: ' if chunk_name else ''
             raise StandardisedError(prefix + str(e)) from e
 
     def get_dask_array(self, array_name, chunks, dtype, offset=(), errors=0):
@@ -494,7 +494,7 @@ class ChunkStore(object):
         in_name = array.name
         out_name = array_name
         # Make out_name unique to avoid clashes and caches
-        out_name = 'store-{}-{}-{}'.format(out_name, offset, uuid.uuid4().hex)
+        out_name = f'store-{out_name}-{offset}-{uuid.uuid4().hex}'
         put = _scalar_to_chunk(self.put_chunk_noraise)
         if offset:
             put = _add_offset_to_slices(put, offset)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -379,24 +379,22 @@ class ChunkStore:
         try:
             shape = tuple(s.stop - s.start for s in slices)
         except (TypeError, AttributeError):
-            raise BadChunk('Array {!r}: chunk ID should be a sequence of '
-                           'slice objects, not {}'.format(array_name, slices))
+            raise BadChunk(f'Array {array_name!r}: chunk ID should be '
+                           f'a sequence of slice objects, not {slices}')
         # Verify that all slice strides are unity (i.e. it's a "simple" slice)
         if not all([s.step in (1, None) for s in slices]):
-            raise BadChunk('Array {!r}: chunk ID {} contains non-unit strides'
-                           .format(array_name, slices))
+            raise BadChunk(f'Array {array_name!r}: chunk ID {slices} contains non-unit strides')
         # Construct chunk name from array_name + slices
         chunk_name = cls.join(array_name, cls.chunk_id_str(slices))
         if chunk is not None and chunk.shape != shape:
-            raise BadChunk('Chunk {!r}: shape {} implied by slices does not '
-                           'match actual shape {}'
-                           .format(chunk_name, shape, chunk.shape))
+            raise BadChunk(f'Chunk {chunk_name!r}: shape {shape} implied by slices '
+                           f'does not match actual shape {chunk.shape}')
         if chunk is not None and chunk.dtype.hasobject:
-            raise BadChunk('Chunk {!r}: actual dtype {} cannot contain '
-                           'objects'.format(chunk_name, chunk.dtype))
+            raise BadChunk(f'Chunk {chunk_name!r}: actual dtype {chunk.dtype} '
+                           'cannot contain objects')
         if dtype is not None and np.dtype(dtype).hasobject:
-            raise BadChunk('Chunk {!r}: Requested dtype {} cannot contain '
-                           'objects'.format(chunk_name, dtype))
+            raise BadChunk(f'Chunk {chunk_name!r}: Requested dtype {dtype} '
+                           'cannot contain objects')
         return chunk_name, shape
 
     @contextlib.contextmanager

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -43,10 +43,8 @@ class DictChunkStore(ChunkStore):
             # Ensure that chunk is array (otherwise 0-dim array becomes number)
             chunk = array[slices] if slices != () else array
         if chunk.shape != shape or chunk.dtype != dtype:
-            raise BadChunk('Chunk {!r}: requested dtype {} and/or shape {} '
-                           'differs from expected dtype {} and shape {}'
-                           .format(chunk_name, chunk.dtype, chunk.shape,
-                                   dtype, shape))
+            raise BadChunk(f'Chunk {chunk_name!r}: requested dtype {chunk.dtype} and/or shape '
+                           f'{chunk.shape} differs from expected dtype {dtype} and shape {shape}')
         return chunk
 
     def create_array(self, array_name):

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -32,7 +32,7 @@ class DictChunkStore(ChunkStore):
 
     def __init__(self, **kwargs):
         error_map = {KeyError: ChunkNotFound, IndexError: ChunkNotFound}
-        super(DictChunkStore, self).__init__(error_map)
+        super().__init__(error_map)
         self.arrays = kwargs
 
     def get_chunk(self, array_name, slices, dtype):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -96,10 +96,8 @@ class NpyFileChunkStore(ChunkStore):
         with self._standard_errors(chunk_name):
             chunk = np.load(filename, allow_pickle=False)
         if chunk.shape != shape or chunk.dtype != dtype:
-            raise BadChunk('Chunk {!r}: NPY file dtype {} and/or shape {} '
-                           'differs from expected dtype {} and shape {}'
-                           .format(chunk_name, chunk.dtype, chunk.shape,
-                                   dtype, shape))
+            raise BadChunk(f'Chunk {chunk_name!r}: NPY file dtype {chunk.dtype} and/or shape '
+                           f'{chunk.shape} differs from expected dtype {dtype} and shape {shape}')
         return chunk
 
     def create_array(self, array_name):

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -81,10 +81,9 @@ class NpyFileChunkStore(ChunkStore):
     """
 
     def __init__(self, path, direct_write=False):
-        super(NpyFileChunkStore, self).__init__({IOError: ChunkNotFound,
-                                                 ValueError: ChunkNotFound})
+        super().__init__({IOError: ChunkNotFound, ValueError: ChunkNotFound})
         if not os.path.isdir(path):
-            raise StoreUnavailable('Directory {!r} does not exist'.format(path))
+            raise StoreUnavailable(f'Directory {path!r} does not exist')
         self.path = path
         self.direct_write = direct_write
         if direct_write and not hasattr(os, 'O_DIRECT'):

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -85,7 +85,7 @@ class ConcatenatedLazyIndexer(LazyIndexer):
         descr = [self._name_shape_dtype(self.name, shape, dtype)]
         for n, indexer in enumerate(self.indexers):
             indexer_descr = str(indexer).split('\n')
-            descr += [('- Indexer %03d: ' % (n,)) + indexer_descr[0]]
+            descr += [f'- Indexer {n:03d}: ' + indexer_descr[0]]
             descr += ['               ' + indescr for indescr in indexer_descr[1:]]
         for transform in self.transforms:
             shape, dtype = transform.new_shape(shape), transform.dtype if transform.dtype is not None else dtype
@@ -195,10 +195,10 @@ class ConcatenatedLazyIndexer(LazyIndexer):
             return dtypes.pop()
         elif np.all([np.issubdtype(dtype, np.string_) for dtype in dtypes]):
             # Strings of different lengths have different dtypes (e.g. '|S1' vs '|S10') but can be safely concatenated
-            return np.dtype('|S%d' % (max([dt.itemsize for dt in dtypes]),))
+            return np.dtype('|S{}'.format(max([dt.itemsize for dt in dtypes])))
         else:
-            raise ConcatenationError("Incompatible dtypes among sub-indexers making up indexer '%s':\n%s" %
-                                     (self.name, '\n'.join([repr(indexer) for indexer in self.indexers])))
+            raise ConcatenationError(f"Incompatible dtypes among sub-indexers making up indexer '{self.name}':\n"
+                                     + '\n'.join([repr(indexer) for indexer in self.indexers]))
 
 # -------------------------------------------------------------------------------------------------
 # -- CLASS :  ConcatenatedSensorGetter
@@ -251,7 +251,7 @@ class ConcatenatedSensorGetter(SensorGetter):
             # but underlying names may legitimately differ for datasets of
             # different minor versions (even within the same version...).
             raise ConcatenationError('Cannot concatenate sensor with different '
-                                     'underlying names: %s' % (names,))
+                                     f'underlying names: {names}')
         super().__init__(names[0])
         self._data = data
 
@@ -382,7 +382,7 @@ class ConcatenatedSensorCache(SensorCache):
         # Get array, categorical data or raw sensor data from each cache
         split_data = self._get(name, select=select, extract=extract, **kwargs)
         if all(sd is None for sd in split_data):
-            raise KeyError('Key %s not found in any of the concatenated datasets' % name)
+            raise KeyError(f'Key {name} not found in any of the concatenated datasets')
         # If this sensor has already been partially extracted,
         # we are forced to extract it in rest of caches too
         if not extract and not all(sd is None or isinstance(sd, SensorGetter) for sd in split_data):

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -75,7 +75,7 @@ class Subarray:
 
     def __repr__(self):
         """Short human-friendly string representation of subarray object."""
-        return "<katdal.Subarray antennas={} inputs={} corrprods={} at 0x{:x}>".format(
+        return "<katdal.Subarray antennas={} inputs={} corrprods={} at {:#x}>".format(
                len(self.ants), len(self.inputs), len(self.corr_products), id(self))
 
     @property
@@ -407,7 +407,7 @@ class DataSet:
     def __repr__(self):
         """Short human-friendly string representation of data set object."""
         class_name = self.__class__.__name__
-        return f"<katdal.{class_name} '{self.name}' shape {self.shape} at 0x{id(self):x}>"
+        return f"<katdal.{class_name} '{self.name}' shape {self.shape} at {id(self):#x}>"
 
     def __str__(self):
         """Verbose human-friendly string representation of data set."""

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -41,7 +41,7 @@ class BrokenFile(Exception):
     """Data set could not be loaded because file is inconsistent or misses critical bits."""
 
 
-class Subarray(object):
+class Subarray:
     """Subarray specification.
 
     A subarray is determined by the specific correlation products produced by the
@@ -69,7 +69,7 @@ class Subarray(object):
                                        for inpA, inpB in corr_products])
         # Extract all inputs (and associated antennas) from corr product list
         self.inputs = sorted(set(np.ravel(self.corr_products)))
-        input_ants = set([inp[:-1] for inp in self.inputs])
+        input_ants = {inp[:-1] for inp in self.inputs}
         # Only keep antennas that are involved in correlation products
         self.ants = [ant for ant in ants if ant.name in input_ants]
 
@@ -83,8 +83,7 @@ class Subarray(object):
     def _description(self):
         """Complete string representation, used internally for comparisons."""
         ants = '\n'.join(ant.description for ant in self.ants)
-        corrprods = ' '.join('%s,%s' % (inpA, inpB)
-                             for inpA, inpB in self.corr_products)
+        corrprods = ' '.join(f'{inpA},{inpB}' for inpA, inpB in self.corr_products)
         return '\n'.join((ants, corrprods))
 
     def __eq__(self, other):
@@ -113,7 +112,7 @@ def _robust_target(description):
     try:
         return katpoint.Target(description)
     except ValueError:
-        logger.warning("Invalid target description '%s' - replaced with dummy target" % (description,))
+        logger.warning("Invalid target description '%s' - replaced with dummy target", description)
         return katpoint.Target('Nothing, special')
 
 
@@ -168,14 +167,14 @@ def _calc_mjd(cache, name):
 
 def _calc_lst(cache, name, ant):
     """Calculate local sidereal time (LST) timestamps using sensor cache contents."""
-    antenna = cache.get('Antennas/%s/antenna' % (ant,))[0]
+    antenna = cache.get(f'Antennas/{ant}/antenna')[0]
     cache[name] = lst = antenna.local_sidereal_time(cache.timestamps[:])
     return lst
 
 
 def _calc_radec(cache, name, ant):
     """Calculate (ra, dec) pointing coordinates using sensor cache contents."""
-    ant_group = 'Antennas/%s/' % (ant,)
+    ant_group = f'Antennas/{ant}/'
     antenna = cache.get(ant_group + 'antenna')[0]
     az = cache.get(ant_group + 'az')
     el = cache.get(ant_group + 'el')
@@ -188,7 +187,7 @@ def _calc_radec(cache, name, ant):
 
 def _calc_parangle(cache, name, ant):
     """Calculate parallactic angle using sensor cache contents."""
-    ant_group = 'Antennas/%s/' % (ant,)
+    ant_group = f'Antennas/{ant}/'
     antenna = cache.get(ant_group + 'antenna')[0]
     az = cache.get(ant_group + 'az')
     el = cache.get(ant_group + 'el')
@@ -200,7 +199,7 @@ def _calc_parangle(cache, name, ant):
 
 def _calc_target_coords(cache, name, ant, projection, coordsys):
     """Calculate target coordinates using sensor cache contents."""
-    ant_group = 'Antennas/%s/' % (ant,)
+    ant_group = f'Antennas/{ant}/'
     antenna = cache.get(ant_group + 'antenna')[0]
     if coordsys == 'radec':
         lon = cache.get(ant_group + 'ra')
@@ -219,14 +218,14 @@ def _calc_target_coords(cache, name, ant, projection, coordsys):
         x[segm], y[segm] = target.sphere_to_plane(lon[segm], lat[segm],
                                                   cache.timestamps[segm],
                                                   antenna, projection, coordsys)
-    cache[ant_group + 'target_x_%s_%s' % (projection, coordsys)] = x
-    cache[ant_group + 'target_y_%s_%s' % (projection, coordsys)] = y
+    cache[ant_group + f'target_x_{projection}_{coordsys}'] = x
+    cache[ant_group + f'target_y_{projection}_{coordsys}'] = y
     return x if name.startswith(ant_group + 'target_x') else y
 
 
 def _calc_uvw_basis(cache, name, ant):
     """Calculate (u,v,w) basis vectors using sensor cache contents."""
-    ant_group = 'Antennas/%s/' % (ant,)
+    ant_group = f'Antennas/{ant}/'
     antenna = cache.get(ant_group + 'antenna')[0]
     u = np.empty((len(cache.timestamps), 3))
     v = np.empty((len(cache.timestamps), 3))
@@ -246,7 +245,7 @@ def _calc_uvw_basis(cache, name, ant):
 def _calc_uvw_per_ant(cache, name, ant):
     """Calculate (u,v,w) coordinates per antenna using sensor cache contents."""
     array_antenna = cache.get('Antennas/array/antenna')[0]
-    antenna = cache.get('Antennas/%s/antenna' % (ant,))[0]
+    antenna = cache.get(f'Antennas/{ant}/antenna')[0]
     basis = cache.get('Antennas/array/basis_' + name[-1])
     # Obtain baseline vector from array reference to specified antenna
     baseline_m = array_antenna.baseline_toward(antenna)
@@ -269,7 +268,7 @@ DEFAULT_VIRTUAL_SENSORS = {
 # -------------------------------------------------------------------------------------------------
 
 
-class DataSet(object):
+class DataSet:
     """Base class for accessing a visibility data set.
 
     This provides a simple interface to a generic file (or files) containing
@@ -408,20 +407,20 @@ class DataSet(object):
 
     def __repr__(self):
         """Short human-friendly string representation of data set object."""
-        return "<katdal.%s '%s' shape %s at 0x%x>" % (self.__class__.__name__, self.name, self.shape, id(self))
+        return "<katdal.{} '{}' shape {} at 0x{:x}>".format(self.__class__.__name__, self.name, self.shape, id(self))
 
     def __str__(self):
         """Verbose human-friendly string representation of data set."""
         # Start with static file information
         descr = ['===============================================================================',
-                 'Name: %s (version %s)' % (self.name, self.version),
+                 f'Name: {self.name} (version {self.version})',
                  '===============================================================================',
-                 'Observer: %s  Experiment ID: %s' % (self.observer if self.observer else '-',
-                                                      self.experiment_id if self.experiment_id else '-'),
-                 "Description: '%s'" % (self.description if self.description else 'No description',),
-                 'Observed from %s to %s' % (self.start_time.local(), self.end_time.local()),
-                 'Dump rate / period: %.5f Hz / %.3f s' % (1 / self.dump_period, self.dump_period),
-                 'Subarrays: %d' % (len(self.subarrays),),
+                 'Observer: {}  Experiment ID: {}'.format(self.observer if self.observer else '-',
+                                                          self.experiment_id if self.experiment_id else '-'),
+                 "Description: '{}'".format(self.description if self.description else 'No description'),
+                 f'Observed from {self.start_time.local()} to {self.end_time.local()}',
+                 'Dump rate / period: {:.5f} Hz / {:.3f} s'.format(1 / self.dump_period, self.dump_period),
+                 'Subarrays: {}'.format(len(self.subarrays)),
                  '  ID  Antennas                            Inputs  Corrprods']
         for n, sub in enumerate(self.subarrays):
             ant_names = ','.join([ant.name for ant in sub.ants])
@@ -439,7 +438,7 @@ class DataSet(object):
         descr += ['-------------------------------------------------------------------------------',
                   'Data selected according to the following criteria:']
         for k, v in sorted(self._selection.items()):
-            descr.append('  %s=%s' % (k, ("'%s'" % (v,)) if isinstance(v, str) else v))
+            descr.append('  {}={}'.format(k, f"'{v}'" if isinstance(v, str) else v))
         descr.append('-------------------------------------------------------------------------------')
         descr.append('Shape: (%d dumps, %d channels, %d correlation products) => Size: %s' %
                      tuple(list(self.shape) + ['%.3f %s' % ((self.size / 1e9, 'GB') if self.size > 1e9 else
@@ -471,7 +470,7 @@ class DataSet(object):
             # Calculate average target flux over selected frequency band
             flux_spectrum = target.flux_density(self.freqs / 1e6)
             flux_valid = ~np.isnan(flux_spectrum)
-            flux = ('%9.2f' % (flux_spectrum[flux_valid].mean(),)) if np.any(flux_valid) else ''
+            flux = '{:9.2f}'.format(flux_spectrum[flux_valid].mean()) if np.any(flux_valid) else ''
             target_dumps = ((self.sensor.get('Observation/target_index') == n) & self._time_keep).sum()
             descr.append('  %2d  %s  %s  %11s  %11s  %s  %5d  %s' %
                          (n, target.name.ljust(name_len), target_type.ljust(8),
@@ -729,7 +728,7 @@ class DataSet(object):
                 scans = _selection_to_list(v)
                 scan_keep = np.zeros(len(self._time_keep), dtype=np.bool)
                 scan_sensor = self.sensor.get('Observation/scan_state' if k == 'scans' else 'Observation/label')
-                scan_index_sensor = self.sensor.get('Observation/%s_index' % (k[:-1],))
+                scan_index_sensor = self.sensor.get('Observation/{}_index'.format(k[:-1]))
                 for scan in scans:
                     if isinstance(scan, numbers.Integral):
                         scan_keep |= (scan_index_sensor == scan)
@@ -836,7 +835,7 @@ class DataSet(object):
         self.channel_width = self.spectral_windows[self.spw].channel_width
         self.corr_products = self.subarrays[self.subarray].corr_products[self._corrprod_keep]
         self.inputs = sorted(set(np.ravel(self.corr_products)))
-        input_ants = set([inp[:-1] for inp in self.inputs])
+        input_ants = {inp[:-1] for inp in self.inputs}
         self.ants = [ant for ant in self.subarrays[self.subarray].ants if ant.name in input_ants]
         # Ensure that updated selections make their way to sensor cache, as
         # well as any underlying datasets and data lazy indexers that need it
@@ -1035,7 +1034,7 @@ class DataSet(object):
     def _sensor_per_ant(self, base_name):
         """Extract a single sensor per antenna and safely stack the results."""
         def sensor_data(ant_name):
-            return self.sensor['Antennas/%s/%s' % (ant_name, base_name)]
+            return self.sensor[f'Antennas/{ant_name}/{base_name}']
         return np.column_stack([sensor_data(ant.name) for ant in self.ants]) \
             if self.ants else np.zeros((self.shape[0], 0))
 
@@ -1047,8 +1046,8 @@ class DataSet(object):
         what (u, v, w) sensors need.
         """
         def difference(antA, antB):
-            coord1 = self.sensor['Antennas/%s/%s' % (antA, base_name)]
-            coord2 = self.sensor['Antennas/%s/%s' % (antB, base_name)]
+            coord1 = self.sensor[f'Antennas/{antA}/{base_name}']
+            coord2 = self.sensor[f'Antennas/{antB}/{base_name}']
             return coord1 - coord2
         return np.column_stack([difference(inpA[:-1], inpB[:-1])
                                 for inpA, inpB in self.corr_products]) \
@@ -1118,7 +1117,7 @@ class DataSet(object):
         float, shape (*T*, *A*).
 
         """
-        name = 'target_x_%s_%s' % (self.target_projection, self.target_coordsys)
+        name = f'target_x_{self.target_projection}_{self.target_coordsys}'
         return rad2deg(self._sensor_per_ant(name))
 
     @property
@@ -1134,7 +1133,7 @@ class DataSet(object):
         float, shape (*T*, *A*).
 
         """
-        name = 'target_y_%s_%s' % (self.target_projection, self.target_coordsys)
+        name = f'target_y_{self.target_projection}_{self.target_coordsys}'
         return rad2deg(self._sensor_per_ant(name))
 
     @property

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -75,9 +75,8 @@ class Subarray:
 
     def __repr__(self):
         """Short human-friendly string representation of subarray object."""
-        return "<katdal.Subarray antennas=%d inputs=%d corrprods=%d at 0x%x>" % \
-               (len(self.ants), len(self.inputs), len(self.corr_products),
-                id(self))
+        return "<katdal.Subarray antennas={} inputs={} corrprods={} at 0x{:x}>".format(
+               len(self.ants), len(self.inputs), len(self.corr_products), id(self))
 
     @property
     def _description(self):
@@ -407,7 +406,8 @@ class DataSet:
 
     def __repr__(self):
         """Short human-friendly string representation of data set object."""
-        return "<katdal.{} '{}' shape {} at 0x{:x}>".format(self.__class__.__name__, self.name, self.shape, id(self))
+        class_name = self.__class__.__name__
+        return f"<katdal.{class_name} '{self.name}' shape {self.shape} at 0x{id(self):x}>"
 
     def __str__(self):
         """Verbose human-friendly string representation of data set."""
@@ -728,7 +728,7 @@ class DataSet:
                 scans = _selection_to_list(v)
                 scan_keep = np.zeros(len(self._time_keep), dtype=np.bool)
                 scan_sensor = self.sensor.get('Observation/scan_state' if k == 'scans' else 'Observation/label')
-                scan_index_sensor = self.sensor.get('Observation/{}_index'.format(k[:-1]))
+                scan_index_sensor = self.sensor.get(f'Observation/{k[:-1]}_index')
                 for scan in scans:
                     if isinstance(scan, numbers.Integral):
                         scan_keep |= (scan_index_sensor == scan)
@@ -1029,7 +1029,7 @@ class DataSet:
         The sidereal times are returned in an array of float, shape (*T*,).
 
         """
-        return self.sensor['Antennas/%s/lst' % self.ref_ant] * (12 / np.pi)
+        return self.sensor[f'Antennas/{self.ref_ant}/lst'] * (12 / np.pi)
 
     def _sensor_per_ant(self, base_name):
         """Extract a single sensor per antenna and safely stack the results."""

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -180,9 +180,8 @@ def view_l0_capture_stream(telstate, capture_block_id=None, stream_name=None,
     stream_type = telstate.get('stream_type', 'unknown')
     expected_type = 'sdp.vis'
     if stream_type != expected_type:
-        raise ValueError("Found stream {!r} but it has the wrong type {!r},"
-                         " expected {!r}".format(stream_name, stream_type,
-                                                 expected_type))
+        raise ValueError(f"Found stream {stream_name!r} but it has the wrong type "
+                         f"{stream_type!r}, expected {expected_type!r}")
     logger.info('Using capture block %r and stream %r',
                 capture_block_id, stream_name)
     return telstate, capture_block_id, stream_name
@@ -225,10 +224,8 @@ def _upgrade_chunk_info(chunk_info, improved_chunk_info):
     for key, improved_info in improved_chunk_info.items():
         original_info = chunk_info.get(key, improved_info)
         if improved_info['shape'][1:] != original_info['shape'][1:]:
-            raise ValueError("Original '{}' array has shape {} while improved"
-                             "version has shape {}"
-                             .format(key, original_info['shape'],
-                                     improved_info['shape']))
+            raise ValueError(f"Original '{key}' array has shape {original_info['shape']} "
+                             f"while improved version has shape {improved_info['shape']}")
         chunk_info[key] = improved_info
     return chunk_info
 
@@ -449,8 +446,8 @@ class TelstateDataSource(DataSource):
             if chunk_store == 'auto' and not kwargs.get('s3_endpoint_url'):
                 chunk_store = rdb_store
         else:
-            raise DataSourceNotFound("Unknown URL scheme '{}' - telstate expects "
-                                     "file, redis, or http(s)".format(url_parts.scheme))
+            raise DataSourceNotFound(f"Unknown URL scheme '{url_parts.scheme}' - "
+                                     'telstate expects file, redis, or http(s)')
         telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate, **kwargs)
         if chunk_store == 'auto':
             chunk_store = infer_chunk_store(url_parts, telstate, **kwargs)
@@ -469,6 +466,6 @@ def open_data_source(url, **kwargs):
         # Amend the error message for the case of an IP address without scheme
         url_parts = urllib.parse.urlparse(url, scheme='file')
         if url_parts.scheme == 'file' and not os.path.isfile(url_parts.path):
-            raise DataSourceNotFound('{} (add a URL scheme if {!r} is not meant to be a file)'
-                                     .format(e, url_parts.path)) from e
+            raise DataSourceNotFound(f'{e} (add a URL scheme if {url_parts.path!r} '
+                                     'is not meant to be a file)') from e
         raise

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -38,7 +38,7 @@ class DataSourceNotFound(Exception):
     """File associated with DataSource not found or server not responding."""
 
 
-class AttrsSensors(object):
+class AttrsSensors:
     """Metadata in the form of attributes and sensors.
 
     Parameters
@@ -57,7 +57,7 @@ class AttrsSensors(object):
         self.name = name
 
 
-class DataSource(object):
+class DataSource:
     """A generic data source presenting both correlator data and metadata.
 
     Parameters

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -158,7 +158,8 @@ class H5DataV1(DataSet):
                obj.dtype.names == ('timestamp', 'value', 'status'):
                 # Assume sensor dataset name is AntennaN/Sensors/dataset and rename it to Antennas/{ant}/dataset
                 ant_name = to_str(obj.parent.parent.attrs['description']).split(',')[0]
-                standardised_name = 'Antennas/{}/{}'.format(ant_name, name.split('/')[-1])
+                dataset_name = name.split('/')[-1]
+                standardised_name = f"Antennas/{ant_name}/{dataset_name}"
                 cache[standardised_name] = RecordSensorGetter(obj, standardised_name)
         ants_group.visititems(register_sensor)
         # Use estimated data timestamps for now, to speed up data segmentation
@@ -189,8 +190,8 @@ class H5DataV1(DataSet):
             corrprods.append(tuple([input_label[inp] for inp in match.groups()]))
         data_cp_len = len(self._scan_groups[0]['data'].dtype)
         if len(corrprods) != data_cp_len:
-            raise BrokenFile('Number of baseline labels received from correlator '
-                             '(%d) differs from number of baselines in data (%d)' % (len(corrprods), data_cp_len))
+            raise BrokenFile(f'Number of baseline labels received from correlator ({len(corrprods)}) '
+                             f'differs from number of baselines in data ({data_cp_len})')
         self.subarrays = [Subarray(ants, corrprods)]
         self.sensor['Observation/subarray'] = CategoricalData(self.subarrays, [0, len(data_timestamps)])
         self.sensor['Observation/subarray_index'] = CategoricalData([0], [0, len(data_timestamps)])
@@ -208,8 +209,8 @@ class H5DataV1(DataSet):
         num_chans = corr_group.attrs['num_freq_channels']
         data_num_chans = self._scan_groups[0]['data'].shape[1]
         if num_chans != data_num_chans:
-            raise BrokenFile('Number of channels received from correlator '
-                             '(%d) differs from number of channels in data (%d)' % (num_chans, data_num_chans))
+            raise BrokenFile(f'Number of channels received from correlator ({num_chans}) '
+                             f'differs from number of channels in data ({data_num_chans})')
         channel_width = corr_group.attrs['channel_bandwidth_hz']
         self.spectral_windows = [SpectralWindow(centre_freq, channel_width, num_chans, 'poco')]
         self.sensor['Observation/spw'] = CategoricalData(self.spectral_windows, [0, len(data_timestamps)])

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -17,6 +17,7 @@
 """Data accessor class for HDF5 files produced by KAT-7 correlator."""
 
 import logging
+import secrets
 
 import numpy as np
 import h5py
@@ -126,8 +127,7 @@ def dummy_dataset(name, shape, dtype, value):
     """
     # It is important to randomise the filename as h5py does not allow two writable file objects with the same name
     # Without this randomness katdal can only open one file requiring a dummy dataset
-    random_string = ''.join(f'{x:02x}' for x in np.random.randint(256, size=8))
-    dummy_file = h5py.File(f'{name}_{random_string}.h5', 'x', driver='core', backing_store=False)
+    dummy_file = h5py.File(f'{name}_{secrets.token_hex(8)}.h5', 'x', driver='core', backing_store=False)
     return dummy_file.create_dataset(name, shape=shape, maxshape=shape,
                                      dtype=dtype, fillvalue=value, compression='gzip')
 
@@ -453,7 +453,7 @@ class H5DataV2(DataSet):
             for proc in self.file['History']['process_log']:
                 # proc has a structured dtype and to_str doesn't work on it, so
                 # we have to to_str each element.
-                param_list = '{:>15}:'.format(to_str(proc[0]))
+                param_list = f'{to_str(proc[0]):>15}:'
                 for param in to_str(proc[1]).split(','):
                     param_list += f'  {param}'
                 descr.append(param_list)

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -17,6 +17,7 @@
 """Data accessor class for HDF5 files produced by RTS correlator."""
 
 import logging
+import secrets
 from collections import Counter
 
 import numpy as np
@@ -104,8 +105,7 @@ def dummy_dataset(name, shape, dtype, value):
     """
     # It is important to randomise the filename as h5py does not allow two writable file objects with the same name
     # Without this randomness katdal can only open one file requiring a dummy dataset
-    random_string = ''.join(f'{x:02x}' for x in np.random.randint(256, size=8))
-    dummy_file = h5py.File(f'{name}_{random_string}.h5', 'x', driver='core', backing_store=False)
+    dummy_file = h5py.File(f'{name}_{secrets.token_hex(8)}.h5', 'x', driver='core', backing_store=False)
     return dummy_file.create_dataset(name, shape=shape, maxshape=shape,
                                      dtype=dtype, fillvalue=value, compression='gzip')
 
@@ -865,7 +865,7 @@ class H5DataV3(DataSet):
             for proc in self.file['History']['process_log']:
                 # proc has a structured dtype and to_str doesn't work on it, so
                 # we have to to_str each element.
-                param_list = '{:>15}:'.format(to_str(proc[0]))
+                param_list = f'{to_str(proc[0]):>15}:'
                 for param in to_str(proc[1]).split(','):
                     param_list += f'  {param}'
                 descr.append(param_list)

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -43,7 +43,7 @@ def _range_to_slice(index):
     """
     if not len(index):
         return slice(None, 0, None)
-    if any(i for i in index if i < 0):
+    if any(i < 0 for i in index):
         raise ValueError(f'Could not convert {index} to a slice '
                          '(contains negative elements)')
     increments_left = set(np.diff(index))

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -160,7 +160,7 @@ class InvalidTransform(Exception):
     """Transform changes data shape in unallowed way."""
 
 
-class LazyTransform(object):
+class LazyTransform:
     """Transformation to be applied by LazyIndexer after final indexing.
 
     A :class:`LazyIndexer` potentially applies a chain of transforms to the
@@ -211,7 +211,7 @@ class LazyTransform(object):
 # -------------------------------------------------------------------------------------------------
 
 
-class LazyIndexer(object):
+class LazyIndexer:
     """Two-stage deferred indexer for objects with expensive __getitem__ calls.
 
     This class was originally designed to extend and speed up the indexing
@@ -317,7 +317,7 @@ class LazyIndexer(object):
     def _name_shape_dtype(self, name, shape, dtype):
         """Helper function to create strings for display (limits dtype length)."""
         dtype_str = (str(dtype)[:50] + '...') if len(str(dtype)) > 50 else str(dtype)
-        return "%s -> %s %s" % (name, shape, dtype_str)
+        return f"{name} -> {shape} {dtype_str}"
 
     def __str__(self):
         """Verbose human-friendly string representation of lazy indexer object."""
@@ -463,7 +463,7 @@ class LazyIndexer(object):
                       self.transforms, self._initial_dtype)
 
 
-class DaskLazyIndexer(object):
+class DaskLazyIndexer:
     """Turn a dask Array into a LazyIndexer by computing it upon indexing.
 
     The LazyIndexer wraps an underlying `dataset` in the form of a dask Array.
@@ -614,7 +614,7 @@ class DaskLazyIndexer(object):
         """Verbose human-friendly string representation of indexer object."""
         names = [self.name]
         names += [_callable_name(transform) for transform in self.transforms]
-        return ' | '.join(names) + ' -> {} {}'.format(self.shape, self.dtype)
+        return ' | '.join(names) + f' -> {self.shape} {self.dtype}'
 
     @property
     def shape(self):

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -201,7 +201,7 @@ class LazyTransform:
         """Short human-friendly string representation of lazy transform object."""
         class_name = self.__class__.__name__
         dtype = 'unchanged' if self.dtype is None else self.dtype
-        return f"<katdal.{class_name} '{self.name}': type '{dtype}' at 0x{id(self):x}>"
+        return f"<katdal.{class_name} '{self.name}': type '{dtype}' at {id(self):#x}>"
 
     def __call__(self, data, keep):
         """Transform data (`keep` is user-specified second-stage index)."""
@@ -312,7 +312,7 @@ class LazyIndexer:
 
     def __repr__(self):
         """Short human-friendly string representation of lazy indexer object."""
-        return "<katdal.{} '{}': shape {}, type {} at 0x{:x}>".format(
+        return "<katdal.{} '{}': shape {}, type {} at {:#x}>".format(
                self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
 
     def _name_shape_dtype(self, name, shape, dtype):
@@ -607,7 +607,7 @@ class DaskLazyIndexer:
 
     def __repr__(self):
         """Short human-friendly string representation of indexer object."""
-        return "<katdal.{} '{}': shape {}, type {} at 0x{:x}>".format(
+        return "<katdal.{} '{}': shape {}, type {} at {:#x}>".format(
             self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
 
     def __str__(self):

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -44,13 +44,13 @@ def _range_to_slice(index):
     if not len(index):
         return slice(None, 0, None)
     if any(i for i in index if i < 0):
-        raise ValueError('Could not convert {} to a slice (contains negative '
-                         'elements)'.format(index))
+        raise ValueError(f'Could not convert {index} to a slice '
+                         '(contains negative elements)')
     increments_left = set(np.diff(index))
     step = increments_left.pop() if increments_left else 1
     if step == 0 or increments_left:
-        raise ValueError('Could not convert {} to a slice (unevenly spaced or '
-                         'zero increments)'.format(index))
+        raise ValueError(f'Could not convert {index} to a slice '
+                         '(unevenly spaced or zero increments)')
     start = index[0]
     stop = index[-1] + step
     # Avoid descending below 0 and thereby wrapping back to the top
@@ -199,8 +199,9 @@ class LazyTransform:
 
     def __repr__(self):
         """Short human-friendly string representation of lazy transform object."""
-        return "<katdal.%s '%s': type '%s' at 0x%x>" % \
-               (self.__class__.__name__, self.name, 'unchanged' if self.dtype is None else self.dtype, id(self))
+        class_name = self.__class__.__name__
+        dtype = 'unchanged' if self.dtype is None else self.dtype
+        return f"<katdal.{class_name} '{self.name}': type '{dtype}' at 0x{id(self):x}>"
 
     def __call__(self, data, keep):
         """Transform data (`keep` is user-specified second-stage index)."""
@@ -311,8 +312,8 @@ class LazyIndexer:
 
     def __repr__(self):
         """Short human-friendly string representation of lazy indexer object."""
-        return "<katdal.%s '%s': shape %s, type %s at 0x%x>" % \
-               (self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
+        return "<katdal.{} '{}': shape {}, type {} at 0x{:x}>".format(
+               self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
 
     def _name_shape_dtype(self, name, shape, dtype):
         """Helper function to create strings for display (limits dtype length)."""
@@ -453,7 +454,7 @@ class LazyIndexer:
         allowed_shapes = [self._initial_shape[:(n + 1)] for n in range(len(self._initial_shape))]
         if new_shape[:len(self._initial_shape)] not in allowed_shapes:
             raise InvalidTransform('Transform chain may only add or drop dimensions at the end of data shape: '
-                                   'final shape is %s, expected one of %s' % (new_shape, allowed_shapes))
+                                   f'final shape is {new_shape}, expected one of {allowed_shapes}')
         return new_shape
 
     @property
@@ -607,8 +608,7 @@ class DaskLazyIndexer:
     def __repr__(self):
         """Short human-friendly string representation of indexer object."""
         return "<katdal.{} '{}': shape {}, type {} at 0x{:x}>".format(
-            self.__class__.__name__, self.name, self.shape, self.dtype,
-            id(self))
+            self.__class__.__name__, self.name, self.shape, self.dtype, id(self))
 
     def __str__(self):
         """Verbose human-friendly string representation of indexer object."""

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -36,7 +36,7 @@ import katpoint
 from . import ms_extra
 
 
-class RawArray(object):
+class RawArray:
     """Shared memory array, in representation that can be passed through multiprocessing queue"""
     def __init__(self, shape, dtype):
         self.shape = shape

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -86,9 +86,8 @@ def tiled_array(comment, valueType, ndim, dataManagerGroup, **kwargs):
 
 def define_hypercolumn(desc):
     """Add hypercolumn definitions to table description."""
-    desc['_define_hypercolumn_'] = dict([(v['dataManagerGroup'],
-                                          dict(HCdatanames=[k], HCndim=v['ndim'] + 1))
-                                         for k, v in desc.items() if v['dataManagerType'] == 'TiledShapeStMan'])
+    desc['_define_hypercolumn_'] = {v['dataManagerGroup']: dict(HCdatanames=[k], HCndim=v['ndim'] + 1)
+                                    for k, v in desc.items() if v['dataManagerType'] == 'TiledShapeStMan'}
 
 
 # Map MeasurementSet string types to numpy types
@@ -981,7 +980,7 @@ def write_rows(t, row_dict, verbose=True):
     for col_name, col_data in row_dict.items():
         if col_name not in t.colnames():
             if verbose:
-                print("  column '%s' not in table" % (col_name,))
+                print(f"  column '{col_name}' not in table")
             continue
         if col_data.dtype.kind == 'U':
             col_data = np.char.encode(col_data, encoding='utf-8')
@@ -1005,7 +1004,7 @@ def write_dict(ms_dict, ms_name, verbose=True):
         # Iterate through row groups that are separate dicts within the sub_dict array
         for row_dict in sub_dict:
             if verbose:
-                print("Table %s:" % (sub_table_name,))
+                print(f"Table {sub_table_name}:")
             # Open main table or sub-table
             if sub_table_name == 'MAIN':
                 t = open_table(ms_name, verbose=verbose)

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -33,9 +33,8 @@ from casacore import tables
 pyc_ver = parse_version(casacore.__version__)
 req_ver = parse_version("2.2.1")
 if not pyc_ver >= req_ver:
-    raise ImportError("python-casacore %s is required, but the current version is %s. "
-                      "Note that python-casacore %s requires at least casacore 2.3.0."
-                      % (req_ver, pyc_ver, req_ver))
+    raise ImportError(f"python-casacore {req_ver} is required, but the current version is {pyc_ver}. "
+                      f"Note that python-casacore {req_ver} requires at least casacore 2.3.0.")
 
 
 def open_table(name, readonly=False, verbose=False, **kwargs):
@@ -589,7 +588,7 @@ def populate_polarization_dict(ms_pols=['HH', 'VV'], stokes_i=False, circular=Fa
                  'HH': 9, 'VV': 12, 'HV': 10, 'VH': 11}
     if len(ms_pols) > 1 and stokes_i:
         print("Warning: Polarisation to be marked as stokes, but more than 1 polarisation "
-              "product specified. Using first specified pol (%s)" % ms_pols[0])
+              f"product specified. Using first specified pol ({ms_pols[0]})")
         ms_pols = [ms_pols[0]]
     #  Indices describing receptors of feed going into correlation (integer, 2-dim)
     polarization_dict = {}
@@ -741,7 +740,7 @@ def populate_source_dict(phase_centers, time_origins, field_names=None):
     phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))
     num_fields = len(phase_centers)
     if field_names is None:
-        field_names = ['Source%d' % (field,) for field in range(num_fields)]
+        field_names = [f'Source{field}' for field in range(num_fields)]
     source_dict = {}
     # Source identifier as specified in the FIELD sub-table (integer)
     source_dict['SOURCE_ID'] = np.arange(num_fields, dtype=np.int32)
@@ -790,7 +789,7 @@ def populate_field_dict(phase_centers, time_origins, field_names=None):
     phase_centers = np.atleast_2d(np.asarray(phase_centers, np.float64))[:, np.newaxis, :]
     num_fields = len(phase_centers)
     if field_names is None:
-        field_names = ['Field%d' % (field,) for field in range(num_fields)]
+        field_names = [f'Field{field}' for field in range(num_fields)]
     field_dict = {}
     # Special characteristics of field, e.g. position code (string)
     field_dict['CODE'] = np.tile('T', num_fields)
@@ -976,7 +975,7 @@ def write_rows(t, row_dict, verbose=True):
     # Add the space required for this group of rows
     t.addrows(num_rows)
     if verbose:
-        print("  added %d rows" % (num_rows,))
+        print(f"  added {num_rows} rows")
     for col_name, col_data in row_dict.items():
         if col_name not in t.colnames():
             if verbose:

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -104,7 +104,7 @@ class SensorGetter:
     def __repr__(self):
         """Short human-friendly string representation of sensor data object."""
         class_name = self.__class__.__name__
-        return f"<katdal.{class_name} '{self.name}' at 0x{id(self):x}>"
+        return f"<katdal.{class_name} '{self.name}' at {id(self):#x}>"
 
 
 class SimpleSensorGetter(SensorGetter):
@@ -169,7 +169,7 @@ class RecordSensorGetter(SensorGetter):
 
     def __repr__(self):
         """Short human-friendly string representation of sensor data object."""
-        return "<katdal.{} '{}' len={} type={} at 0x{:x}>".format(
+        return "<katdal.{} '{}' len={} type={} at {:#x}>".format(
                self.__class__.__name__, self.name,
                len(self._data), self._data['value'].dtype, id(self))
 
@@ -652,9 +652,9 @@ class SensorCache(MutableMapping):
             names = sorted([key for key in self.keys()])
             maxlen = max([len(name) for name in names])
             objects = [self.get(name, extract=False) for name in names]
-        obj_reprs = [(f"<numpy.ndarray shape={obj.shape} type={obj.dtype} at 0x{id(obj):x}>"
+        obj_reprs = [(f"<numpy.ndarray shape={obj.shape} type={obj.dtype} at {id(obj):#x}>"
                       if isinstance(obj, np.ndarray) else repr(obj)) for obj in objects]
-        actual = ['{} : {}'.format(str(name).ljust(maxlen), obj_repr)
+        actual = [f'{name!s:{maxlen}} : {obj_repr}'
                   for name, obj_repr in zip(names, obj_reprs)]
         virtual = ['{} : <function {}.{}>'
                    .format(str(pat).ljust(maxlen), func.__module__, func.__name__)
@@ -666,7 +666,7 @@ class SensorCache(MutableMapping):
         """Short human-friendly string representation of sensor cache object."""
         with self._lock:
             sensors = [self.get(name, extract=False) for name in self.keys()]
-        return "<katdal.{} sensors={} cached={} virtual={} at 0x{:x}>".format(
+        return "<katdal.{} sensors={} cached={} virtual={} at {:#x}>".format(
                self.__class__.__name__, len(sensors),
                np.sum([not isinstance(s, SensorGetter) for s in sensors]),
                len(self.virtual), id(self))

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -656,8 +656,7 @@ class SensorCache(MutableMapping):
                       if isinstance(obj, np.ndarray) else repr(obj)) for obj in objects]
         actual = [f'{name!s:{maxlen}} : {obj_repr}'
                   for name, obj_repr in zip(names, obj_reprs)]
-        virtual = ['{} : <function {}.{}>'
-                   .format(str(pat).ljust(maxlen), func.__module__, func.__name__)
+        virtual = [f'{pat!s:{maxlen}} : <function {func.__module__}.{func.__name__}>'
                    for pat, func in self.virtual.items()]
         return '\n'.join(['Actual sensors', '--------------'] + actual +
                          ['\nVirtual sensors', '---------------'] + virtual)

--- a/katdal/spectral_window.py
+++ b/katdal/spectral_window.py
@@ -92,13 +92,11 @@ class SpectralWindow:
 
     def __repr__(self):
         """Short human-friendly string representation of spectral window object."""
-        return "<katdal.SpectralWindow %s-band product=%s centre=%.3f MHz " \
-               "bandwidth=%.3f MHz channels=%d at 0x%x>" % \
-               (self.band if self.band else 'unknown',
-                repr(self.product) if self.product else 'unknown',
-                self.centre_freq / 1e6,
-                self.bandwidth / 1e6,
-                self.num_chans, id(self))
+        band = self.band if self.band else 'unknown',
+        product = repr(self.product) if self.product else 'unknown'
+        return (f"<katdal.SpectralWindow {band}-band product={product} "
+                f"centre={self.centre_freq/1e6:.3f} MHz bandwidth={self.bandwidth/1e6:.3f} MHz "
+                f"channels={self.num_chans} at 0x{id(self):x}>")
 
     @property
     def _description(self):

--- a/katdal/spectral_window.py
+++ b/katdal/spectral_window.py
@@ -96,7 +96,7 @@ class SpectralWindow:
         product = repr(self.product) if self.product else 'unknown'
         return (f"<katdal.SpectralWindow {band}-band product={product} "
                 f"centre={self.centre_freq/1e6:.3f} MHz bandwidth={self.bandwidth/1e6:.3f} MHz "
-                f"channels={self.num_chans} at 0x{id(self):x}>")
+                f"channels={self.num_chans} at {id(self):#x}>")
 
     @property
     def _description(self):

--- a/katdal/spectral_window.py
+++ b/katdal/spectral_window.py
@@ -19,7 +19,7 @@ import threading
 import numpy as np
 
 
-class SpectralWindow(object):
+class SpectralWindow:
     """Spectral window specification.
 
     A spectral window is determined by the number of frequency channels produced

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -460,15 +460,13 @@ class TestVirtualCorrectionSensors:
                     m, n, multi_channel=True, targets=True))
 
     def test_unknown_inputs_and_products(self):
-        known_input = '{}{}'.format(ANTS[0], POLS[0])
+        known_input = ANTS[0] + POLS[0]
         with assert_raises(KeyError):
             self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/K/unknown')
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/{}/unknown/{}'
-                           .format(CAL_STREAM, known_input))
+            self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/unknown/{known_input}')
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/{}/K_unknown/{}'
-                           .format(CAL_STREAM, known_input))
+            self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/K_unknown/{known_input}')
         with assert_raises(KeyError):
             self.cache.get('Calibration/Corrections/unknown/K/' + known_input)
         with assert_raises(KeyError):

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -89,7 +89,7 @@ ATTRS = {'antlist': ANTS, 'pol_ordering': POLS,
          'n_chans': CAL_N_CHANS, 'product_B_parts': BANDPASS_PARTS,
          'measured_flux': PIPELINE_FLUXES}
 CAL_PRODUCT_TYPES = ('K', 'B', 'G', 'GPHASE')
-CAL_PRODUCTS = ['{}.{}'.format(CAL_STREAM, prod) for prod in CAL_PRODUCT_TYPES]
+CAL_PRODUCTS = [f'{CAL_STREAM}.{prod}' for prod in CAL_PRODUCT_TYPES]
 
 
 def create_delay(pol, ant):
@@ -266,7 +266,7 @@ def assert_categorical_data_equal(actual, desired):
         assert_array_equal(a, d)
 
 
-class TestComplexInterp(object):
+class TestComplexInterp:
     """Test the :func:`~katdal.applycal.complex_interp` function."""
     def setup(self):
         self.xi = np.arange(1., 10.)
@@ -315,7 +315,7 @@ class TestComplexInterp(object):
         assert_allclose(y[-1], 1j, rtol=1e-14)
 
 
-class TestCalProductAccess(object):
+class TestCalProductAccess:
     """Test the :func:`~katdal.applycal.*_cal_product` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
@@ -351,7 +351,7 @@ class TestCalProductAccess(object):
             product[part] = INVALID_GAIN
             assert_array_equal(product_sensor[12], product)
             # Recalculate on the next pass
-            del cache['Calibration/Products/{}/B'.format(CAL_STREAM)]
+            del cache[f'Calibration/Products/{CAL_STREAM}/B']
         # All parts gone triggers a KeyError
         del cache[CAL_STREAM + '_product_B' + str(BANDPASS_PARTS - 1)]
         with assert_raises(KeyError):
@@ -368,7 +368,7 @@ class TestCalProductAccess(object):
         assert_array_equal(product_sensor[GAIN_EVENTS], product)
 
 
-class TestCorrectionPerInput(object):
+class TestCorrectionPerInput:
     """Test the :func:`~katdal.applycal.calc_*_correction` functions."""
     def setup(self):
         self.cache = create_sensor_cache()
@@ -412,7 +412,7 @@ class TestCorrectionPerInput(object):
                     m, n, multi_channel=True, targets=True))
 
 
-class TestVirtualCorrectionSensors(object):
+class TestVirtualCorrectionSensors:
     """Test :func:`~katdal.applycal.add_applycal_sensors` function."""
     def setup(self):
         self.cache = create_sensor_cache()
@@ -433,28 +433,28 @@ class TestVirtualCorrectionSensors(object):
     def test_delay_sensors(self, stream=CAL_STREAM):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/{}/K/{}{}'.format(stream, ant, pol)
+                sensor_name = f'Calibration/Corrections/{stream}/K/{ant}{pol}'
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[10 + n], delay_corrections(m, n))
 
     def test_bandpass_sensors(self, stream=CAL_STREAM):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/{}/B/{}{}'.format(stream, ant, pol)
+                sensor_name = f'Calibration/Corrections/{stream}/B/{ant}{pol}'
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[12 + n], bandpass_corrections(m, n))
 
     def test_gain_sensors(self, stream=CAL_STREAM):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/{}/G/{}{}'.format(stream, ant, pol)
+                sensor_name = f'Calibration/Corrections/{stream}/G/{ant}{pol}'
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[:], gain_corrections(m, n))
 
     def test_selfcal_gain_sensors(self, stream=CAL_STREAM):
         for n, ant in enumerate(ANTS):
             for m, pol in enumerate(POLS):
-                sensor_name = 'Calibration/Corrections/{}/GPHASE/{}{}'.format(stream, ant, pol)
+                sensor_name = f'Calibration/Corrections/{stream}/GPHASE/{ant}{pol}'
                 sensor = self.cache.get(sensor_name)
                 assert_array_equal(sensor[:], gain_corrections(
                     m, n, multi_channel=True, targets=True))
@@ -462,7 +462,7 @@ class TestVirtualCorrectionSensors(object):
     def test_unknown_inputs_and_products(self):
         known_input = '{}{}'.format(ANTS[0], POLS[0])
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Corrections/{}/K/unknown'.format(CAL_STREAM))
+            self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/K/unknown')
         with assert_raises(KeyError):
             self.cache.get('Calibration/Corrections/{}/unknown/{}'
                            .format(CAL_STREAM, known_input))
@@ -472,7 +472,7 @@ class TestVirtualCorrectionSensors(object):
         with assert_raises(KeyError):
             self.cache.get('Calibration/Corrections/unknown/K/' + known_input)
         with assert_raises(KeyError):
-            self.cache.get('Calibration/Products/{}/K_unknown'.format(CAL_STREAM))
+            self.cache.get(f'Calibration/Products/{CAL_STREAM}/K_unknown')
         with assert_raises(KeyError):
             self.cache.get('Calibration/Products/unknown/K')
 
@@ -484,7 +484,7 @@ class TestVirtualCorrectionSensors(object):
         self.test_gain_sensors('my_cal')
 
 
-class TestCalibrateFlux(object):
+class TestCalibrateFlux:
     """Test :func:`~katdal.applycal.calibrate_flux` function."""
 
     def setup(self):
@@ -513,7 +513,7 @@ class TestCalibrateFlux(object):
         assert_categorical_data_equal(calibrated_sensor, self.sensor)
 
 
-class TestCalcCorrection(object):
+class TestCalcCorrection:
     """Test :func:`~katdal.applycal.calc_correction` function."""
     def setup(self):
         self.cache = create_sensor_cache()
@@ -566,7 +566,7 @@ class TestCalcCorrection(object):
         assert_array_equal(corrections, expected_corrections)
 
 
-class TestApplyCal(object):
+class TestApplyCal:
     """Test :func:`~katdal.applycal.apply_vis_correction` and friends"""
     def setup(self):
         self.cache = create_sensor_cache()

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -182,8 +182,7 @@ class ChunkStoreTestBase:
         array_retrieved = pull.compute()
         array = dask_array.compute()
         assert_array_equal(array_retrieved, array,
-                           "Error retrieving {} / {} / {}"
-                           .format(array_name, offset, dask_array.chunks))
+                           f'Error retrieving {array_name} / {offset} / {dask_array.chunks}')
 
     def test_chunk_non_existent(self):
         array_name = self.array_name('haha')
@@ -246,8 +245,7 @@ class ChunkStoreTestBase:
             assert_equal(array_retrieved.shape, dask_array.shape)
             assert_equal(array_retrieved.dtype, dask_array.dtype)
             assert_array_equal(array_retrieved[np.s_[3:8, 30:60, 0:2]], 17,
-                               "Missing chunk in {} not replaced by default value"
-                               .format(array_name))
+                               f'Missing chunk in {array_name} not replaced by default value')
         # Now store the last quarter and check that complete array is correct
         self.put_dask_array('big_y2', np.s_[3:8, 30:60, 0:2])
         self.get_dask_array('big_y2')

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -26,7 +26,7 @@ from katdal.chunkstore import (ChunkStore, generate_chunks,
                                StoreUnavailable, ChunkNotFound, BadChunk)
 
 
-class TestGenerateChunks(object):
+class TestGenerateChunks:
     """Test the `generate_chunks` function."""
     def __init__(self):
         self.shape = (10, 8192, 144)
@@ -90,7 +90,7 @@ class TestGenerateChunks(object):
         assert_equal(chunks, ((10,), 1024 * (8,), (144,)))
 
 
-class TestChunkStore(object):
+class TestChunkStore:
     """This tests the base class functionality."""
 
     def test_put_get(self):
@@ -128,7 +128,7 @@ class TestChunkStore(object):
                 {}['ha']
 
 
-class ChunkStoreTestBase(object):
+class ChunkStoreTestBase:
     """Standard tests performed on all types of ChunkStore."""
 
     # Instance of store instantiated once per class via class-level fixture
@@ -153,8 +153,7 @@ class ChunkStoreTestBase(object):
         self.store.create_array(array_name)
         self.store.put_chunk(array_name, slices, chunk)
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
-        assert_array_equal(chunk_retrieved, chunk,
-                           "Error storing {}[{}]".format(var_name, slices))
+        assert_array_equal(chunk_retrieved, chunk, f"Error storing {var_name}[{slices}]")
 
     def make_dask_array(self, var_name, slices=()):
         """Turn (part of) an existing ndarray into a dask array."""

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -440,8 +440,7 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
         time_offset = now - initial_time
         # Print to stdout instead of stderr so that it doesn't spew all over
         # the screen in normal operation.
-        print("Token proxy: {} ({:.3f}) {}".format(self.log_date_time_string(),
-                                                   time_offset, format % args))
+        print(f"Token proxy: {self.log_date_time_string()} ({time_offset:.3f}) {format % args}")
 
 
 class _TokenHTTPProxyServer(http.server.HTTPServer):

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -94,7 +94,7 @@ def get_free_port(host):
         yield port
 
 
-class TestReadArray(object):
+class TestReadArray:
     def _test(self, array):
         fp = io.BytesIO()
         np.save(fp, array)
@@ -162,7 +162,7 @@ def encode_jwt(header, payload, signature=86 * 'x'):
     return header_payload + signature
 
 
-class TestTokenUtils(object):
+class TestTokenUtils:
     """Test token utility and validation functions."""
 
     def test_jwt_broken_token(self):
@@ -281,7 +281,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
     def test_store_unavailable_unresponsive_server(self):
         host = '127.0.0.1'
         with get_free_port(host) as port:
-            url = 'http://{}:{}/'.format(host, port)
+            url = f'http://{host}:{port}/'
             store = S3ChunkStore(url, timeout=0.1, retries=0)
             with assert_raises(StoreUnavailable):
                 store.is_complete('store_is_not_listening_on_that_port')
@@ -300,7 +300,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         telstate['capture_block_id'] = cbid
         telstate['stream_name'] = sn
         # Save telstate to temp RDB file since RDBWriter needs a filename and not a handle
-        rdb_filename = '{}_{}.rdb'.format(cbid, sn)
+        rdb_filename = f'{cbid}_{sn}.rdb'
         temp_filename = os.path.join(self.tempdir, rdb_filename)
         with RDBWriter(temp_filename) as rdbw:
             rdbw.save(telstate)
@@ -441,8 +441,8 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
         time_offset = now - initial_time
         # Print to stdout instead of stderr so that it doesn't spew all over
         # the screen in normal operation.
-        print("Token proxy: %s (%.3f) %s" % (self.log_date_time_string(),
-                                             time_offset, format % args))
+        print("Token proxy: {} ({:.3f}) {}".format(self.log_date_time_string(),
+                                                   time_offset, format % args))
 
 
 class _TokenHTTPProxyServer(http.server.HTTPServer):
@@ -463,7 +463,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
     def setup_class(cls):
         cls.proxy_url = None
         cls.httpd = None
-        super(TestS3ChunkStoreToken, cls).setup_class()
+        super().setup_class()
 
     @classmethod
     def teardown_class(cls):
@@ -473,7 +473,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
             cls.httpd = None
             cls.httpd_thread.join()
             cls.httpd_thread = None
-        super(TestS3ChunkStoreToken, cls).teardown_class()
+        super().teardown_class()
 
     @classmethod
     def prepare_store_args(cls, url, **kwargs):
@@ -492,7 +492,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
             # because teardown calls httpd.shutdown and that hangs if
             # serve_forever wasn't called.
             cls.httpd = httpd
-            cls.proxy_url = 'http://{}:{}'.format(proxy_host, proxy_port)
+            cls.proxy_url = f'http://{proxy_host}:{proxy_port}'
         elif url != cls.httpd.target:
             raise RuntimeError('Cannot use multiple target URLs with http proxy')
         # The token authorises the standard bucket and anything starting with PREFIX

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -368,8 +368,8 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
                     pause = READ_PAUSE if flavour == 'pause' else 0.0
                     glitch_location = int(glitch.group(2))
                 else:
-                    raise ValueError("Unknown command '{}' in proxy suggestion {}"
-                                     .format(command, suggestion))
+                    raise ValueError(f"Unknown command '{command}' "
+                                     f'in proxy suggestion {suggestion}')
             else:
                 # We're done with this suggestion since its time ran out
                 del self.server.initial_request_time[key]
@@ -385,8 +385,7 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
         except InvalidToken:
             prefixes = []
         if not any(self.path.lstrip('/').startswith(prefix) for prefix in prefixes):
-            self.send_response(401, 'Unauthorized (got: {}, allowed: {})'
-                                    .format(self.path, prefixes))
+            self.send_response(401, f'Unauthorized (got: {self.path}, allowed: {prefixes})')
             self.end_headers()
             return
 

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8
-
 ################################################################################
 # Copyright (c) 2020, National Research Foundation (Square Kilometre Array)
 #
@@ -26,7 +24,7 @@ from katdal.sensordata import SensorCache, SimpleSensorGetter
 from katdal.concatdata import ConcatenatedSensorCache
 
 
-class TestConcatenatedSensorCache(object):
+class TestConcatenatedSensorCache:
     @staticmethod
     def _make_cache(timestamps, sensors):
         cache_data = {}

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -31,7 +31,7 @@ from katdal.spectral_window import SpectralWindow
 class MinimalDataSet(DataSet):
     """Minimal data set containing a single target track."""
     def __init__(self, target, subarray, spectral_window, timestamps):
-        super(MinimalDataSet, self).__init__(name='test', ref_ant='array')
+        super().__init__(name='test', ref_ant='array')
         num_dumps = len(timestamps)
         num_chans = spectral_window.num_chans
         num_corrprods = len(subarray.corr_products)
@@ -44,10 +44,10 @@ class MinimalDataSet(DataSet):
         self.spectral_windows = [spectral_window]
         sensors = {}
         for ant in subarray.ants:
-            sensors['Antennas/%s/antenna' % (ant.name,)] = constant_sensor(ant)
+            sensors[f'Antennas/{ant.name}/antenna'] = constant_sensor(ant)
             az, el = target.azel(timestamps, ant)
-            sensors['Antennas/%s/az' % (ant.name,)] = az
-            sensors['Antennas/%s/el' % (ant.name,)] = el
+            sensors[f'Antennas/{ant.name}/az'] = az
+            sensors[f'Antennas/{ant.name}/el'] = el
         # Extract array reference position as 'array_ant' from last antenna
         array_ant_fields = ['array'] + ant.description.split(',')[1:5]
         array_ant = Antenna(','.join(array_ant_fields))
@@ -55,7 +55,7 @@ class MinimalDataSet(DataSet):
 
         sensors['Observation/target'] = constant_sensor(target)
         for name in ('spw', 'subarray', 'scan', 'compscan', 'target'):
-            sensors['Observation/%s_index' % (name,)] = constant_sensor(0)
+            sensors[f'Observation/{name}_index'] = constant_sensor(0)
         sensors['Observation/scan_state'] = constant_sensor('track')
         sensors['Observation/label'] = constant_sensor('track')
 
@@ -95,7 +95,7 @@ def test_selection_to_list():
     assert_equal(_selection_to_list('all', all=['a', 'b']), ['a', 'b'])
 
 
-class TestVirtualSensors(object):
+class TestVirtualSensors:
     def setup(self):
         self.target = Target('PKS1934-638, radec, 19:39, -63:42')
         self.antennas = [Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -64,8 +64,7 @@ def _make_fake_stream(telstate, store, cbid, stream, shape,
         for j in range(i, n_ant):
             for x in 'hv':
                 for y in 'hv':
-                    bls_ordering.append(('m{:03}{}'.format(i, x),
-                                         'm{:03}{}'.format(j, y)))
+                    bls_ordering.append((f'm{i:03}{x}', f'm{j:03}{y}'))
     s_view['bls_ordering'] = np.array(bls_ordering)
     if not flags_only:
         s_view['need_weights_power_scale'] = True
@@ -117,7 +116,7 @@ def assert_telstate_data_source_equal(source1, source2):
     np.testing.assert_array_equal(source1.data.weights.compute(), source2.data.weights.compute())
 
 
-class TestTelstateDataSource(object):
+class TestTelstateDataSource:
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
         self.store = NpyFileChunkStore(self.tempdir)
@@ -239,7 +238,7 @@ class TestTelstateDataSource(object):
         # Save RDB file to e.g. 'tempdir/cb/cb_sdp_l0.rdb', as if 'tempdir' is a real S3 bucket
         rdb_dir = os.path.join(self.tempdir, cbid)
         os.mkdir(rdb_dir)
-        rdb_filename = os.path.join(rdb_dir, '{}_{}.rdb'.format(cbid, sn))
+        rdb_filename = os.path.join(rdb_dir, f'{cbid}_{sn}.rdb')
         # Insert CBID and stream name at the top level, just like metawriter does
         self.telstate['capture_block_id'] = cbid
         self.telstate['stream_name'] = sn

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -31,7 +31,7 @@ def slice_to_range(s, l):
     return range(*s.indices(l))
 
 
-class TestRangeToSlice(object):
+class TestRangeToSlice:
     """Test the :func:`~katdal.lazy_indexer._range_to_slice` function."""
     @staticmethod
     def _check_slice(start, stop, step):
@@ -63,7 +63,7 @@ class TestRangeToSlice(object):
             _range_to_slice([1, 1, 2, 3, 5, 8, 13])
 
 
-class TestSimplifyIndex(object):
+class TestSimplifyIndex:
     """Test the :func:`~katdal.lazy_indexer._simplify_index` function."""
     def setup(self):
         self.shape = (3, 4, 5)
@@ -173,7 +173,7 @@ def numpy_oindex_lite(x, keep):
 UNEVEN = [False, True, True, True, False, False, True, True, False, True]
 
 
-class TestDaskGetitem(object):
+class TestDaskGetitem:
     """Test the :func:`~katdal.lazy_indexer.dask_getitem` function."""
     def setup(self):
         shape = (10, 20, 30, 40)
@@ -243,7 +243,7 @@ class TestDaskGetitem(object):
                         np.s_[0, 2:5, 3 * UNEVEN, np.newaxis, [4, 6]])
 
 
-class TestDaskLazyIndexer(object):
+class TestDaskLazyIndexer:
     """Test the :class:`~katdal.lazy_indexer.DaskLazyIndexer` class."""
     def setup(self):
         shape = (10, 20, 30)
@@ -254,7 +254,7 @@ class TestDaskLazyIndexer(object):
         def transform1(x):
             return x
         transform2 = lambda x: x    # noqa: E731
-        class Transform3(object):   # noqa: E306
+        class Transform3:   # noqa: E306
             def __call__(self, x):
                 return x
         transform3 = Transform3()
@@ -262,7 +262,7 @@ class TestDaskLazyIndexer(object):
         transforms = [transform1, transform2, transform3, transform4]
         indexer = DaskLazyIndexer(self.data_dask, transforms=transforms)
         expected = 'x | transform1 | <lambda> | Transform3 | transform1'
-        expected += ' -> {} {}'.format(indexer.shape, indexer.dtype)
+        expected += f' -> {indexer.shape} {indexer.dtype}'
         assert_equal(str(indexer), expected)
         # Simply exercise repr - no need to check result
         repr(indexer)

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -253,8 +253,8 @@ class TestDaskLazyIndexer:
     def test_str_repr(self):
         def transform1(x):
             return x
-        transform2 = lambda x: x    # noqa: E731
-        class Transform3:   # noqa: E306
+        transform2 = lambda x: x  # noqa: E731
+        class Transform3:         # noqa: E306
             def __call__(self, x):
                 return x
         transform3 = Transform3()

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8
-
 ################################################################################
 # Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
 #
@@ -33,47 +31,47 @@ def assert_equal_typed(a, b):
     assert_equal(type(a), type(b))
 
 
-class TestToStr(object):
+class TestToStr:
     def test_non_str(self):
         assert_equal_typed(to_str(3), 3)
         assert_equal_typed(to_str(None), None)
 
     def test_simple_str(self):
         assert_equal_typed(to_str(b'hello'), 'hello')
-        assert_equal_typed(to_str(u'hello'), 'hello')
+        assert_equal_typed(to_str('hello'), 'hello')
 
     def test_non_ascii(self):
         assert_equal_typed(to_str(b'caf\xc3\xa9'), 'café')
-        assert_equal_typed(to_str(u'café'), 'café')
+        assert_equal_typed(to_str('café'), 'café')
 
     def test_list(self):
-        assert_equal_typed(to_str([b'hello', u'world']), ['hello', 'world'])
+        assert_equal_typed(to_str([b'hello', 'world']), ['hello', 'world'])
 
     def test_tuple(self):
-        assert_equal_typed(to_str((b'hello', u'world')), ('hello', 'world'))
+        assert_equal_typed(to_str((b'hello', 'world')), ('hello', 'world'))
 
     def test_dict(self):
-        assert_equal_typed(to_str({b'hello': b'world', u'abc': u'xyz'}),
+        assert_equal_typed(to_str({b'hello': b'world', 'abc': 'xyz'}),
                            {'hello': 'world', 'abc': 'xyz'})
 
     def test_custom_dict(self):
-        assert_equal_typed(to_str(OrderedDict([(b'hello', b'world'), (u'abc', u'xyz')])),
+        assert_equal_typed(to_str(OrderedDict([(b'hello', b'world'), ('abc', 'xyz')])),
                            OrderedDict([('hello', 'world'), ('abc', 'xyz')]))
 
     def test_numpy_str(self):
         a = np.array([[b'abc', b'def'], [b'ghi', b'jk']])
-        b = np.array([[u'abc', u'def'], [u'ghi', u'jk']])
+        b = np.array([['abc', 'def'], ['ghi', 'jk']])
         c = np.array([['abc', 'def'], ['ghi', 'jk']])
         np.testing.assert_array_equal(to_str(a), c)
         np.testing.assert_array_equal(to_str(b), c)
 
     def test_numpy_object(self):
-        a = np.array([b'abc', u'def', (b'xyz', u'uvw')], dtype='O')
+        a = np.array([b'abc', 'def', (b'xyz', 'uvw')], dtype='O')
         b = np.array(['abc', 'def', ('xyz', 'uvw')], dtype='O')
         np.testing.assert_array_equal(to_str(a), b)
 
 
-class TestSensorCache(object):
+class TestSensorCache:
     def _cache_data(self):
         sensors = [
             ('foo', [4.0, 7.0], [3.0, 6.0]),

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -23,7 +23,7 @@ from nose.tools import assert_equal
 from katdal.spectral_window import SpectralWindow
 
 
-class TestSpectralWindow(object):
+class TestSpectralWindow:
     def setUp(self):
         self.lsb = SpectralWindow(1000.0, 10.0, 6, sideband=-1, product='lsb')
         self.usb = SpectralWindow(1000.0, 10.0, 6, sideband=1, band='X')

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -89,7 +89,7 @@ def put_fake_dataset(store, prefix, shape, chunk_overrides=None, array_overrides
     return data, chunk_info
 
 
-class TestChunkStoreVisFlagsWeights(object):
+class TestChunkStoreVisFlagsWeights:
     """Test the :class:`ChunkStoreVisFlagsWeights` dataset store."""
 
     @classmethod
@@ -118,7 +118,7 @@ class TestChunkStoreVisFlagsWeights(object):
     def test_van_vleck(self):
         ants = 7
         index1, index2 = np.triu_indices(ants)
-        inputs = ['m{:03}h'.format(i) for i in range(ants)]
+        inputs = [f'm{i:03}h' for i in range(ants)]
         corrprods = np.array([(inputs[a], inputs[b]) for (a, b) in zip(index1, index2)])
         auto_indices, _, _ = corrprod_to_autocorr(corrprods)
         # Put fake dataset into chunk store
@@ -146,7 +146,7 @@ class TestChunkStoreVisFlagsWeights(object):
     def test_weight_power_scale(self):
         ants = 7
         index1, index2 = np.triu_indices(ants)
-        inputs = ['m{:03}h'.format(i) for i in range(ants)]
+        inputs = [f'm{i:03}h' for i in range(ants)]
         corrprods = np.array([(inputs[a], inputs[b]) for (a, b) in zip(index1, index2)])
         # Put fake dataset into chunk store
         store = NpyFileChunkStore(self.tempdir)

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -56,11 +56,11 @@ class VisFlagsWeights:
 
     def __init__(self, vis, flags, weights, unscaled_weights=None, name='custom'):
         if not (vis.shape == flags.shape == weights.shape):
-            raise ValueError("Shapes of vis %s, flags %s and weights %s differ"
-                             % (vis.shape, flags.shape, weights.shape))
+            raise ValueError(f'Shapes of vis {vis.shape}, flags {flags.shape} '
+                             f'and weights {weights.shape} differ')
         if unscaled_weights is not None and (unscaled_weights.shape != vis.shape):
-            raise ValueError("Shapes of unscaled weights %s and vis %s differ"
-                             % (unscaled_weights.shape, vis.shape))
+            raise ValueError(f'Shapes of unscaled weights {unscaled_weights.shape} '
+                             f'and vis {vis.shape} differ')
         self.vis = vis
         self.flags = flags
         self.weights = weights
@@ -365,7 +365,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             vis = correct_autocorr_quantisation(vis, corrprods)
         elif van_vleck != 'off':
             raise ValueError("The van_vleck parameter should be one of ['off', 'autocorr'], "
-                             "got '{}' instead".format(van_vleck))
+                             f"got '{van_vleck}' instead")
 
         # Combine low-resolution weights and high-resolution weights_channel
         stored_weights = darray['weights'] * darray['weights_channel'][..., np.newaxis]

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -33,7 +33,7 @@ from .van_vleck import autocorr_lookup_table
 logger = logging.getLogger(__name__)
 
 
-class VisFlagsWeights(object):
+class VisFlagsWeights:
     """Correlator data in the form of visibilities, flags and weights.
 
     This container stores the triplet of visibilities, flags and weights

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -304,7 +304,7 @@ class VisibilityDataV4(DataSet):
         for ant in cam_ants:
             # Try sanitised version of RX serial number first
             rx_serial = attrs.get(f'{ant}_rsc_rx{band}_serial_number', 0)
-            self.receivers[ant] = f'{band}.{rx_serial:d}'
+            self.receivers[ant] = f'{band}.{rx_serial}'
             nd_sensor = f'{ant}_dig_{band}_band_noise_diode'
             if nd_sensor in self.sensor:
                 # A sensor alias would be ideal for this but it only deals with suffixes ATM

--- a/scripts/ff_holo_to_h5v1.py
+++ b/scripts/ff_holo_to_h5v1.py
@@ -42,7 +42,7 @@ ants_group, corr_group = f['Antennas'], f['Correlator']
 # Vague attempt not to mess up the wrong HDF5 file
 if 'version' in f.attrs or f.attrs['k7w_file_version'] != 3 or 'augment' in f.attrs or \
    len(ants_group) != 2 or len(ants_group[list(ants_group.keys())[-1]]) > 0:
-    raise ValueError('%s does not seem to be an FF holography data file' % (filename,))
+    raise ValueError(f'{filename} does not seem to be an FF holography data file')
 
 # First antenna => scan_ant (also reference), second antenna => ref_ant
 scan_ant, ref_ant = ants_group.keys()
@@ -85,9 +85,9 @@ if description[0].startswith(' -25:53') and description[1].startswith(' 27:41'):
     # The default holography source at XDM
     if abs(target_az - (-26)) < 1.0 and abs(target_el - 57) < 1.0:
         sat_name, lo_freq_hz = 'EUTELSAT W2M', 1135.5e6
-        print("It looks like the antennas pointed at '%s'" % (sat_name,))
+        print(f"It looks like the antennas pointed at '{sat_name}'")
 # Create an azel target to replace the default dummy target
-f['Scans']['CompoundScan0'].attrs['target'] = '%s, azel, %g, %g' % (sat_name, target_az, target_el)
+f['Scans']['CompoundScan0'].attrs['target'] = f'{sat_name}, azel, {target_az:g}, {target_el:g}'
 f['Scans']['CompoundScan0'].attrs['label'] = 'holo'
 
 # The correlator mapping is actually scan_ant => 0x and ref_ant => 0y, regardless of pol

--- a/scripts/h5list.py
+++ b/scripts/h5list.py
@@ -55,7 +55,7 @@ for f in files:
     try:
         d = katdal.open(f, quicklook=True)
     except Exception as e:
-        print('%s %s - %s' % (f, e.__class__.__name__, e))
+        print(f'{f} {e.__class__.__name__} - {e}')
         continue
     name = os.path.basename(f)
     name = (name[:10] + '...') if len(name) > 13 else name

--- a/scripts/mvf_rechunk.py
+++ b/scripts/mvf_rechunk.py
@@ -20,11 +20,11 @@ from katdal.datasources import TelstateDataSource, view_capture_stream, infer_ch
 from katdal.flags import DATA_LOST
 
 
-class RechunkSpec(object):
+class RechunkSpec:
     def __init__(self, arg):
         match = re.match(r'^([A-Za-z0-9_.]+)/([A-Za-z0-9_]+):(\d+),(\d+)', arg)
         if not match:
-            raise ValueError('Could not parse {!r}'.format(arg))
+            raise ValueError(f'Could not parse {arg!r}')
         self.stream = match.group(1)
         self.array = match.group(2)
         self.time = int(match.group(3))
@@ -49,7 +49,7 @@ def _make_lost(data, block_info):
         return np.zeros(info['chunk-shape'], np.uint8)
 
 
-class Array(object):
+class Array:
     def __init__(self, stream_name, array_name, store, chunk_info):
         self.stream_name = stream_name
         self.array_name = array_name
@@ -149,14 +149,14 @@ def main():
         try:
             chunk_info = sts['chunk_info']
         except KeyError as exc:
-            raise RuntimeError('Could not get chunk info for {!r}: {}'.format(stream_name, exc))
+            raise RuntimeError(f'Could not get chunk info for {stream_name!r}: {exc}')
         for array_name, array_info in chunk_info.items():
             if args.new_prefix is not None:
                 array_info['prefix'] = args.new_prefix + '-' + stream_name.replace('_', '-')
             prefix = array_info['prefix']
             path = os.path.join(args.dest, prefix)
             if os.path.exists(path):
-                raise RuntimeError('Directory {!r} already exists'.format(path))
+                raise RuntimeError(f'Directory {path!r} already exists')
             store = get_chunk_store(args.source, sts, array_name)
             # Older files have dtype as an object that can't be encoded in msgpack
             dtype = np.dtype(array_info['dtype'])
@@ -195,7 +195,7 @@ def main():
     for spec in args.spec:
         key = (spec.stream, spec.array)
         if key not in arrays:
-            raise RuntimeError('{}/{} is not a known array'.format(spec.stream, spec.array))
+            raise RuntimeError(f'{spec.stream}/{spec.array} is not a known array')
         arrays[key].data = arrays[key].data.rechunk({0: spec.time, 1: spec.freq})
 
     # Write out the new data

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -60,7 +60,7 @@ def default_ms_name(args, centre_freq=None):
         dataset_basename = os.path.splitext(dataset_filename)[0]
     # Add frequency to name to disambiguate multiple spectral windows
     if centre_freq:
-        dataset_basename += '_%dHz' % (int(centre_freq),)
+        dataset_basename += f'_{int(centre_freq)}Hz'
     # Add ".et_al" as reminder that we concatenated multiple datasets
     return '{}{}.ms'.format(dataset_basename, "" if len(args) == 1 else ".et_al")
 
@@ -287,9 +287,8 @@ def main():
 
     # Check we have the chosen polarisations
     if np.any([pol not in pols_in_dataset for pol in pols_to_use]):
-        raise RuntimeError("Selected polarisation(s): %s not available. "
-                           "Available polarisation(s): %s"
-                           % (','.join(pols_to_use), ','.join(pols_in_dataset)))
+        raise RuntimeError(f"Selected polarisation(s): {', '.join(pols_to_use)} not available. "
+                           f"Available polarisation(s): {','.join(pols_in_dataset)}")
 
     # Set full_pol if this is selected via options.pols_to_use
     if set(pols_to_use) == {'HH', 'HV', 'VH', 'VV'} and not options.circular:
@@ -300,8 +299,7 @@ def main():
         dataset.select(reset='T')
 
         centre_freq = dataset.spectral_windows[win].centre_freq
-        print('Extract MS for spw %d: centre frequency %d Hz'
-              % (win, int(centre_freq)))
+        print(f'Extract MS for spw {win}: centre frequency {int(centre_freq)} Hz')
 
         # If no output MS directory name supplied, infer it from dataset(s)
         if options.output_ms is None:
@@ -320,8 +318,8 @@ def main():
         # The first step is to copy the blank template MS to our desired output
         # (making sure it's not already there)
         if os.path.exists(ms_name):
-            raise RuntimeError("MS '%s' already exists - please remove it "
-                               "before running this script" % (ms_name,))
+            raise RuntimeError(f"MS '{ms_name}' already exists - please remove it "
+                               "before running this script")
 
         print("Will create MS output in " + ms_name)
 
@@ -329,21 +327,19 @@ def main():
         if options.elevation_range is not None:
             emin, emax = options.elevation_range.split(',')
             print("\nThe MS can be flagged by elevation in casapy v3.4.0 or higher, with the command:")
-            print("      tflagdata(vis='%s', mode='elevation', lowerlimit=%s, "
-                  "upperlimit=%s, action='apply')\n" % (ms_name, emin, emax))
+            print(f"      tflagdata(vis='{ms_name}', mode='elevation', lowerlimit={emin}, "
+                  f"upperlimit={emax}, action='apply')\n")
 
         # Instructions to create uvfits file if requested
         if options.uvfits:
             uv_name = basename + ".uvfits"
             print("\nThe MS can be converted into a uvfits file in casapy, with the command:")
-            print("      exportuvfits(vis='%s', fitsfile='%s', datacolumn='data')\n"
-                  % (ms_name, uv_name))
+            print(f"      exportuvfits(vis='{ms_name}', fitsfile='{uv_name}', datacolumn='data')\n")
 
         if options.full_pol:
             print("\n#### Producing a full polarisation MS (HH,HV,VH,VV) ####\n")
         else:
-            print("\n#### Producing MS with %s polarisation(s) ####\n"
-                  % (','.join(pols_to_use)))
+            print(f"\n#### Producing MS with {','.join(pols_to_use)} polarisation(s) ####\n")
 
         # if fringe stopping is requested, check that it has not already been done in hardware
         if options.stop_w:
@@ -363,14 +359,13 @@ def main():
 
             if (first_chan < 0) or (last_chan >= dataset.shape[1]):
                 raise RuntimeError("Requested channel range outside data set boundaries. "
-                                   "Set channels in the range [0,%s]" % (dataset.shape[1] - 1,))
+                                   f"Set channels in the range [0,{dataset.shape[1] - 1}]")
             if first_chan > last_chan:
-                raise RuntimeError("First channel (%d) bigger than last channel (%d) - "
-                                   "did you mean it the other way around?"
-                                   % (first_chan, last_chan))
+                raise RuntimeError(f"First channel ({first_chan}) bigger than last channel "
+                                   f"({last_chan}) - did you mean it the other way around?")
 
             chan_range = slice(first_chan, last_chan + 1)
-            print("\nChannel range %d through %d." % (first_chan, last_chan))
+            print(f"\nChannel range {first_chan} through {last_chan}.")
             dataset.select(channels=chan_range)
 
         # Are we averaging?
@@ -385,11 +380,10 @@ def main():
             # Check how many channels we are dropping
             chan_remainder = nchan % options.chanbin
             avg_nchan = int(nchan / min(nchan, options.chanbin))
-            print("Averaging %s channels, output ms will have %s channels."
-                  % (options.chanbin, avg_nchan))
+            print(f"Averaging {options.chanbin} channels, output ms will have {avg_nchan} channels.")
             if chan_remainder > 0:
-                print("The last %s channels in the data will be dropped during averaging "
-                      "(%s does not divide %s)." % (chan_remainder, options.chanbin, nchan))
+                print(f"The last {chan_remainder} channels in the data will be dropped "
+                      f"during averaging ({options.chanbin} does not divide {nchan}).")
             chan_av = options.chanbin
             nchan = avg_nchan
         else:
@@ -420,8 +414,8 @@ def main():
             dataset.select(corrprods='cross')
             print("\nCross-correlations only.")
 
-        print("\nUsing %s as the reference antenna. All targets and scans "
-              "will be based on this antenna.\n" % (dataset.ref_ant,))
+        print(f"\nUsing {dataset.ref_ant} as the reference antenna. All targets and scans "
+              "will be based on this antenna.\n")
         # MS expects timestamps in MJD seconds
         start_time = dataset.start_time.to_mjd() * 24 * 60 * 60
         end_time = dataset.end_time.to_mjd() * 24 * 60 * 60
@@ -496,23 +490,20 @@ def main():
             for scan_ind, scan_state, target in dataset.scans():
                 s = time.time()
                 scan_len = dataset.shape[0]
+                prefix = f'scan {scan_ind:3d} ({scan_len:4d} samples)'
                 if scan_state != 'track':
                     if options.verbose:
-                        print("scan %3d (%4d samples) skipped '%s' - not a track"
-                              % (scan_ind, scan_len, scan_state))
+                        print(f"{prefix} skipped '{scan_state}' - not a track")
                     continue
                 if scan_len < 2:
                     if options.verbose:
-                        print("scan %3d (%4d samples) skipped - too short"
-                              % (scan_ind, scan_len))
+                        print(f'{prefix} skipped - too short')
                     continue
                 if target.body_type != 'radec':
                     if options.verbose:
-                        print("scan %3d (%4d samples) skipped - target '%s' not RADEC"
-                              % (scan_ind, scan_len, target.name))
+                        print(f"{prefix} skipped - target '{target.name}' not RADEC")
                     continue
-                print("scan %3d (%4d samples) loaded. Target: '%s'. Writing to disk..."
-                      % (scan_ind, scan_len, target.name))
+                print(f"{prefix} loaded. Target: '{target.name}'. Writing to disk...")
 
                 # Get the average dump time for this scan (equal to scan length
                 # if the dump period is longer than a scan)
@@ -530,8 +521,7 @@ def main():
                     field_centers.append((ra, dec))
                     field_times.append(katpoint.Timestamp(utc_seconds[0]).to_mjd() * 60 * 60 * 24)
                     if options.verbose:
-                        print("Added new field %d: '%s' %s %s"
-                              % (len(field_names) - 1, target.name, ra, dec))
+                        print(f"Added new field {len(field_names) - 1}: '{target.name}' {ra} {dec}")
                 field_id = field_names.index(target.name)
 
                 # Determine the observation tag for this scan
@@ -608,14 +598,12 @@ def main():
                 s1 = time.time() - s
 
                 if average_data and utc_seconds.shape != ntime_av:
-                    print("Averaged %s x %s second dumps to %s x %s second dumps"
-                          % (np.shape(utc_seconds)[0], dataset.dump_period,
-                             ntime_av, dump_time_width))
+                    print(f'Averaged {np.shape(utc_seconds)[0]} x {dataset.dump_period} second dumps '
+                          f'to {ntime_av} x {dump_time_width} second dumps')
 
                 scan_size_mb = float(scan_size) / (1024**2)
 
-                print("Wrote scan data (%f MiB) in %f s (%f MiBps)\n"
-                      % (scan_size_mb, s1, scan_size_mb / s1))
+                print(f"Wrote scan data ({scan_size_mb} MiB) in {s1} s ({scan_size_mb / s1} MiBps)\n")
 
                 scan_itr += 1
                 total_size += scan_size

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -603,7 +603,8 @@ def main():
 
                 scan_size_mb = float(scan_size) / (1024**2)
 
-                print(f"Wrote scan data ({scan_size_mb} MiB) in {s1} s ({scan_size_mb / s1} MiBps)\n")
+                print(f'Wrote scan data ({scan_size_mb:.3f} MiB) '
+                      f'in {s1:.3f} s ({scan_size_mb / s1:.3f} MiBps)\n')
 
                 scan_itr += 1
                 total_size += scan_size

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -62,7 +62,7 @@ def default_ms_name(args, centre_freq=None):
     if centre_freq:
         dataset_basename += '_%dHz' % (int(centre_freq),)
     # Add ".et_al" as reminder that we concatenated multiple datasets
-    return '%s%s.ms' % (dataset_basename, "" if len(args) == 1 else ".et_al")
+    return '{}{}.ms'.format(dataset_basename, "" if len(args) == 1 else ".et_al")
 
 
 def load(dataset, indices, vis, weights, flags):
@@ -237,8 +237,8 @@ def main():
 
         def _cp_index(a1, a2, pol):
             """Create correlator product index from antenna pair and pol."""
-            a1 = "%s%s" % (a1.name, pol[0].lower())
-            a2 = "%s%s" % (a2.name, pol[1].lower())
+            a1 = a1.name + pol[0].lower()
+            a2 = a2.name + pol[1].lower()
             return corrprod_to_index.get((a1, a2), -1)
 
         # Generate baseline antenna pairs
@@ -292,7 +292,7 @@ def main():
                            % (','.join(pols_to_use), ','.join(pols_in_dataset)))
 
     # Set full_pol if this is selected via options.pols_to_use
-    if set(pols_to_use) == set(['HH', 'HV', 'VH', 'VV']) and not options.circular:
+    if set(pols_to_use) == {'HH', 'HV', 'VH', 'VV'} and not options.circular:
         options.full_pol = True
 
     # Extract one MS per spectral window in the dataset(s)
@@ -405,7 +405,7 @@ def main():
             average_data = True
             dump_av = int(np.round(options.dumptime / dataset.dump_period))
             time_av = dump_av * dataset.dump_period
-            print("Averaging %s second dumps to %s seconds." % (dataset.dump_period, time_av))
+            print(f"Averaging {dataset.dump_period} second dumps to {time_av} seconds.")
         else:
             # No averaging in time
             dump_av = 1
@@ -657,7 +657,7 @@ def main():
         # Finally we write the MS as per our created dicts
         ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
         if options.tar:
-            tar = tarfile.open('%s.tar' % (ms_name,), 'w')
+            tar = tarfile.open(f'{ms_name}.tar', 'w')
             tar.add(ms_name, arcname=os.path.basename(ms_name))
             tar.close()
 
@@ -697,11 +697,11 @@ def main():
 
                 # for each solution type in the file, create a table
                 for sol in solution_types:
-                    caltable_name = '{0}.{1}'.format(basename, sol)
-                    sol_name = 'cal_product_{0}'.format(sol,)
+                    caltable_name = f'{basename}.{sol}'
+                    sol_name = f'cal_product_{sol}'
 
                     if sol_name in first_dataset.file['TelescopeState'].keys():
-                        print(' - creating {0} solution table: {1}\n'.format(sol, caltable_name))
+                        print(f' - creating {sol} solution table: {caltable_name}\n')
 
                         # get solution values from the file
                         solutions = first_dataset.file['TelescopeState'][sol_name][()]
@@ -782,7 +782,7 @@ def main():
                             main_subtable = ms_extra.open_table(os.path.join(main_table.name(),
                                                                              subtable))
                             main_subtable.copy(subtable_location, deep=True)
-                            caltable.putkeyword(subtable, 'Table: {0}'.format(subtable_location))
+                            caltable.putkeyword(subtable, f'Table: {subtable_location}')
                             if subtable == 'ANTENNA':
                                 caltable.putkeyword('NAME', antlist)
                                 caltable.putkeyword('STATION', antlist)

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -32,7 +32,7 @@ import numpy as np
 import katdal
 
 
-class ResampledImage(object):
+class ResampledImage:
     """Image that only loads enough data that will fit onto screen pixels.
 
     Parameters
@@ -131,5 +131,5 @@ else:
                         autoscale=opts.autoscale, ax=ax)
     ax.set_xlabel('Channel index')
     ax.set_ylabel('Dump index')
-    ax.set_title('Spectrogram %s %s %s' % (d.name, ant, opts.pol))
+    ax.set_title(f'Spectrogram {d.name} {ant} {opts.pol}')
     plt.show()


### PR DESCRIPTION
Upgrade code automatically to Python 3.6 syntax using `pyupgrade --py36-plus`. By far the most common changes are:

- Old-style formatted strings to f-strings
- Remove inheritance from `object`
- Use `super()`
- Replace `set([...])` with `{...}`
- Remove 'u' literal string prefixes

I've edited the output to align whitespace and to preserve the `%` formatting in logger output (in those crufty old places where I first assembled the formatted string instead of passing the arguments to the logger as one should). In a handful of places I also simplified the format strings further.

And then I also went for another large bout of manual f-string conversion (or at least`%` -> `.format` conversion where more suitable). This is pretty mind-numbing, eye-watering stuff, so apologies in advance :-)
