### PR TITLE
SPR1-766: Verify that S3 bucket is not empty

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -611,7 +611,9 @@ class S3ChunkStore(ChunkStore):
         """Check that bucket associated with `url` exists and is not empty."""
         bucket = _bucket_url(url)
         try:
-            response = self.complete_request('GET', bucket, process=lambda r: r)
+            # Speed up the request by only checking that the bucket has at least one key
+            response = self.complete_request('GET', bucket, process=lambda r: r,
+                                             params={'max-keys': 1})
         except S3ObjectNotFound as err:
             # There is no point continuing if the bucket is completely missing
             raise StoreUnavailable(err) from chunk_error

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -618,7 +618,7 @@ class S3ChunkStore(ChunkStore):
             # There is no point continuing if the bucket is completely missing
             raise StoreUnavailable(err) from chunk_error
         # An empty bucket response has no Contents elements (no need for full XML parsing)
-        if response.ok and b'<Contents>' not in response.content:
+        if b'<Contents>' not in response.content:
             msg = f'S3 bucket {bucket} is empty - your data is not currently accessible'
             raise StoreUnavailable(msg) from chunk_error
 

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -617,6 +617,7 @@ class S3ChunkStore(ChunkStore):
         except S3ObjectNotFound as err:
             # There is no point continuing if the bucket is completely missing
             raise StoreUnavailable(err) from chunk_error
+        assert response.ok, f'Listing {bucket} failed: {response} {response.content}'
         # An empty bucket response has no Contents elements (no need for full XML parsing)
         if b'<Contents>' not in response.content:
             msg = f'S3 bucket {bucket} is empty - your data is not currently accessible'

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -46,7 +46,7 @@ from urllib3.util.retry import Retry
 import numpy as np
 from numpy.testing import assert_array_equal
 from nose import SkipTest
-from nose.tools import assert_raises, assert_equal, assert_true, timed
+from nose.tools import assert_raises, assert_equal, assert_in, assert_not_in, timed
 import requests
 import jwt
 import katsdptelstate
@@ -346,10 +346,10 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             self.store.get_chunk(f'{BUCKET}-empty/x', slices, dtype)
         # Check that the standard bucket has not been verified yet
         bucket_url = urllib.parse.urljoin(self.store._url, BUCKET)
-        assert_true(bucket_url not in self.store._verified_buckets)
+        assert_not_in(bucket_url, self.store._verified_buckets)
         # Check that the standard bucket remains verified after initial check
         self.test_chunk_non_existent()
-        assert_true(bucket_url in self.store._verified_buckets)
+        assert_in(bucket_url, self.store._verified_buckets)
 
 
 class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -326,6 +326,17 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         source_direct = TelstateDataSource(view, cbid, sn, self.store)
         assert_telstate_data_source_equal(source_from_url, source_direct)
 
+    def test_missing_or_empty_buckets(self):
+        slices = (slice(0, 1),)
+        dtype = np.dtype(np.float)
+        # Without create_array the bucket is missing
+        with assert_raises(StoreUnavailable):
+            self.store.get_chunk(f'{BUCKET}-missing/x', slices, dtype)
+        self.store.create_array(f'{BUCKET}-empty/x')
+        # Without put_chunk the bucket is empty
+        with assert_raises(StoreUnavailable):
+            self.store.get_chunk(f'{BUCKET}-empty/x', slices, dtype)
+
 
 class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
     """HTTP proxy that substitutes AWS credentials in place of a bearer token."""


### PR DESCRIPTION
Whenever a chunk is not found, go and check the associated bucket. If the bucket is missing or empty, raise `StoreUnavailable` instead since this is a fatal error. In the past katdal would happily return a bucketload of zeros with no complaints.

The bucket exists but is empty if the dataset has been archived to tape. A completely missing bucket is unlikely, but check for it anyway.

~~We perform the check with every missing chunk because that is simpler than tracking which buckets we verified. The overhead should be low, since we typically either have all chunks missing (the aim of this fix) or only a handful of chunks missing. Besides that, 404s are quite quick compared to the downloading of actual chunks.~~

We cache all verified buckets on the store, assuming that a bucket won't empty while we are accessing it with katdal.

