### PR TITLE
SPR1-1210: Fix mvftoms on macOS and Python 3.8+

### DIFF
--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -44,6 +44,8 @@ from katdal.flags import NAMES as FLAG_NAMES
 
 SLOTS = 4    # Controls overlap between loading and writing
 
+CPInfo = namedtuple('CPInfo', 'ant1_index ant2_index ant1 ant2 cp_index')
+
 
 def casa_style_int_list(range_string, use_argparse=False, opt_unit="m"):
     """Turn CASA style range string "[0-9]*~[0-9]*, ..." into a list of ints.
@@ -308,8 +310,6 @@ def main():
                     for p in pols_to_use]
         cp_index = np.array(cp_index, dtype=np.int32)
 
-        CPInfo = namedtuple("CPInfo", ["ant1_index", "ant2_index",
-                                       "ant1", "ant2", "cp_index"])
         return CPInfo(ant1_index, ant2_index, ant1, ant2, cp_index)
 
     # Open dataset


### PR DESCRIPTION
Multiprocessing changed its default process start method on macOS to "spawn" in Python 3.8. This requires the parameters to `Process.__init__` to be picklable. One of them is an instance of the `CPInfo` namedtuple. This class is defined locally in the `corrprod_index` function, where pickle cannot find it.

Fix the issue by moving the definition of `CPInfo` to the module/script level.