### PR TITLE
SPR1-1138: Improve the exposure of CBF sensors

### DIFF
--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -106,11 +106,23 @@ def _calc_delay(cache, name, inp):
     return delay_data if name.endswith('delay') else phase_data
 
 
+def _calc_gain(cache, name, inp):
+    """Extract virtual applied F-engine gain sensors from raw CBF sensors."""
+    instrument = cache.get('Correlator/instrument')[0]
+    # The real/imag parts are cast to int16 in the F-engine but the CBF sensor
+    # seems to report back the CAM request, so round them here to be more accurate
+    sensor_data = cache.get(f'{instrument}_antenna_channelised_voltage_{inp}_eq',
+                            transform=lambda g: np.array(g, dtype=np.complex64).round())
+    cache[name] = sensor_data
+    return sensor_data
+
+
 VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
 VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
                         'Antennas/{ant}/el': _calc_azel,
                         'Correlator/Inputs/{inp}/applied_delay': _calc_delay,
-                        'Correlator/Inputs/{inp}/applied_phase': _calc_delay})
+                        'Correlator/Inputs/{inp}/applied_phase': _calc_delay,
+                        'Correlator/Inputs/{inp}/applied_gain': _calc_gain})
 
 DEFAULT_CAL_PRODUCTS = ('l1.K', 'l1.B', 'l1.G', 'l2.GPHASE')
 

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -79,7 +79,7 @@ def _calc_azel(cache, name, ant):
 def _calc_delay(cache, name, inp):
     """Extract virtual applied delay/phase sensors from raw CBF sensors."""
     # Obtain the relevant CBF attributes from the cache
-    stream = cache.get('Correlator/f_engine_stream')[0]
+    stream = cache.get('Correlator/antenna_channelised_voltage_stream')[0]
     sync_time = cache.get('Correlator/sync_time')[0]
     scale_factor_timestamp = cache.get('Correlator/scale_factor_timestamp')[0]
     # Don't extract the sensor since the real timestamps are hidden in the values
@@ -109,7 +109,7 @@ def _calc_delay(cache, name, inp):
 
 def _calc_gain(cache, name, inp):
     """Extract virtual applied F-engine gain sensors from raw CBF sensors."""
-    stream = cache.get('Correlator/f_engine_stream')[0]
+    stream = cache.get('Correlator/antenna_channelised_voltage_stream')[0]
     # The real/imag parts are cast to int16 in the F-engine but the CBF sensor
     # seems to report back the CAM request, so round them here to be more accurate
     sensor_data = cache.get(f'{stream}_{inp}_eq',
@@ -360,7 +360,7 @@ class VisibilityDataV4(DataSet):
         # ------ Extract correlator settings ------
 
         if f_engine_stream is not None:
-            self.sensor['Correlator/f_engine_stream'] = CategoricalData(
+            self.sensor['Correlator/antenna_channelised_voltage_stream'] = CategoricalData(
                 [f_engine_stream], all_dumps)
         sync_time = attrs.get('sync_time')
         if sync_time is not None:

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -76,6 +76,13 @@ def _calc_azel(cache, name, ant):
     return sensor_data
 
 
+VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
+VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
+                        'Antennas/{ant}/el': _calc_azel})
+
+DEFAULT_CAL_PRODUCTS = ('l1.K', 'l1.B', 'l1.G', 'l2.GPHASE')
+
+
 def _add_sensor_alias(cache, new_name, old_name):
     """Add an optional alias for single sensor in sensor cache."""
     try:
@@ -117,13 +124,6 @@ def _normalise_cal_products(products, cal_streams):
                              f'stream{streams}, product type (one of {product_types}) '
                              'or <stream>.<product_type>')
     return normalised_cal_products, skip_missing_products
-
-
-VIRTUAL_SENSORS = dict(DEFAULT_VIRTUAL_SENSORS)
-VIRTUAL_SENSORS.update({'Antennas/{ant}/az': _calc_azel,
-                        'Antennas/{ant}/el': _calc_azel})
-
-DEFAULT_CAL_PRODUCTS = ('l1.K', 'l1.B', 'l1.G', 'l2.GPHASE')
 
 # -----------------------------------------------------------------------------
 # -- CLASS :  VisibilityDataV4
@@ -185,10 +185,10 @@ class VisibilityDataV4(DataSet):
         self.dump_period = attrs['int_time']
         # The CBF dump period is not in the lite RDB version
         try:
-            src_stream = attrs['src_streams'][0]
+            correlator_stream = attrs['src_streams'][0]
             # XXX: should use telstate.join if attrs is a telstate
-            self.cbf_dump_period = attrs[src_stream + '_int_time']
-            cbf_n_accs = attrs[src_stream + '_n_accs']
+            self.cbf_dump_period = attrs[correlator_stream + '_int_time']
+            cbf_n_accs = attrs[correlator_stream + '_n_accs']
         except (KeyError, IndexError):
             self.cbf_dump_period = self.accumulations_per_dump = None
         else:


### PR DESCRIPTION
There is now the following set of virtual sensors that expose the underlying CBF sensors (`wide_antenna_channelised_voltage_{inp}_delay/eq`) in a more katdal-friendly way:
```
Correlator/Inputs/{inp}/applied_delay [seconds]
Correlator/Inputs/{inp}/applied_phase [radians]
Correlator/Inputs/{inp}/applied_gain [complex64, shape (n_chans,)]
```
The idea is to use them to undo delay tracking and/or F-engine gains.

@spassmoor I recall you did similar experiments at some stage, so I'm including you in the review mix.

PS the `applied_phase` sensor is there for completeness but I'm still figuring out the best way to use it in delay tracking inversion.