### PR TITLE
SPR1-1155: Select targets by their tags (first attempt)

### DIFF
--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -702,12 +702,13 @@ class DataSet:
             If `spw` or `subarray` is out of range
 
         """
-        time_selectors = ['dumps', 'timerange', 'scans', 'compscans', 'targets']
+        time_selectors = ['dumps', 'timerange', 'scans', 'compscans',
+                          'targets', 'target_tags']
         freq_selectors = ['channels', 'freqrange']
         corrprod_selectors = ['corrprods', 'ants', 'inputs', 'pol']
         # Check if keywords are valid and raise exception only if this is explicitly enabled
         valid_kwargs = time_selectors + freq_selectors + corrprod_selectors + \
-            ['spw', 'subarray', 'weights', 'flags', 'reset', 'strict', 'target_tags']
+            ['spw', 'subarray', 'weights', 'flags', 'reset', 'strict']
         # Check for definition of strict
         strict = kwargs.get('strict', True)
         if strict and set(kwargs.keys()) - set(valid_kwargs):
@@ -803,9 +804,10 @@ class DataSet:
                 tags = v if is_iterable(v) else [v]
                 target_keep = np.zeros(len(self._time_keep), dtype=np.bool)
                 target_index_sensor = self.sensor.get('Observation/target_index')
-                for target_index in self.target_indices:
-                    target_tags = self.catalogue.targets[target_index].tags
+                for target in self.catalogue.targets:
+                    target_tags = target.tags
                     if set(target_tags) & set(tags):
+                        target_index = self.catalogue.targets.index(target)
                         target_keep |= (target_index_sensor == target_index)
                 self._time_keep &= target_keep
             # Selections that affect frequency axis

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -694,7 +694,7 @@ class DataSet:
         corrprod_selectors = ['corrprods', 'ants', 'inputs', 'pol']
         # Check if keywords are valid and raise exception only if this is explicitly enabled
         valid_kwargs = time_selectors + freq_selectors + corrprod_selectors + \
-            ['spw', 'subarray', 'weights', 'flags', 'reset', 'strict']
+            ['spw', 'subarray', 'weights', 'flags', 'reset', 'strict', 'target_tags']
         # Check for definition of strict
         strict = kwargs.get('strict', True)
         if strict and set(kwargs.keys()) - set(valid_kwargs):
@@ -785,6 +785,15 @@ class DataSet:
                         logger.warning("Skipping unknown selected target '%s'", t)
                         continue
                     target_keep |= (target_index_sensor == target_index)
+                self._time_keep &= target_keep
+            elif k == 'target_tags':
+                tags = v if is_iterable(v) else [v]
+                target_keep = np.zeros(len(self._time_keep), dtype=np.bool)
+                target_index_sensor = self.sensor.get('Observation/target_index')
+                for target_index in self.target_indices:
+                    target_tags = self.catalogue.targets[target_index].tags
+                    if set(target_tags) & set(tags):
+                        target_keep |= (target_index_sensor == target_index)
                 self._time_keep &= target_keep
             # Selections that affect frequency axis
             elif k == 'channels':

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -114,8 +114,7 @@ def test_selection_to_list():
 
 class TestVirtualSensors:
     def setup(self):
-        self.target = Target('PKS1934-638, radec, 19:39, -63:42',
-                             tags='radec')
+        self.target = Target('PKS1934-638, radec, 19:39, -63:42')
         self.antennas = [Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
                                  '-8.264 -207.29 8.5965'),
                          Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
@@ -168,9 +167,9 @@ class TestVirtualSensors:
 
     def test_tag_selection(self):
         self.dataset.select(target_tags='radec')
-        assert_equal(len(self.dataset.target_indices), 1)
+        assert_equal(self.dataset.target_indices, [0])
         self.dataset.select(target_tags='incorrect_tag')
-        assert_equal(len(self.dataset.target_indices), 0)
+        assert_equal(self.dataset.target_indices, [])
 
     def test_selecting_antenna(self):
         self.dataset.select(ants='~m000')

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -114,7 +114,8 @@ def test_selection_to_list():
 
 class TestVirtualSensors:
     def setup(self):
-        self.target = Target('PKS1934-638, radec, 19:39, -63:42')
+        self.target = Target('PKS1934-638, radec, 19:39, -63:42',
+                             tags='radec')
         self.antennas = [Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
                                  '-8.264 -207.29 8.5965'),
                          Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
@@ -164,3 +165,9 @@ class TestVirtualSensors:
         assert_array_equal(self.dataset.u[:, 5], u)
         assert_array_equal(self.dataset.v[:, 5], v)
         assert_array_equal(self.dataset.w[:, 5], w)
+
+    def test_tag_selection(self):
+        self.dataset.select(target_tags='radec')
+        assert_equal(len(self.dataset.target_indices), 1)
+        self.dataset.select(target_tags='incorrect_tag')
+        assert_equal(len(self.dataset.target_indices), 0)


### PR DESCRIPTION
Allow users to select target by their tags.
e.g. 
```Python
d = katdal.open(url)
d.select(target_tags='gaincal')
```