### PR TITLE
SPR1-897: Expose the raw flags of MVFv4 datasets

### DIFF
--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -578,29 +578,13 @@ class ConcatenatedDataSet(DataSet):
             Names of selected flag types (or 'all' for the lot)
 
         """
-        if time_keep is not None:
-            self._time_keep = time_keep
-            for n, d in enumerate(self.datasets):
-                d._set_keep(time_keep=self._time_keep[self._segments[n]:self._segments[n + 1]])
-            # Ensure that sensor cache gets updated time selection
-            if self.sensor:
-                self.sensor._set_keep(self._time_keep)
-        if freq_keep is not None:
-            self._freq_keep = freq_keep
-            for n, d in enumerate(self.datasets):
-                d._set_keep(freq_keep=self._freq_keep)
-        if corrprod_keep is not None:
-            self._corrprod_keep = corrprod_keep
-            for n, d in enumerate(self.datasets):
-                d._set_keep(corrprod_keep=self._corrprod_keep)
-        if weights_keep is not None:
-            self._weights_keep = weights_keep
-            for n, d in enumerate(self.datasets):
-                d._set_keep(weights_keep=self._weights_keep)
-        if flags_keep is not None:
-            self._flags_keep = flags_keep
-            for n, d in enumerate(self.datasets):
-                d._set_keep(flags_keep=self._flags_keep)
+        super()._set_keep(time_keep, freq_keep, corrprod_keep, weights_keep, flags_keep)
+        for n, d in enumerate(self.datasets):
+            d._set_keep(time_keep=self._time_keep[self._segments[n]:self._segments[n + 1]],
+                        freq_keep=self._freq_keep,
+                        corrprod_keep=self._corrprod_keep,
+                        weights_keep=self._weights_keep,
+                        flags_keep=self._flags_keep)
 
     @property
     def timestamps(self):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -549,46 +549,43 @@ class VisibilityDataV4(DataSet):
 
         """
         DataSet._set_keep(self, time_keep, freq_keep, corrprod_keep, weights_keep, flags_keep)
-        update_all = time_keep is not None or freq_keep is not None or corrprod_keep is not None
-        update_flags = update_all or flags_keep is not None
         if not self.source.data:
             self._vis = self._weights = self._flags = self._raw_flags = self._excision = None
-        elif update_flags:
-            # Create first-stage index from dataset selectors. Note: use
-            # the member variables, not the parameters, because the parameters
-            # can be None to indicate no change
-            stage1 = (self._time_keep, self._freq_keep, self._corrprod_keep)
-            if update_all:
-                # Cache dask graphs for the data fields
-                self._vis = DaskLazyIndexer(self._corrected.vis, stage1)
-                self._weights = DaskLazyIndexer(self._corrected.weights, stage1)
-                self._raw_flags = DaskLazyIndexer(self._corrected.flags, stage1)
-            flag_transforms = []
-            if ~self._flags_select != 0:
-                # Copy so that the lambda isn't affected by future changes
-                select = self._flags_select.copy()
-                flag_transforms.append(lambda flags: da.bitwise_and(select, flags))
-            flag_transforms.append(lambda flags: flags.view(np.bool_))
-            self._flags = DaskLazyIndexer(self._corrected.flags, stage1, flag_transforms)
-            unscaled_weights = self._corrected.unscaled_weights
-            if unscaled_weights is None or self.accumulations_per_dump is None:
-                self._excision = None
-            else:
-                # The maximum / expected number of CBF dumps per SDP dump
-                cbf_dumps_per_sdp_dump = round(self.dump_period / self.cbf_dump_period)
-                accs_per_sdp_dump = np.float32(self.accumulations_per_dump)
-                accs_per_cbf_dump = accs_per_sdp_dump / np.float32(cbf_dumps_per_sdp_dump)
-                # Each unscaled weight represents the actual number of accumulations per SDP dump.
-                # Correct most of the weight compression artefacts by forcing each weight to be
-                # an integer multiple of CBF n_accs, and then convert it to an excision fraction.
-                def integer_cbf_dumps(w):
-                    return da.round(w / accs_per_cbf_dump) * accs_per_cbf_dump
+            return
+        # Create first-stage index from dataset selectors. Note: use
+        # the member variables, not the parameters, because the parameters
+        # can be None to indicate no change
+        stage1 = (self._time_keep, self._freq_keep, self._corrprod_keep)
+        # Cache dask graphs for the data fields
+        self._vis = DaskLazyIndexer(self._corrected.vis, stage1)
+        self._weights = DaskLazyIndexer(self._corrected.weights, stage1)
+        self._raw_flags = DaskLazyIndexer(self._corrected.flags, stage1)
+        flag_transforms = []
+        if ~self._flags_select != 0:
+            # Copy so that the lambda isn't affected by future changes
+            select = self._flags_select.copy()
+            flag_transforms.append(lambda flags: da.bitwise_and(select, flags))
+        flag_transforms.append(lambda flags: flags.view(np.bool_))
+        self._flags = DaskLazyIndexer(self._corrected.flags, stage1, flag_transforms)
+        unscaled_weights = self._corrected.unscaled_weights
+        if unscaled_weights is None or self.accumulations_per_dump is None:
+            self._excision = None
+        else:
+            # The maximum / expected number of CBF dumps per SDP dump
+            cbf_dumps_per_sdp_dump = round(self.dump_period / self.cbf_dump_period)
+            accs_per_sdp_dump = np.float32(self.accumulations_per_dump)
+            accs_per_cbf_dump = accs_per_sdp_dump / np.float32(cbf_dumps_per_sdp_dump)
+            # Each unscaled weight represents the actual number of accumulations per SDP dump.
+            # Correct most of the weight compression artefacts by forcing each weight to be
+            # an integer multiple of CBF n_accs, and then convert it to an excision fraction.
+            def integer_cbf_dumps(w):
+                return da.round(w / accs_per_cbf_dump) * accs_per_cbf_dump
 
-                def excision_fraction(w):
-                    return (accs_per_sdp_dump - w) / accs_per_sdp_dump
+            def excision_fraction(w):
+                return (accs_per_sdp_dump - w) / accs_per_sdp_dump
 
-                excision_transforms = [integer_cbf_dumps, excision_fraction]
-                self._excision = DaskLazyIndexer(unscaled_weights, stage1, excision_transforms)
+            excision_transforms = [integer_cbf_dumps, excision_fraction]
+            self._excision = DaskLazyIndexer(unscaled_weights, stage1, excision_transforms)
 
     @property
     def timestamps(self):

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -568,7 +568,7 @@ class VisibilityDataV4(DataSet):
             select = self._flags_select.copy()
             def bitwise_and(flags): return da.bitwise_and(select, flags)
             flag_transforms.append(bitwise_and)
-        # Convert uint8 to bool by ORing all the bits
+        # View uint8 as bool (can still be undone by flags.view(np.uint8))
         def view_as_bool(flags): return flags.view(np.bool_)
         flag_transforms.append(view_as_bool)
         self._flags = DaskLazyIndexer(self._corrected.flags, stage1, flag_transforms)


### PR DESCRIPTION
Expose the raw flags of MVFv4 datasets, which are the uint8s stored in the chunk store (L0 or L1), augmented by the `data_lost` bit that also covers the corresponding vis and weights chunks, and the `postproc` bit produced by the optional applycal step. It is therefore the final flag bits before they are combined into bools, which tells you why data points are flagged.

The `raw_flags` indexer will honour stage 1 and stage 2 selections done on the time, frequency and corrprod axes, but ignores flag selections. It always returns all available flag bits.

Also refactor some of the cruft in `_set_keep` while we are at it.