### PR TITLE
SPR1-930: Prepare for v0.19

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+Copyright (c) 2011-2021, National Research Foundation (SARAO)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,18 @@
 History
 =======
 
+0.19 (2021-11-23)
+-----------------
+* Support scans and non-radec targets like planets in mvftoms (#333)
+* Expose the raw flags of MVF4 datasets (#335)
+* Expose CBF F-engine sensors: applied delays, phases and gains (#338)
+* Verify that S3 bucket is not empty to detect datasets archived to tape (#344)
+* Populate SIGMA_SPECTRUM and redo SIGMA and WEIGHT in mvftoms (#347)
+* Have a sensible DataSet.name and also add a separate DataSet.url (#337)
+* Allow deselection of antennas using '~m0XX' (#340)
+* Allow nested DaskLazyIndexers (#336)
+* Fix mvftoms on macOS and Python 3.8+ (#339)
+
 0.18 (2021-04-20)
 -----------------
 * Switch to PyJWT 2 and Python 3.6, cleaning up Python 2 relics (#321 - #323)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-import katdal
+import katdal  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,9 +14,9 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 import katdal  # noqa: E402
-
 
 # -- Project information -----------------------------------------------------
 

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -19,14 +19,14 @@
 import logging as _logging
 import urllib.parse
 
-from .datasources import open_data_source
-from .dataset import DataSet, WrongVersion  # noqa: F401
-from .spectral_window import SpectralWindow  # noqa: F401
-from .lazy_indexer import LazyTransform, dask_getitem  # noqa: F401
 from .concatdata import ConcatenatedDataSet
+from .dataset import DataSet, WrongVersion  # noqa: F401
+from .datasources import open_data_source
 from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2
 from .h5datav3 import H5DataV3
+from .lazy_indexer import LazyTransform, dask_getitem  # noqa: F401
+from .spectral_window import SpectralWindow  # noqa: F401
 from .visdatav4 import VisibilityDataV4
 
 

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/__init__.py
+++ b/katdal/__init__.py
@@ -20,9 +20,9 @@ import logging as _logging
 import urllib.parse
 
 from .datasources import open_data_source
-from .dataset import DataSet, WrongVersion
-from .spectral_window import SpectralWindow
-from .lazy_indexer import LazyTransform, dask_getitem
+from .dataset import DataSet, WrongVersion  # noqa: F401
+from .spectral_window import SpectralWindow  # noqa: F401
+from .lazy_indexer import LazyTransform, dask_getitem  # noqa: F401
 from .concatdata import ConcatenatedDataSet
 from .h5datav1 import H5DataV1
 from .h5datav2 import H5DataV2

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -18,15 +18,14 @@
 
 import logging
 
-import numpy as np
 import dask.array as da
 import numba
+import numpy as np
 
 from .categorical import CategoricalData, ComparableArrayWrapper
+from .flags import POSTPROC
 from .sensordata import SensorGetter, SimpleSensorGetter
 from .spectral_window import SpectralWindow
-from .flags import POSTPROC
-
 
 # A constant indicating invalid / absent gain (typically due to flagged data)
 INVALID_GAIN = np.complex64(complex(np.nan, np.nan))

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -72,10 +72,12 @@ def complex_interp(x, xi, yi, left=None, right=None):
     mag_left = phase_left = mag_right = phase_right = None
     if left is not None:
         mag_left = np.abs(left)
-        phase_left = np.unwrap([phase_i[0], np.angle(left)])[1]
+        with np.errstate(invalid='ignore'):
+            phase_left = np.unwrap([phase_i[0], np.angle(left)])[1]
     if right is not None:
         mag_right = np.abs(right)
-        phase_right = np.unwrap([phase_i[-1], np.angle(right)])[1]
+        with np.errstate(invalid='ignore'):
+            phase_right = np.unwrap([phase_i[-1], np.angle(right)])[1]
     # Interpolate magnitude and phase separately, and reassemble
     mag = np.interp(x, xi, mag_i, left=mag_left, right=mag_right)
     phase = np.interp(x, xi, phase_i, left=phase_left, right=phase_right)

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -498,7 +498,7 @@ def calc_correction_per_corrprod(dump, channels, params):
 
 def _correction_block(block_info, params):
     """Calculate applycal correction for a single time-freq-baseline chunk."""
-    slices = tuple(slice(*l) for l in block_info[None]['array-location'])
+    slices = tuple(slice(*loc) for loc in block_info[None]['array-location'])
     block_shape = block_info[None]['chunk-shape']
     correction = np.empty(block_shape, np.complex64)
     # TODO: make calc_correction_per_corrprod multi-dump aware

--- a/katdal/applycal.py
+++ b/katdal/applycal.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 ################################################################################
 
-import numpy as np
 import numba
+import numpy as np
 
 
 @numba.jit(nopython=True, parallel=True)

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -508,7 +508,7 @@ class ChunkStore:
                     stop_chunk -= 1
                     c = chunks[axis][stop_chunk]
                     shape[axis] -= c
-                chunks[axis] = chunks[axis][start_chunk : stop_chunk]
+                chunks[axis] = chunks[axis][start_chunk:stop_chunk]
                 if not chunks[axis]:
                     chunks[axis] = (0,)   # Dask doesn't allow empty chunk lists
                 index[axis] = slice(start, stop)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -18,13 +18,13 @@
 
 import contextlib
 import functools
-import uuid
 import io
+import uuid
 
-import numpy as np
 import dask
 import dask.array as da
 import dask.highlevelgraph
+import numpy as np
 
 
 class ChunkStoreError(Exception):

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -16,7 +16,7 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on a dict of arrays."""
 
-from .chunkstore import ChunkStore, ChunkNotFound, BadChunk
+from .chunkstore import BadChunk, ChunkNotFound, ChunkStore
 
 
 class DictChunkStore(ChunkStore):

--- a/katdal/chunkstore_dict.py
+++ b/katdal/chunkstore_dict.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/chunkstore_npy.py
+++ b/katdal/chunkstore_npy.py
@@ -16,14 +16,14 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on NPY files."""
 
-import os
+import contextlib
 import errno
 import mmap
-import contextlib
+import os
 
 import numpy as np
 
-from .chunkstore import (ChunkStore, StoreUnavailable, ChunkNotFound, BadChunk,
+from .chunkstore import (BadChunk, ChunkNotFound, ChunkStore, StoreUnavailable,
                          npy_header_and_body)
 
 

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -16,33 +16,33 @@
 
 """A store of chunks (i.e. N-dimensional arrays) based on the Amazon S3 API."""
 
+import base64
 import contextlib
+import copy
+import hashlib
+import json
 import threading
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
-import urllib.error
-import hashlib
-import base64
-import copy
-import json
-import time
 
+import jwt
 import numpy as np
 import requests
-import jwt
+
 try:
-    import botocore.credentials
     import botocore.auth
+    import botocore.credentials
 except ImportError:
     botocore = None
-from urllib3.util.retry import Retry
-from urllib3.response import HTTPResponse
 from urllib3.exceptions import MaxRetryError
+from urllib3.response import HTTPResponse
+from urllib3.util.retry import Retry
 
-from .chunkstore import (ChunkStore, StoreUnavailable, ChunkNotFound, BadChunk,
+from .chunkstore import (BadChunk, ChunkNotFound, ChunkStore, StoreUnavailable,
                          npy_header_and_body)
 from .sensordata import to_str
-
 
 # Lifecycle policies unfortunately use XML encoding rather than JSON.
 # Following path of least resistance we simply .format() this string

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -21,11 +21,12 @@ from functools import reduce
 
 import numpy as np
 
-from .lazy_indexer import LazyIndexer
-from .sensordata import SensorGetter, SensorData, SensorCache, dummy_sensor_getter
-from .categorical import (CategoricalData, unique_in_order,
-                          concatenate_categorical)
+from .categorical import (CategoricalData, concatenate_categorical,
+                          unique_in_order)
 from .dataset import DataSet
+from .lazy_indexer import LazyIndexer
+from .sensordata import (SensorCache, SensorData, SensorGetter,
+                         dummy_sensor_getter)
 
 
 class ConcatenationError(Exception):

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -16,7 +16,6 @@
 
 """Class for concatenating visibility data sets."""
 
-import os.path
 import itertools
 from functools import reduce
 

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -16,17 +16,15 @@
 
 """Base class for accessing a visibility data set."""
 
-import time
 import logging
 import numbers
 import pathlib
+import time
 import urllib.parse
 
-import numpy as np
-
 import katpoint
+import numpy as np
 from katpoint import is_iterable, rad2deg
-
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -122,7 +122,7 @@ def parse_url_or_path(url_or_path):
     url_parts = urllib.parse.urlparse(url_or_path)
     # Assume filesystem path if there is no scheme (unless url is empty string)
     if not url_parts.scheme and url_parts.path:
-       # A file:// URL expects an absolute path (local paths can't be located)
+        # A file:// URL expects an absolute path (local paths can't be located)
         absolute_path = str(pathlib.Path(url_parts.path).absolute())
         # Note to self: namedtuple._replace is not a private method, despite the underscore!
         url_parts = url_parts._replace(scheme='file', path=absolute_path)
@@ -838,10 +838,10 @@ class DataSet:
                 if _is_deselection(ant_names):
                     ant_names = [ant_name[1:] for ant_name in ant_names]
                     self._corrprod_keep &= [(inpA[:-1] not in ant_names and inpB[:-1] not in ant_names)
-                                        for inpA, inpB in self.subarrays[self.subarray].corr_products]
+                                            for inpA, inpB in self.subarrays[self.subarray].corr_products]
                 else:
                     self._corrprod_keep &= [(inpA[:-1] in ant_names and inpB[:-1] in ant_names)
-                                        for inpA, inpB in self.subarrays[self.subarray].corr_products]
+                                            for inpA, inpB in self.subarrays[self.subarray].corr_products]
             elif k == 'inputs':
                 inps = _selection_to_list(v)
                 self._corrprod_keep &= [(inpA in inps and inpB in inps)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -16,21 +16,20 @@
 
 """Various sources of correlator data and metadata."""
 
-import urllib.parse
-import os.path
 import io
 import logging
+import os.path
+import urllib.parse
 
 import katsdptelstate
 import numpy as np
 
-from .sensordata import TelstateSensorGetter, TelstateToStr
-from .chunkstore_s3 import S3ChunkStore
-from .chunkstore_npy import NpyFileChunkStore
 from .chunkstore import ChunkStoreError
-from .vis_flags_weights import ChunkStoreVisFlagsWeights
+from .chunkstore_npy import NpyFileChunkStore
+from .chunkstore_s3 import S3ChunkStore
 from .dataset import parse_url_or_path
-
+from .sensordata import TelstateSensorGetter, TelstateToStr
+from .vis_flags_weights import ChunkStoreVisFlagsWeights
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/flags.py
+++ b/katdal/flags.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2019-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -17,21 +17,21 @@
 """Data accessor class for HDF5 files produced by Fringe Finder correlator."""
 
 import logging
-import re
 import pathlib
+import re
 
-import numpy as np
 import h5py
 import katpoint
+import numpy as np
 
-from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray,
-                      DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
-                      _robust_target)
-from .spectral_window import SpectralWindow
-from .sensordata import RecordSensorGetter, SensorCache, to_str
 from .categorical import CategoricalData
-from .lazy_indexer import LazyIndexer, LazyTransform
 from .concatdata import ConcatenatedLazyIndexer
+from .dataset import (DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
+                      BrokenFile, DataSet, Subarray, WrongVersion,
+                      _robust_target)
+from .lazy_indexer import LazyIndexer, LazyTransform
+from .sensordata import RecordSensorGetter, SensorCache, to_str
+from .spectral_window import SpectralWindow
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -17,21 +17,22 @@
 """Data accessor class for HDF5 files produced by KAT-7 correlator."""
 
 import logging
-import secrets
 import pathlib
+import secrets
 
-import numpy as np
 import h5py
 import katpoint
+import numpy as np
 
-from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray,
-                      DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
-                      _robust_target, _selection_to_list)
-from .spectral_window import SpectralWindow
-from .sensordata import RecordSensorGetter, SensorCache, to_str
 from .categorical import CategoricalData, sensor_to_categorical
+from .dataset import (DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
+                      BrokenFile, DataSet, Subarray, WrongVersion,
+                      _robust_target, _selection_to_list)
+from .flags import DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .flags import NAMES as FLAG_NAMES
 from .lazy_indexer import LazyIndexer, LazyTransform
-from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .sensordata import RecordSensorGetter, SensorCache, to_str
+from .spectral_window import SpectralWindow
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -17,24 +17,25 @@
 """Data accessor class for HDF5 files produced by RTS correlator."""
 
 import logging
+import pathlib
 import secrets
 from collections import Counter
-import pathlib
 
-import numpy as np
 import h5py
 import katpoint
 import katsdptelstate
+import numpy as np
 
-from .dataset import (DataSet, WrongVersion, BrokenFile, Subarray,
-                      DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
-                      _robust_target, _selection_to_list)
-from .spectral_window import SpectralWindow
-from .sensordata import (SensorCache, RecordSensorGetter,
-                         H5TelstateSensorGetter, telstate_decode, to_str)
 from .categorical import CategoricalData
+from .dataset import (DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
+                      BrokenFile, DataSet, Subarray, WrongVersion,
+                      _robust_target, _selection_to_list)
+from .flags import DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .flags import NAMES as FLAG_NAMES
 from .lazy_indexer import LazyIndexer, LazyTransform
-from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .sensordata import (H5TelstateSensorGetter, RecordSensorGetter,
+                         SensorCache, telstate_decode, to_str)
+from .spectral_window import SpectralWindow
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -18,13 +18,13 @@
 
 import copy
 import threading
+from functools import partial, reduce
 from numbers import Integral
-from functools import reduce, partial
 
-import numpy as np
 import dask.array as da
 import dask.highlevelgraph
 import dask.optimization
+import numpy as np
 
 # TODO support advanced integer indexing with non-strictly increasing indices (i.e. out-of-order and duplicates)
 

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -25,13 +25,13 @@ not be suited to other use cases. It is put into a separate module as a
 workaround for https://bugs.python.org/issue9914.
 """
 
-from collections import namedtuple
 import contextlib
 import multiprocessing
 import multiprocessing.sharedctypes
+from collections import namedtuple
 
-import numpy as np
 import katpoint
+import numpy as np
 
 from . import ms_extra
 

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -24,10 +24,10 @@ import os
 import os.path
 from copy import deepcopy
 
-import numpy as np
-from pkg_resources import parse_version
 import casacore
+import numpy as np
 from casacore import tables
+from pkg_resources import parse_version
 
 # Perform python-casacore version checks
 pyc_ver = parse_version(casacore.__version__)

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -19,14 +19,15 @@
 import logging
 import re
 import threading
+
 try:
     from collections.abc import MutableMapping
 except ImportError:
     from collections import MutableMapping
 
-import numpy as np
 import katpoint
 import katsdptelstate
+import numpy as np
 import requests
 
 from .categorical import (ComparableArrayWrapper, infer_dtype,

--- a/katdal/spectral_window.py
+++ b/katdal/spectral_window.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/s3_utils.py
+++ b/katdal/test/s3_utils.py
@@ -30,7 +30,6 @@ should not be used.
 import contextlib
 import os
 import pathlib
-import socket
 import subprocess
 import time
 import urllib.parse

--- a/katdal/test/s3_utils.py
+++ b/katdal/test/s3_utils.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2020, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -18,24 +18,24 @@
 
 from functools import partial
 
+import dask.array as da
 import katpoint
 import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
-from nose.tools import assert_raises, assert_equal
-import dask.array as da
+from nose.tools import assert_equal, assert_raises
+from numpy.testing import assert_allclose, assert_array_equal
 
-from katdal.spectral_window import SpectralWindow
-from katdal.sensordata import SensorCache, SimpleSensorGetter
-from katdal.categorical import (ComparableArrayWrapper, CategoricalData,
+from katdal.applycal import (INVALID_GAIN, add_applycal_sensors,
+                             apply_flags_correction, apply_vis_correction,
+                             apply_weights_correction,
+                             calc_bandpass_correction, calc_correction,
+                             calc_delay_correction, calc_gain_correction,
+                             calibrate_flux, complex_interp, get_cal_product)
+from katdal.categorical import (CategoricalData, ComparableArrayWrapper,
                                 sensor_to_categorical)
-from katdal.applycal import (complex_interp, get_cal_product, INVALID_GAIN,
-                             calc_delay_correction, calc_bandpass_correction,
-                             calc_gain_correction, apply_vis_correction,
-                             apply_weights_correction, apply_flags_correction,
-                             add_applycal_sensors, calc_correction, calibrate_flux)
 from katdal.flags import POSTPROC
+from katdal.sensordata import SensorCache, SimpleSensorGetter
+from katdal.spectral_window import SpectralWindow
 from katdal.visdatav4 import SENSOR_PROPS
-
 
 POLS = ['v', 'h']
 ANTS = ['m000', 'm001', 'm002', 'm003', 'm004']

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_categorical.py
+++ b/katdal/test/test_categorical.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -16,15 +16,15 @@
 
 """Tests for :py:mod:`katdal.chunkstore`."""
 
-import numpy as np
-from numpy.testing import assert_array_equal
-from nose.tools import (assert_raises, assert_equal, assert_true,
-                        assert_false, assert_is_instance)
 import dask.array as da
+import numpy as np
+from nose.tools import (assert_equal, assert_false, assert_is_instance,
+                        assert_raises, assert_true)
+from numpy.testing import assert_array_equal
 
-from katdal.chunkstore import (ChunkStore, generate_chunks,
-                               StoreUnavailable, ChunkNotFound, BadChunk,
-                               PlaceholderChunk)
+from katdal.chunkstore import (BadChunk, ChunkNotFound, ChunkStore,
+                               PlaceholderChunk, StoreUnavailable,
+                               generate_chunks)
 
 
 class TestGenerateChunks:

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -18,8 +18,8 @@
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from nose.tools import (assert_raises, assert_equal, assert_true, assert_false,
-                        assert_is_instance, assert_is_none)
+from nose.tools import (assert_raises, assert_equal, assert_true,
+                        assert_false, assert_is_instance)
 import dask.array as da
 
 from katdal.chunkstore import (ChunkStore, generate_chunks,

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -17,14 +17,14 @@
 """Tests for :py:mod:`katdal.chunkstore_npy`."""
 
 import os
-import tempfile
 import shutil
+import tempfile
 
 from nose import SkipTest
 from nose.tools import assert_raises
 
-from katdal.chunkstore_npy import NpyFileChunkStore
 from katdal.chunkstore import StoreUnavailable
+from katdal.chunkstore_npy import NpyFileChunkStore
 from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -27,39 +27,40 @@ an older version is detected, the test will be skipped.
 .. _race condition: https://github.com/minio/minio/issues/6324
 """
 
+import contextlib
+import http.server
+import io
 import os
-import tempfile
+import pathlib
+import re
 import shutil
+import socket
+import tempfile
 import threading
 import time
-import socket
-import http.server
 import urllib.parse
-import contextlib
-import io
 import warnings
-import re
-import pathlib
-from urllib3.util.retry import Retry
 
-import numpy as np
-from numpy.testing import assert_array_equal
-from nose import SkipTest
-from nose.tools import assert_raises, assert_equal, assert_in, assert_not_in, timed
-import requests
 import jwt
 import katsdptelstate
+import numpy as np
+import requests
 from katsdptelstate.rdb_writer import RDBWriter
+from nose import SkipTest
+from nose.tools import (assert_equal, assert_in, assert_not_in, assert_raises,
+                        timed)
+from numpy.testing import assert_array_equal
+from urllib3.util.retry import Retry
 
-from katdal.chunkstore_s3 import (S3ChunkStore, _AWSAuth, read_array,
-                                  decode_jwt, InvalidToken, TruncatedRead,
-                                  _DEFAULT_SERVER_GLITCHES)
-from katdal.chunkstore import StoreUnavailable, ChunkNotFound
-from katdal.test.test_chunkstore import ChunkStoreTestBase
-from katdal.test.s3_utils import S3User, S3Server, MissingProgram
+from katdal.chunkstore import ChunkNotFound, StoreUnavailable
+from katdal.chunkstore_s3 import (_DEFAULT_SERVER_GLITCHES, InvalidToken,
+                                  S3ChunkStore, TruncatedRead, _AWSAuth,
+                                  decode_jwt, read_array)
 from katdal.datasources import TelstateDataSource
-from katdal.test.test_datasources import make_fake_data_source, assert_telstate_data_source_equal
-
+from katdal.test.s3_utils import MissingProgram, S3Server, S3User
+from katdal.test.test_chunkstore import ChunkStoreTestBase
+from katdal.test.test_datasources import (assert_telstate_data_source_equal,
+                                          make_fake_data_source)
 
 # Use a standard bucket for most tests to ensure valid bucket name (regex '^[0-9a-z.-]{3,63}$')
 BUCKET = 'katdal-unittest'

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -37,7 +37,6 @@ import http.server
 import urllib.parse
 import contextlib
 import io
-import os
 import warnings
 import re
 import pathlib

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -20,8 +20,8 @@ import numpy as np
 from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises
 
 from katdal.categorical import CategoricalData
-from katdal.sensordata import SensorCache, SimpleSensorGetter
 from katdal.concatdata import ConcatenatedSensorCache
+from katdal.sensordata import SensorCache, SimpleSensorGetter
 
 
 class TestConcatenatedSensorCache:

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2020, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2020-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -16,15 +16,15 @@
 
 """Tests for :py:mod:`katdal.dataset`."""
 
-from nose.tools import assert_equal
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from katpoint import Target, Antenna, Timestamp, rad2deg
+from katpoint import Antenna, Target, Timestamp, rad2deg
+from nose.tools import assert_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from katdal.dataset import (_selection_to_list, DataSet, Subarray,
-                            DEFAULT_VIRTUAL_SENSORS, parse_url_or_path)
-from katdal.sensordata import SensorCache
 from katdal.categorical import CategoricalData
+from katdal.dataset import (DEFAULT_VIRTUAL_SENSORS, DataSet, Subarray,
+                            _selection_to_list, parse_url_or_path)
+from katdal.sensordata import SensorCache
 from katdal.spectral_window import SpectralWindow
 
 

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -16,22 +16,22 @@
 
 """Tests for :py:mod:`katdal.datasources`."""
 
-import urllib.parse
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
+import urllib.parse
 
-import numpy as np
-from nose.tools import assert_raises
 import katsdptelstate
+import numpy as np
 from katsdptelstate.rdb_writer import RDBWriter
+from nose.tools import assert_raises
 
 from katdal.chunkstore_npy import NpyFileChunkStore
-from katdal.datasources import (TelstateDataSource, view_l0_capture_stream, open_data_source,
-                                DataSourceNotFound)
+from katdal.datasources import (DataSourceNotFound, TelstateDataSource,
+                                open_data_source, view_l0_capture_stream)
 from katdal.flags import DATA_LOST
-from katdal.vis_flags_weights import correct_autocorr_quantisation
 from katdal.test.test_vis_flags_weights import put_fake_dataset
+from katdal.vis_flags_weights import correct_autocorr_quantisation
 
 
 def _make_fake_stream(telstate, store, cbid, stream, shape,

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -79,9 +79,9 @@ def _make_fake_stream(telstate, store, cbid, stream, shape,
 
 
 def make_fake_data_source(telstate, store, l0_shape, cbid='cb', l1_flags_shape=None,
-                         l0_chunk_overrides=None, l1_flags_chunk_overrides=None,
-                         l0_array_overrides=None, l1_flags_array_overrides=None,
-                         bls_ordering_override=None):
+                          l0_chunk_overrides=None, l1_flags_chunk_overrides=None,
+                          l0_array_overrides=None, l1_flags_array_overrides=None,
+                          bls_ordering_override=None):
     """Create a complete fake data source.
 
     The resulting telstate and chunk store are suitable for constructing
@@ -155,14 +155,11 @@ class TestTelstateDataSource:
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             preselect=dict(dumps=np.s_[[1, 2]]))
+            TelstateDataSource(view, cbid, sn, self.store, preselect=dict(dumps=np.s_[[1, 2]]))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             preselect=dict(dumps=np.s_[5:0:-1]))
+            TelstateDataSource(view, cbid, sn, self.store, preselect=dict(dumps=np.s_[5:0:-1]))
         with assert_raises(IndexError):
-            data_source = TelstateDataSource(view, cbid, sn, self.store,
-                                             preselect=dict(frequencies=np.s_[:]))
+            TelstateDataSource(view, cbid, sn, self.store, preselect=dict(frequencies=np.s_[:]))
 
     def test_preselect(self):
         view, cbid, sn, l0_data, l1_flags_data = \
@@ -251,7 +248,7 @@ class TestTelstateDataSource:
         l0_shape = (18, 16, 40)
         l1_flags_shape = (20, 8, 40)
         view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, l0_shape,
-                                                    l1_flags_shape=l1_flags_shape)
+                                                     l1_flags_shape=l1_flags_shape)
         with assert_raises(ValueError):
             TelstateDataSource(view, cbid, sn, self.store)
 

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -16,15 +16,16 @@
 
 """Tests for :py:mod:`katdal.lazy_indexer`."""
 
-from numbers import Integral
 from functools import partial
+from numbers import Integral
 
-import numpy as np
 import dask.array as da
-from nose.tools import assert_raises, assert_equal
+import numpy as np
+from nose.tools import assert_equal, assert_raises
 
-from katdal.lazy_indexer import (_range_to_slice, _simplify_index,
-                                 _dask_oindex, dask_getitem, DaskLazyIndexer)
+from katdal.lazy_indexer import (DaskLazyIndexer, _dask_oindex,
+                                 _range_to_slice, _simplify_index,
+                                 dask_getitem)
 
 
 def slice_to_range(s, length):

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -17,13 +17,15 @@
 """Tests for :py:mod:`katdal.sensordata`."""
 
 from collections import OrderedDict
-
-import numpy as np
-from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises, assert_is_instance
 from unittest import mock
 
-from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter, to_str,
-                               remove_duplicates_and_invalid_values, telstate_decode)
+import numpy as np
+from nose.tools import (assert_equal, assert_in, assert_is_instance,
+                        assert_not_in, assert_raises)
+
+from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter,
+                               remove_duplicates_and_invalid_values,
+                               telstate_decode, to_str)
 
 
 def assert_equal_typed(a, b):

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -17,8 +17,8 @@
 """Tests for :py:mod:`katdal.spectral_window`."""
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from katdal.spectral_window import SpectralWindow
 

--- a/katdal/test/test_van_vleck.py
+++ b/katdal/test/test_van_vleck.py
@@ -16,7 +16,7 @@
 
 import numpy as np
 
-from katdal.van_vleck import norm0_cdf, autocorr_lookup_table
+from katdal.van_vleck import autocorr_lookup_table, norm0_cdf
 
 
 def test_norm0_cdf():

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2018-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -16,23 +16,23 @@
 
 """Tests for :py:mod:`katdal.vis_flags_weights`."""
 
-import tempfile
-import shutil
+import itertools
 import os
 import random
-import itertools
+import shutil
+import tempfile
 
-import numpy as np
-from numpy.testing import assert_array_equal
-from nose.tools import assert_equal, assert_raises
 import dask.array as da
+import numpy as np
+from nose.tools import assert_equal, assert_raises
+from numpy.testing import assert_array_equal
 
 from katdal.chunkstore import generate_chunks
 from katdal.chunkstore_npy import NpyFileChunkStore
-from katdal.vis_flags_weights import (VisFlagsWeights, ChunkStoreVisFlagsWeights,
-                                      corrprod_to_autocorr)
-from katdal.van_vleck import autocorr_lookup_table
 from katdal.flags import DATA_LOST
+from katdal.van_vleck import autocorr_lookup_table
+from katdal.vis_flags_weights import (ChunkStoreVisFlagsWeights,
+                                      VisFlagsWeights, corrprod_to_autocorr)
 
 
 def test_vis_flags_weights():

--- a/katdal/van_vleck.py
+++ b/katdal/van_vleck.py
@@ -18,8 +18,8 @@
 
 import math
 
-import numpy as np
 import numba
+import numpy as np
 
 
 @numba.vectorize(['f8(f8, f8)'], nopython=True, cache=True)

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -19,17 +19,16 @@
 import itertools
 import logging
 
-import numpy as np
 import dask.array as da
+import numba
+import numpy as np
+import toolz
 from dask.array.rechunk import intersect_chunks
 from dask.highlevelgraph import HighLevelGraph
-import toolz
-import numba
 
 from .chunkstore import PlaceholderChunk
 from .flags import DATA_LOST
 from .van_vleck import autocorr_lookup_table
-
 
 logger = logging.getLogger(__name__)
 

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -31,7 +31,7 @@ from .dataset import (DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
                       _selection_to_list)
 # FLAG_DESCRIPTIONS isn't used, but it's kept here for compatibility with
 # external code that might get it from here
-from .flags import DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .flags import DESCRIPTIONS as FLAG_DESCRIPTIONS  # noqa: F401
 from .flags import NAMES as FLAG_NAMES  # noqa: F401
 from .lazy_indexer import DaskLazyIndexer
 from .sensordata import SensorCache, SimpleSensorGetter

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -18,25 +18,25 @@
 
 import logging
 
-import numpy as np
-import katpoint
 import dask.array as da
+import katpoint
+import numpy as np
 
-from .dataset import (DataSet, BrokenFile, Subarray, DEFAULT_SENSOR_PROPS,
-                      DEFAULT_VIRTUAL_SENSORS, _robust_target,
-                      _selection_to_list)
-from .vis_flags_weights import VisFlagsWeights
-from .spectral_window import SpectralWindow
-from .sensordata import SensorCache, SimpleSensorGetter
+from .applycal import (CAL_PRODUCT_TYPES, INVALID_GAIN, add_applycal_sensors,
+                       apply_flags_correction, apply_vis_correction,
+                       apply_weights_correction, calc_correction)
 from .categorical import CategoricalData, ComparableArrayWrapper
-from .lazy_indexer import DaskLazyIndexer
-from .applycal import (add_applycal_sensors, calc_correction,
-                       apply_vis_correction, apply_weights_correction,
-                       apply_flags_correction, CAL_PRODUCT_TYPES, INVALID_GAIN)
+from .dataset import (DEFAULT_SENSOR_PROPS, DEFAULT_VIRTUAL_SENSORS,
+                      BrokenFile, DataSet, Subarray, _robust_target,
+                      _selection_to_list)
 # FLAG_DESCRIPTIONS isn't used, but it's kept here for compatibility with
 # external code that might get it from here
-from .flags import NAMES as FLAG_NAMES, DESCRIPTIONS as FLAG_DESCRIPTIONS   # noqa: F401
-
+from .flags import DESCRIPTIONS as FLAG_DESCRIPTIONS
+from .flags import NAMES as FLAG_NAMES  # noqa: F401
+from .lazy_indexer import DaskLazyIndexer
+from .sensordata import SensorCache, SimpleSensorGetter
+from .spectral_window import SpectralWindow
+from .vis_flags_weights import VisFlagsWeights
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/ff_holo_to_h5v1.py
+++ b/scripts/ff_holo_to_h5v1.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/fix_ant_positions.py
+++ b/scripts/fix_ant_positions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/fix_ant_positions.py
+++ b/scripts/fix_ant_positions.py
@@ -18,8 +18,9 @@
 
 # Update the antenna positions in the specified HDF5 file.
 
-import h5py
 import sys
+
+import h5py
 
 if len(sys.argv) < 2:
     print("Update antenna positions in the specified HDF5 file.\n\nUsage: fix_ant_positions.py <filename.h5>\n")

--- a/scripts/h5list.py
+++ b/scripts/h5list.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/h5list.py
+++ b/scripts/h5list.py
@@ -23,9 +23,9 @@
 # 19 December 2011
 #
 
-import os
-import optparse
 import glob
+import optparse
+import os
 
 import katdal
 

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -18,7 +18,6 @@
 
 import mvftoms
 
-
 if __name__ == '__main__':
     print("h5toms.py is deprecated and has been replaced by mvftoms.py")
     print("For now it is an alias to run mvftoms.py")

--- a/scripts/h5toms.py
+++ b/scripts/h5toms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/mvf_read_benchmark.py
+++ b/scripts/mvf_read_benchmark.py
@@ -10,7 +10,6 @@ import numpy as np
 import katdal
 from katdal.lazy_indexer import DaskLazyIndexer
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('filename')
 parser.add_argument('--time', type=int, default=10, help='Number of times to read per batch')

--- a/scripts/mvf_rechunk.py
+++ b/scripts/mvf_rechunk.py
@@ -2,21 +2,22 @@
 
 """Rechunk an existing MVF dataset"""
 
-import sys
-import os
-import re
 import argparse
 import multiprocessing
+import os
+import re
+import sys
 import urllib.parse
 
-from katsdptelstate.rdb_writer import RDBWriter
-import numpy as np
 import dask
 import dask.array as da
+import numpy as np
+from katsdptelstate.rdb_writer import RDBWriter
 
 from katdal.chunkstore import ChunkStoreError
 from katdal.chunkstore_npy import NpyFileChunkStore
-from katdal.datasources import TelstateDataSource, view_capture_stream, infer_chunk_store
+from katdal.datasources import (TelstateDataSource, infer_chunk_store,
+                                view_capture_stream)
 from katdal.flags import DATA_LOST
 
 

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -20,7 +20,6 @@
 # (MVF) dataset using casacore.
 
 import argparse
-from collections import namedtuple
 import multiprocessing
 import multiprocessing.sharedctypes
 import os
@@ -29,18 +28,18 @@ import re
 import tarfile
 import time
 import urllib.parse
+from collections import namedtuple
 
-import numpy as np
 import dask
-import numba
-
 import katpoint
-import katdal
-from katdal import averager, ms_extra, ms_async
-from katdal.sensordata import telstate_decode
-from katdal.lazy_indexer import DaskLazyIndexer
-from katdal.flags import NAMES as FLAG_NAMES
+import numba
+import numpy as np
 
+import katdal
+from katdal import averager, ms_async, ms_extra
+from katdal.flags import NAMES as FLAG_NAMES
+from katdal.lazy_indexer import DaskLazyIndexer
+from katdal.sensordata import telstate_decode
 
 SLOTS = 4    # Controls overlap between loading and writing
 

--- a/scripts/mvftoms.py
+++ b/scripts/mvftoms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -29,6 +29,7 @@ import time
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 import katdal
 
 

--- a/scripts/spectrogram_plot_example.py
+++ b/scripts/spectrogram_plot_example.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [flake8]
 max-line-length = 120
+
+[darglint]
+docstring_style=numpy
+strictness=long

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@
 
 import os.path
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 here = os.path.dirname(__file__)
 readme = open(os.path.join(here, 'README.rst')).read()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2011-2019, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2011-2021, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Minor changes:
- Suppress unit test warning
- Suppress excess docstring checks
- Update changelog

Bigger changes (but very mechanical):
- Update copyright notice
- Flake8
- isort
