### PR TITLE
SPR1-910 Support h5py 3.0 API in MVF3

### DIFF
--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -214,10 +214,11 @@ def telstate_decode(raw, no_decode=()):
     """
     if isinstance(raw, (np.void, np.ndarray)):
         return to_str(katsdptelstate.decode_value(raw.tostring()))
-    elif raw not in no_decode:
-        return to_str(katsdptelstate.decode_value(raw))
+    raw_str = to_str(raw)
+    if raw_str in no_decode:
+        return raw_str
     else:
-        return to_str(raw)
+        return to_str(katsdptelstate.decode_value(raw_str.encode()))
 
 
 def _h5_telstate_unpack(s):

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -23,7 +23,7 @@ from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises, as
 from unittest.mock import Mock
 
 from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter, to_str,
-                               remove_duplicates_and_invalid_values)
+                               remove_duplicates_and_invalid_values, telstate_decode)
 
 
 def assert_equal_typed(a, b):
@@ -69,6 +69,19 @@ class TestToStr:
         a = np.array([b'abc', 'def', (b'xyz', 'uvw')], dtype='O')
         b = np.array(['abc', 'def', ('xyz', 'uvw')], dtype='O')
         np.testing.assert_array_equal(to_str(a), b)
+
+
+def test_telstate_decode():
+    raw = "S'1'\n."
+    assert telstate_decode(raw) == '1'
+    assert telstate_decode(raw.encode()) == '1'
+    assert telstate_decode(np.void(raw.encode())) == '1'
+    assert telstate_decode('l', no_decode=('l', 's', 'u', 'x')) == 'l'
+    raw_np = ("cnumpy.core.multiarray\nscalar\np1\n(cnumpy\ndtype\np2\n(S'f8'\nI0\nI1\ntRp3\n"
+              "(I3\nS'<'\nNNNI-1\nI-1\nI0\ntbS'8\\xdf\\xd4(\\x89\\xfc\\xef?'\ntRp4\n.")
+    value_np = telstate_decode(raw_np)
+    assert value_np == 0.9995771214953271
+    assert isinstance(value_np, np.float64)
 
 
 class TestSensorCache:

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -72,6 +72,7 @@ class TestToStr:
 
 
 @mock.patch('katsdptelstate.encoding._allow_pickle', True)
+@mock.patch('katsdptelstate.encoding._warn_on_pickle', False)
 def test_telstate_decode():
     raw = "S'1'\n."
     assert telstate_decode(raw) == '1'

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 
 import numpy as np
 from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises, assert_is_instance
-from unittest.mock import Mock
+from unittest import mock
 
 from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter, to_str,
                                remove_duplicates_and_invalid_values, telstate_decode)
@@ -71,6 +71,7 @@ class TestToStr:
         np.testing.assert_array_equal(to_str(a), b)
 
 
+@mock.patch('katsdptelstate.encoding._allow_pickle', True)
 def test_telstate_decode():
     raw = "S'1'\n."
     assert telstate_decode(raw) == '1'
@@ -142,7 +143,7 @@ class TestSensorCache:
         np.testing.assert_array_equal(data, [3.0, 3.0, 3.0, 3.0, 4.0, 5.0, 6.0, 6.0, 6.0, 6.0])
 
     def test_virtual_sensors(self):
-        calculate_value = Mock()
+        calculate_value = mock.Mock()
 
         def _check_sensor(cache, name, **kwargs):
             """Check that virtual sensor function gets the expected parameters."""


### PR DESCRIPTION
The latest major version of h5py (3.0, released Oct 2020) totally
revamps string handling. All string-valued attributes in MVF3 now
return `str` in Python 3 (while h5py 2.x returns `bytes`).

Extend `telstate_decode` to handle both versions and add some tests.