### PR TITLE
Allow subset to be selected at katdal.open time

### DIFF
--- a/doc/tuning.rst
+++ b/doc/tuning.rst
@@ -96,6 +96,12 @@ You might be able to get a little more performance by using
 selections) rather than using :meth:`~.DataSet.select` with
 ``scans='track'``.
 
+When using MVF v4 one can also pass an `index` parameter to :meth:`katdal.open`
+which contains an index expression to slice a subset of the data (time and
+frequency). It is more limited than :meth:`DataSet.select` (it can only select
+contiguous ranges), but if a script is only interested in working on a subset
+of data, this method can be more efficient and uses less memory.
+
 Network versus local disk
 -------------------------
 When loading data from the network, latency is typically higher, and so

--- a/doc/tuning.rst
+++ b/doc/tuning.rst
@@ -96,11 +96,12 @@ You might be able to get a little more performance by using
 selections) rather than using :meth:`~.DataSet.select` with
 ``scans='track'``.
 
-When using MVF v4 one can also pass an `index` parameter to :meth:`katdal.open`
-which contains an index expression to slice a subset of the data (time and
-frequency). It is more limited than :meth:`DataSet.select` (it can only select
-contiguous ranges), but if a script is only interested in working on a subset
-of data, this method can be more efficient and uses less memory.
+When using MVF v4 one can also pass a `select` parameter to :meth:`katdal.open`
+which allows slicing a subset of the data (time and frequency). It is more
+limited than :meth:`DataSet.select` (it can only select contiguous ranges, and
+can only specify the selection in terms of channels and dumps), but if a script
+is only interested in working on a subset of data, this method can be more
+efficient and uses less memory.
 
 Network versus local disk
 -------------------------

--- a/doc/tuning.rst
+++ b/doc/tuning.rst
@@ -96,7 +96,7 @@ You might be able to get a little more performance by using
 selections) rather than using :meth:`~.DataSet.select` with
 ``scans='track'``.
 
-When using MVF v4 one can also pass a `select` parameter to :meth:`katdal.open`
+When using MVF v4 one can also pass a `preselect` parameter to :meth:`katdal.open`
 which allows slicing a subset of the data (time and frequency). It is more
 limited than :meth:`DataSet.select` (it can only select contiguous ranges, and
 can only specify the selection in terms of channels and dumps), but if a script

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -113,6 +113,9 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
             avoiding the slow loading of real timestamps at the cost of
             slightly inaccurate label borders
 
+        See the documentation of :class:`VisibilityDataV4` for the keywords
+        it accepts.
+
     Returns
     -------
     data : :class:`DataSet` object

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -121,7 +121,13 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
         Object providing :class:`DataSet` interface to file(s)
 
     """
-    filenames = [filename] if isinstance(filename, str) else filename
+    if isinstance(filename, str):
+        filenames = [filename]
+    else:
+        unexpected = set(kwargs.get('preselect', {})) - {'channels'}
+        if unexpected:
+            raise IndexError(f'Unsupported preselect key(s) for ConcatenatedDataSet: {unexpected}')
+        filenames = filename
     datasets = []
     for f in filenames:
         # V4 RDB file or live telstate with optional URL-style query string
@@ -130,6 +136,8 @@ def open(filename, ref_ant='', time_offset=0.0, **kwargs):
             dataset = VisibilityDataV4(open_data_source(f, **kwargs),
                                        ref_ant, time_offset, **kwargs)
         else:
+            if 'preselect' in kwargs:
+                raise TypeError('preselect is not supported for this format')
             dataset = _file_action('__call__', f, ref_ant, time_offset, **kwargs)
         datasets.append(dataset)
     return datasets[0] if isinstance(filename, str) else ConcatenatedDataSet(datasets)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -488,10 +488,7 @@ class ChunkStore:
             if not all(isinstance(idx, slice) and idx.step is None
                        for idx in index):
                 raise IndexError('Only slices with unit step are valid indices in get_dask_array')
-            if not offset:
-                offset = [0] * len(shape)
-            else:
-                offset = list(offset)
+            offset = list(offset) if offset else [0] * len(shape)
             for axis in range(len(shape)):
                 if index[axis] == slice(None):
                     continue

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -360,7 +360,7 @@ class TelstateDataSource(DataSource):
     ------
     KeyError
         If telstate lacks critical keys
-    TypeError
+    IndexError
         If `index` does not meet the criteria above.
     """
     def __init__(self, telstate, capture_block_id, stream_name,
@@ -369,7 +369,7 @@ class TelstateDataSource(DataSource):
         if not isinstance(index, tuple) or not all(
                 isinstance(idx, slice) or idx.step not in {None, 1}
                 for idx in index):
-            raise TypeError('index must be a tuple of slices with unit step')
+            raise IndexError('index must be a tuple of slices with unit step')
         self.telstate = TelstateToStr(telstate)
         # Collect sensors
         sensors = {}

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -372,7 +372,7 @@ class TelstateDataSource(DataSource):
             raise IndexError("'select' can only specify 'channels' and 'dumps'")
         for key, idx in select.items():
             if not isinstance(idx, slice) or idx.step not in {None, 1}:
-                raise IndexError(f'{key} must be a slices with unit step')
+                raise IndexError(f'{key} must be a slice with unit step')
 
         self.telstate = TelstateToStr(telstate)
         # Collect sensors

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -23,7 +23,8 @@ from nose.tools import (assert_raises, assert_equal, assert_true, assert_false,
 import dask.array as da
 
 from katdal.chunkstore import (ChunkStore, generate_chunks,
-                               StoreUnavailable, ChunkNotFound, BadChunk)
+                               StoreUnavailable, ChunkNotFound, BadChunk,
+                               PlaceholderChunk)
 
 
 class TestGenerateChunks(object):
@@ -198,7 +199,10 @@ class ChunkStoreTestBase(object):
         assert_equal(zeros.dtype, dtype)
         ones = self.store.get_chunk_or_default(*args, default_value=1)
         assert_array_equal(ones, np.ones(shape, dtype))
-        assert_is_none(self.store.get_chunk_or_none(*args))
+        placeholder = self.store.get_chunk_or_placeholder(*args)
+        assert_is_instance(placeholder, PlaceholderChunk)
+        assert_equal(placeholder.shape, shape)
+        assert_equal(placeholder.dtype, dtype)
 
     def test_chunk_bool_1dim_and_too_small(self):
         # Check basic put + get on 1-D bool

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -296,7 +296,7 @@ class ChunkStoreTestBase:
             np.s_[..., 0:1],
             np.s_[5:6, 29:31],
             np.s_[5:5, 31:31]
-        ]   # TODO: use pytbest.mark.parametrize when converted to pytest
+        ]   # TODO: use pytest.mark.parametrize when converted to pytest
 
         expected = self.big_y2.copy()
         if not self.preloaded_chunks:

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -237,12 +237,23 @@ class ChunkStoreTestBase(object):
         self.get_dask_array('big_y')
         self.get_dask_array('big_y', np.s_[0:3, 0:30, 0:2])
 
+    @staticmethod
+    def _placeholder_to_default(array, default):
+        """Replace :class:`PlaceholderChunk`s in a dask array with a default value."""
+        def map_blocks_func(chunk):
+            if isinstance(chunk, PlaceholderChunk):
+                return np.full(chunk.shape, default, chunk.dtype)
+            else:
+                return chunk
+
+        return da.map_blocks(map_blocks_func, array)
+
     def test_dask_array_put_parts_get_whole(self):
         # Split big array into quarters along existing chunks and reassemble
         self.put_dask_array('big_y2', np.s_[0:3,  0:30, 0:2])
         self.put_dask_array('big_y2', np.s_[3:8,  0:30, 0:2])
         self.put_dask_array('big_y2', np.s_[0:3, 30:60, 0:2])
-        # Before storing last quarter, check that get() replaces it with default
+        # Before storing last quarter, check missing chunk handling
         if not self.preloaded_chunks:
             array_name, dask_array, offset = self.make_dask_array('big_y2')
             pull = self.store.get_dask_array(array_name, dask_array.chunks,
@@ -253,9 +264,58 @@ class ChunkStoreTestBase(object):
             assert_array_equal(array_retrieved[np.s_[3:8, 30:60, 0:2]], 17,
                                "Missing chunk in {} not replaced by default value"
                                .format(array_name))
+
+            pull = self.store.get_dask_array(array_name, dask_array.chunks,
+                                             dask_array.dtype, offset, errors='raise')
+            with assert_raises(ChunkNotFound):
+                pull.compute()
+
+            pull = self.store.get_dask_array(array_name, dask_array.chunks,
+                                             dask_array.dtype, offset, errors='placeholder')
+            # We can't compute pull directly, because placeholders aren't
+            # numpy arrays. So we have to remap them.
+            pull = self._placeholder_to_default(pull, 17)
+            array_retrieved = pull.compute()
+            assert_equal(array_retrieved.shape, dask_array.shape)
+            assert_equal(array_retrieved.dtype, dask_array.dtype)
+            assert_array_equal(array_retrieved[np.s_[3:8, 30:60, 0:2]], 17,
+                               "Missing chunk in {} not replaced by default value"
+                               .format(array_name))
+
         # Now store the last quarter and check that complete array is correct
         self.put_dask_array('big_y2', np.s_[3:8, 30:60, 0:2])
         self.get_dask_array('big_y2')
+
+    def test_get_dask_array_index(self):
+        # Load most but not all of the array, to test error handling
+        self.put_dask_array('big_y2', np.s_[0:3,  0:30, 0:2])
+        self.put_dask_array('big_y2', np.s_[3:8,  0:30, 0:2])
+        self.put_dask_array('big_y2', np.s_[0:3, 30:60, 0:2])
+        array_name, dask_array, offset = self.make_dask_array('big_y2')
+        indices = [
+            (),
+            np.s_[:, :],
+            np.s_[0:8, 0:60, 0:2],
+            np.s_[..., 0:1],
+            np.s_[5:6, 29:31],
+            np.s_[5:5, 31:31]
+        ]   # TODO: use pytbest.mark.parametrize when converted to pytest
+
+        expected = self.big_y2.copy()
+        if not self.preloaded_chunks:
+            expected[3:8, 30:60, 0:2] = 17
+        for index in indices:
+            pull = self.store.get_dask_array(array_name, dask_array.chunks,
+                                             dask_array.dtype, offset, index=index, errors=17)
+            array_retrieved = pull.compute()
+            np.testing.assert_array_equal(array_retrieved, expected[index])
+            # Now test placeholders, to ensure that placeholder slicing works
+            pull = self.store.get_dask_array(array_name, dask_array.chunks,
+                                             dask_array.dtype, offset, index=index,
+                                             errors='placeholder')
+            pull = self._placeholder_to_default(pull, 17)
+            array_retrieved = pull.compute()
+            np.testing.assert_array_equal(array_retrieved, expected[index])
 
     def _test_mark_complete(self, name):
         try:

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -16,6 +16,7 @@
 
 """Tests for :py:mod:`katdal.chunkstore_npy`."""
 
+import os
 import tempfile
 import shutil
 
@@ -39,6 +40,12 @@ class TestNpyFileChunkStore(ChunkStoreTestBase):
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls.tempdir)
+
+    def setup(self):
+        # Clean out data created by previous tests
+        for entry in os.scandir(self.tempdir):
+            if not entry.name.startswith('.') and entry.is_dir():
+                shutil.rmtree(entry.path)
 
     def test_store_unavailable(self):
         assert_raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -135,35 +135,35 @@ class TestTelstateDataSource:
         expected_timestamps = np.arange(20, dtype=np.float32) * 2 + 123456789 + 123
         np.testing.assert_array_equal(data_source.timestamps, expected_timestamps)
 
-    def test_timestamps_select(self):
+    def test_timestamps_preselect(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                         select=dict(dumps=np.s_[2:10]))
+                                         preselect=dict(dumps=np.s_[2:10]))
         np.testing.assert_array_equal(
             data_source.timestamps,
             np.arange(2, 10, dtype=np.float32) * 2 + 123456912)
 
-    def test_bad_select(self):
+    def test_bad_preselect(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             select=dict(dumps=np.s_[[1, 2]]))
+                                             preselect=dict(dumps=np.s_[[1, 2]]))
         with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             select=dict(dumps=np.s_[5:0:-1]))
+                                             preselect=dict(dumps=np.s_[5:0:-1]))
         with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             select=dict(frequencies=np.s_[:]))
+                                             preselect=dict(frequencies=np.s_[:]))
 
-    def test_select(self):
+    def test_preselect(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
-        select = dict(dumps=np.s_[2:10], channels=np.s_[-20:])
+        preselect = dict(dumps=np.s_[2:10], channels=np.s_[-20:])
         index = np.s_[2:10, -20:]
         data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                         upgrade_flags=False, select=select)
+                                         upgrade_flags=False, preselect=preselect)
         np.testing.assert_array_equal(data_source.data.vis.compute(), l0_data['correlator_data'][index])
         np.testing.assert_array_equal(data_source.data.flags.compute(), l0_data['flags'][index])
 

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -135,32 +135,35 @@ class TestTelstateDataSource:
         expected_timestamps = np.arange(20, dtype=np.float32) * 2 + 123456789 + 123
         np.testing.assert_array_equal(data_source.timestamps, expected_timestamps)
 
-    def test_timestamps_index(self):
+    def test_timestamps_select(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
-        data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[2:10, :])
+        data_source = TelstateDataSource(view, cbid, sn, self.store,
+                                         select=dict(dumps=np.s_[2:10]))
         np.testing.assert_array_equal(
             data_source.timestamps,
             np.arange(2, 10, dtype=np.float32) * 2 + 123456912)
 
-    def test_bad_index(self):
+    def test_bad_select(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store, index=[])
+            data_source = TelstateDataSource(view, cbid, sn, self.store,
+                                             select=dict(dumps=np.s_[[1, 2]]))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[[1, 2]])
+            data_source = TelstateDataSource(view, cbid, sn, self.store,
+                                             select=dict(dumps=np.s_[5:0:-1]))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[5:0:-1])
-        with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[:, :, :])
+            data_source = TelstateDataSource(view, cbid, sn, self.store,
+                                             select=dict(frequencies=np.s_[:]))
 
-    def test_index(self):
+    def test_select(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
+        select = dict(dumps=np.s_[2:10], channels=np.s_[-20:])
         index = np.s_[2:10, -20:]
         data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                         upgrade_flags=False, index=index)
+                                         upgrade_flags=False, select=select)
         np.testing.assert_array_equal(data_source.data.vis.compute(), l0_data['correlator_data'][index])
         np.testing.assert_array_equal(data_source.data.flags.compute(), l0_data['flags'][index])
 

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -147,11 +147,11 @@ class TestTelstateDataSource(object):
     def test_bad_index(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
-        with assert_raises(TypeError):
+        with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store, index=[])
-        with assert_raises(TypeError):
+        with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[[1, 2]])
-        with assert_raises(TypeError):
+        with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[5:0:-1])
         with assert_raises(IndexError):
             data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[:, :, :])

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -136,6 +136,35 @@ class TestTelstateDataSource(object):
         expected_timestamps = np.arange(20, dtype=np.float32) * 2 + 123456789 + 123
         np.testing.assert_array_equal(data_source.timestamps, expected_timestamps)
 
+    def test_timestamps_index(self):
+        view, cbid, sn, l0_data, l1_flags_data = \
+            make_fake_data_source(self.telstate, self.store, (20, 64, 40))
+        data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[2:10, :])
+        np.testing.assert_array_equal(
+            data_source.timestamps,
+            np.arange(2, 10, dtype=np.float32) * 2 + 123456912)
+
+    def test_bad_index(self):
+        view, cbid, sn, l0_data, l1_flags_data = \
+            make_fake_data_source(self.telstate, self.store, (20, 64, 40))
+        with assert_raises(TypeError):
+            data_source = TelstateDataSource(view, cbid, sn, self.store, index=[])
+        with assert_raises(TypeError):
+            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[[1, 2]])
+        with assert_raises(TypeError):
+            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[5:0:-1])
+        with assert_raises(IndexError):
+            data_source = TelstateDataSource(view, cbid, sn, self.store, index=np.s_[:, :, :])
+
+    def test_index(self):
+        view, cbid, sn, l0_data, l1_flags_data = \
+            make_fake_data_source(self.telstate, self.store, (20, 64, 40))
+        index = np.s_[2:10, -20:]
+        data_source = TelstateDataSource(view, cbid, sn, self.store,
+                                         upgrade_flags=False, index=index)
+        np.testing.assert_array_equal(data_source.data.vis.compute(), l0_data['correlator_data'][index])
+        np.testing.assert_array_equal(data_source.data.flags.compute(), l0_data['flags'][index])
+
     def test_upgrade_flags(self):
         shape = (20, 16, 40)
         view, cbid, sn, l0_data, l1_flags_data = make_fake_data_source(

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -115,6 +115,19 @@ class TestChunkStoreVisFlagsWeights(object):
         assert_array_equal(vfw.weights.compute(), weights)
         assert_equal(vfw.unscaled_weights, None)
 
+    def test_index(self):
+        # Put fake dataset into chunk store
+        store = NpyFileChunkStore(self.tempdir)
+        prefix = 'cb1'
+        shape = (10, 64, 30)
+        data, chunk_info = put_fake_dataset(store, prefix, shape)
+        index = np.s_[2:5, -20:]
+        vfw = ChunkStoreVisFlagsWeights(store, chunk_info, index=index)
+        weights = data['weights'] * data['weights_channel'][..., np.newaxis]
+        assert_array_equal(vfw.vis.compute(), data['correlator_data'][index])
+        assert_array_equal(vfw.flags.compute(), data['flags'][index])
+        assert_array_equal(vfw.weights.compute(), weights[index])
+
     def test_van_vleck(self):
         ants = 7
         index1, index2 = np.triu_indices(ants)

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -297,7 +297,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             array_name = store.join(info['prefix'], array)
             chunk_args = (array_name, info['chunks'], info['dtype'])
             errors = DATA_LOST if array == 'flags' else 'placeholder'
-            darray[array] = store.get_dask_array(*chunk_args, errors=errors)[index]
+            darray[array] = store.get_dask_array(*chunk_args, index=index, errors=errors)
         flags_orig_name = darray['flags'].name
         flags_raw_name = store.join(chunk_info['flags']['prefix'], 'flags_raw')
         # Combine original flags with data_lost indicating where values were lost from

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -277,6 +277,10 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
         Should be True if `corrprods` is `None`.
     van_vleck : {'off', 'autocorr'}, optional
         Type of Van Vleck (quantisation) correction to perform
+    index : tuple of slice, optional
+        Slice expression to apply to each array before combining them. At the
+        moment this can only have two elements (no slicing of baselines),
+        because ``weights_channel`` only has time and frequency dimensions.
 
     Attributes
     ----------
@@ -285,7 +289,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
     """
 
     def __init__(self, store, chunk_info, corrprods=None,
-                 stored_weights_are_scaled=True, van_vleck='off'):
+                 stored_weights_are_scaled=True, van_vleck='off', index=()):
         self.store = store
         self.vis_prefix = chunk_info['correlator_data']['prefix']
         darray = {}
@@ -293,7 +297,7 @@ class ChunkStoreVisFlagsWeights(VisFlagsWeights):
             array_name = store.join(info['prefix'], array)
             chunk_args = (array_name, info['chunks'], info['dtype'])
             errors = DATA_LOST if array == 'flags' else 'placeholder'
-            darray[array] = store.get_dask_array(*chunk_args, errors=errors)
+            darray[array] = store.get_dask_array(*chunk_args, errors=errors)[index]
         flags_orig_name = darray['flags'].name
         flags_raw_name = store.join(chunk_info['flags']['prefix'], 'flags_raw')
         # Combine original flags with data_lost indicating where values were lost from

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -160,7 +160,7 @@ class VisibilityDataV4(DataSet):
         (if available). A value of None disables flux calibration.
     sensor_store : string, optional
         Hostname / endpoint of katstore webserver to access additional sensors
-    select : dict, optional
+    preselect : dict, optional
         Subset of the data to select. See :class:`.TelstateDataSource` for
         details. This selection is permanent, and further selections made
         by :meth:`.DataSet.select` are relative to this subset.
@@ -170,7 +170,7 @@ class VisibilityDataV4(DataSet):
     """
     def __init__(self, source, ref_ant='', time_offset=0.0, applycal='',
                  gaincal_flux={}, sensor_store=None,
-                 select=None, **kwargs):
+                 preselect=None, **kwargs):
         DataSet.__init__(self, source.name, ref_ant, time_offset)
         attrs = source.metadata.attrs
 
@@ -324,10 +324,10 @@ class VisibilityDataV4(DataSet):
         band_map = dict(l='L', s='S', u='UHF', x='X')   # noqa: E741
         spw = SpectralWindow(centre_freq, channel_width, num_chans, product, sideband,
                              band_map[band])
-        if select is None:
-            select = {}
-        if 'channels' in select:
-            start, stop, stride = select['channels'].indices(num_chans)
+        if preselect is None:
+            preselect = {}
+        if 'channels' in preselect:
+            start, stop, stride = preselect['channels'].indices(num_chans)
             assert stride == 1    # Checked by TelstateDataSource
             spw = spw.subrange(start, stop)
         # Continue with different channel count, but invalidate centre freq

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -333,7 +333,7 @@ class VisibilityDataV4(DataSet):
         if source.data and (spw.num_chans != source.data.shape[1]):
             logger.warning('Number of channels reported in metadata (%d) differs'
                            ' from actual number of channels in data (%d) - '
-                           'trusting the latter', num_chans, source.data.shape[1])
+                           'trusting the latter', spw.num_chans, source.data.shape[1])
             num_chans = source.data.shape[1]
             centre_freq = 0.0
             spw = SpectralWindow(centre_freq, channel_width, num_chans, product, sideband,

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -160,9 +160,9 @@ class VisibilityDataV4(DataSet):
         (if available). A value of None disables flux calibration.
     sensor_store : string, optional
         Hostname / endpoint of katstore webserver to access additional sensors
-    index : tuple of slice, optional
+    select : dict, optional
         Subset of the data to select. See :class:`.TelstateDataSource` for
-        restrictions. This selection is permanent, and further selections made
+        details. This selection is permanent, and further selections made
         by :meth:`.DataSet.select` are relative to this subset.
     kwargs : dict, optional
         Extra keyword arguments, typically meant for other formats and ignored
@@ -170,7 +170,7 @@ class VisibilityDataV4(DataSet):
     """
     def __init__(self, source, ref_ant='', time_offset=0.0, applycal='',
                  gaincal_flux={}, sensor_store=None,
-                 index=(), **kwargs):
+                 select=None, **kwargs):
         DataSet.__init__(self, source.name, ref_ant, time_offset)
         attrs = source.metadata.attrs
 
@@ -324,8 +324,10 @@ class VisibilityDataV4(DataSet):
         band_map = dict(l='L', s='S', u='UHF', x='X')   # noqa: E741
         spw = SpectralWindow(centre_freq, channel_width, num_chans, product, sideband,
                              band_map[band])
-        if index and len(index) >= 2:
-            start, stop, stride = index[1].indices(num_chans)
+        if select is None:
+            select = {}
+        if 'channels' in select:
+            start, stop, stride = select['channels'].indices(num_chans)
             assert stride == 1    # Checked by TelstateDataSource
             spw = spw.subrange(start, stop)
         # Continue with different channel count, but invalidate centre freq


### PR DESCRIPTION
This avoids the cost of building up a massive graph only to select most of it away, and also saves memory since that large graph won't be kept around.

I'm marking this as draft for now because I'm not sure how best to handle pre-MVFv4 (see below). Nevertheless, please review to see if you're happy with the overall approach.

The problem is that an application that wants to use this feature won't necessarily know which version file it is opening, and hence the argument might or might not be ignored. It can check the file version after the fact, but then it would still need to hard-code knowledge of which versions support the feature, and that may change over time.

There are a few possibilities:
1. Just support it in all versions. I haven't looked at LazyIndexer to see how practical this is.
2. Store a flag in each class to indicate whether the feature is supported, which the caller can check.
3. Raise an exception if the caller tries to use the feature and it is not supported; the caller can either check it and fall back, or let it propagate. This has the advantage that callers that don't consider the possibly will get an exception rather than accessing the wrong data, but the disadvantage that falling back now requires re-opening the dataset which could be expensive (although pre-v4 datasets are generally cheap to open).

I also haven't considered concatenated data sets at all.