### PR TITLE
SPR1-897: Allow nested DaskLazyIndexers

### DIFF
--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -532,17 +532,6 @@ class DaskLazyIndexer:
                 self._orig_dataset = None
             return self._dataset
 
-    def add_transform(self, transform):
-        """Add another transform to the end of the transform chain.
-
-        The `transform` is a callable that takes a dask array and returns
-        another dask array.
-        """
-        with self._lock:
-            if self._dataset is not None:
-                self._dataset = transform(self._dataset)
-            self._transforms.append(transform)
-
     def __getitem__(self, keep):
         """Extract a selected array from the underlying dataset.
 

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -479,9 +479,13 @@ class DaskLazyIndexer:
     :class:`numpy.ndarray` output. Both selection steps follow outer indexing
     ("oindex") semantics, by indexing each dimension / axis separately.
 
+    DaskLazyIndexers can also index other DaskLazyIndexers, which allows them
+    to share first-stage selections and/or transforms, and to construct nested
+    or hierarchical indexers.
+
     Parameters
     ----------
-    dataset : :class:`dask.Array`
+    dataset : :class:`dask.Array` or :class:`DaskLazyIndexer`
         The full dataset, from which a subset is chosen by `keep`
     keep : NumPy index expression, optional
         Index expression describing first-stage selection (e.g. as applied by
@@ -519,6 +523,8 @@ class DaskLazyIndexer:
         """Array after first-stage indexing and transformation."""
         with self._lock:
             if self._dataset is None:
+                if isinstance(self._orig_dataset, DaskLazyIndexer):
+                    self._orig_dataset = self._orig_dataset.dataset
                 dataset = dask_getitem(self._orig_dataset, self.keep)
                 for transform in self.transforms:
                     dataset = transform(dataset)

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -303,18 +303,8 @@ class TestDaskLazyIndexer:
         # Add transform at initialisation
         indexer = DaskLazyIndexer(self.data_dask, transforms=[lambda x: 0 * x])
         np.testing.assert_array_equal(indexer[:], np.zeros_like(indexer))
-        # Add transform before first use of object
-        indexer = DaskLazyIndexer(self.data_dask)
-        indexer.add_transform(lambda x: 0 * x)
-        np.testing.assert_array_equal(indexer[:], np.zeros_like(indexer))
-        # Add transform after first use of object
-        indexer = DaskLazyIndexer(self.data_dask)
-        indexer.dataset
-        indexer.add_transform(lambda x: 0 * x)
-        np.testing.assert_array_equal(indexer[:], np.zeros_like(indexer))
         # Check nested indexers
         indexer = DaskLazyIndexer(self.data_dask)
-        indexer2 = DaskLazyIndexer(indexer)
-        indexer2.add_transform(lambda x: 0 * x)
+        indexer2 = DaskLazyIndexer(indexer, transforms=[lambda x: 0 * x])
         np.testing.assert_array_equal(indexer[:], self.data)
         np.testing.assert_array_equal(indexer2[:], np.zeros_like(indexer))

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -27,8 +27,8 @@ from katdal.lazy_indexer import (_range_to_slice, _simplify_index,
                                  _dask_oindex, dask_getitem, DaskLazyIndexer)
 
 
-def slice_to_range(s, l):
-    return range(*s.indices(l))
+def slice_to_range(s, length):
+    return range(*s.indices(length))
 
 
 class TestRangeToSlice:

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -272,6 +272,9 @@ class TestDaskLazyIndexer:
         npy2 = numpy_oindex(npy1, stage2)
         indexer = DaskLazyIndexer(self.data_dask, stage1)
         np.testing.assert_array_equal(indexer[stage2], npy2)
+        # Check nested indexers
+        indexer2 = DaskLazyIndexer(indexer, stage2)
+        np.testing.assert_array_equal(indexer2[()], npy2)
 
     def test_stage1_slices(self):
         self._test_with(np.s_[5:, :, 1::2])
@@ -309,3 +312,9 @@ class TestDaskLazyIndexer:
         indexer.dataset
         indexer.add_transform(lambda x: 0 * x)
         np.testing.assert_array_equal(indexer[:], np.zeros_like(indexer))
+        # Check nested indexers
+        indexer = DaskLazyIndexer(self.data_dask)
+        indexer2 = DaskLazyIndexer(indexer)
+        indexer2.add_transform(lambda x: 0 * x)
+        np.testing.assert_array_equal(indexer[:], self.data)
+        np.testing.assert_array_equal(indexer2[:], np.zeros_like(indexer))

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -571,7 +571,7 @@ class VisibilityDataV4(DataSet):
         # View uint8 as bool (can still be undone by flags.view(np.uint8))
         def view_as_bool(flags): return flags.view(np.bool_)
         flag_transforms.append(view_as_bool)
-        self._flags = DaskLazyIndexer(self._corrected.flags, stage1, flag_transforms)
+        self._flags = DaskLazyIndexer(self._raw_flags, transforms=flag_transforms)
 
         # Create excision indexer based on unscaled weights
         unscaled_weights = self._corrected.unscaled_weights


### PR DESCRIPTION
The main use case is to slap some more transforms onto an existing indexer (think `flags` piggy-backing on `raw_flags`) but it also allows N-stage indexing. The first indexer's `dataset` Dask array becomes the original dataset for the second indexer (lazily), and an additional selection and transform set will then be applied to it to form the `dataset` of the second indexer.

It's only used for the flags indexers for now.