### PR TITLE
SPR1-1143: Allow deselection of antennas in katdal using '~m0XX'

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -168,6 +168,17 @@ def _selection_to_list(names, **groups):
         return [names]
 
 
+def _is_deselection(selectors):
+    """If all the selectors have a tilde ~ , then this is treated as a
+     deselect and we are going to invert the selection.
+     TODO: For version 1 release the deselector interface should just have a leading ~
+     """
+    for selector in selectors:
+        if selector[0] != '~':
+            return False
+    return True
+
+
 DEFAULT_SENSOR_PROPS = {
     '*nd_coupler': {'categorical': True, 'greedy_values': (True,), 'initial_value': '0',
                     'transform': lambda x: x not in ('0', 'False', 0)},
@@ -550,14 +561,6 @@ class DataSet:
                 model.min_freq_MHz = new_min_freq
                 model.max_freq_MHz = new_max_freq
 
-    def _is_deselection(self, selectors):
-        """If all the selectors have a tilde ~ , then this is treated as a
-         deselect and we are going to invert the selection."""
-        for selector in selectors:
-            if selector[0] != '~':
-                return False
-        return True
-
     def _set_keep(self, time_keep=None, freq_keep=None, corrprod_keep=None,
                   weights_keep=None, flags_keep=None):
         """Set time, frequency and/or correlation product selection masks.
@@ -832,7 +835,7 @@ class DataSet:
             elif k == 'ants':
                 ants = _selection_to_list(v)
                 ant_names = [(ant.name if isinstance(ant, katpoint.Antenna) else ant) for ant in ants]
-                if self._is_deselection(ant_names):
+                if _is_deselection(ant_names):
                     ant_names = [ant_name[1:] for ant_name in ant_names]
                     self._corrprod_keep &= [(inpA[:-1] not in ant_names and inpB[:-1] not in ant_names)
                                         for inpA, inpB in self.subarrays[self.subarray].corr_products]

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -164,3 +164,9 @@ class TestVirtualSensors:
         assert_array_equal(self.dataset.u[:, 5], u)
         assert_array_equal(self.dataset.v[:, 5], v)
         assert_array_equal(self.dataset.w[:, 5], w)
+
+    def test_selecting_antenna(self):
+        self.dataset.select(ants='~m000')
+        assert_array_equal(
+            self.dataset.corr_products,
+            [('m063h', 'm063h'), ('m063v', 'm063v')])


### PR DESCRIPTION
This change allows the deselection of a set of antenna by prefacing the antenna with ~