### PR TITLE
SPR1-1944: dask 2022.01.1 breaks katdal due to missing da.core.getem

### DIFF
--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -132,8 +132,12 @@ def _graph_from_arraylike(array_name, chunks, getter):
     """Create dask graph from chunk spec like the older :func:`da.core.getem`."""
     try:
         return da.core.graph_from_arraylike(
-            array_name, chunks, shape=None, name=array_name,
-            getitem=getter, inline_array=True
+            array_name,
+            chunks,
+            shape=tuple(sum(c) for c in chunks),
+            name=array_name,
+            getitem=getter,
+            inline_array=True,
         )
     except AttributeError:
         return da.core.getem(array_name, chunks, getter)

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -129,6 +129,7 @@ def generate_chunks(shape, dtype, max_chunk_size, dims_to_split=None,
 
 class _ArrayLikeGetter:
     """Present an array-like interface to chunk getter function."""
+
     def __init__(self, getter, array_name, chunks, dtype, **kwargs):
         self.getter = getter
         self.array_name = array_name
@@ -530,7 +531,7 @@ class ChunkStore:
         token = da.core.tokenize(self, chunks, dtype, index)
         out_name = f'{array_name}-{offset}-{token}'
         getter_shim = _ArrayLikeGetter(getter, array_name, chunks, dtype, **kwargs)
-        array = da.from_array(getter_shim, chunks, out_name)
+        array = da.from_array(getter_shim, chunks, out_name, asarray=False)
         return array[index]
 
     def put_dask_array(self, array_name, array, offset=()):

--- a/katdal/chunkstore.py
+++ b/katdal/chunkstore.py
@@ -19,8 +19,12 @@
 import contextlib
 import functools
 import io
+import uuid
 
 import dask.array as da
+from dask.highlevelgraph import HighLevelGraph
+from dask.blockwise import blockwise as core_blockwise
+from dask.layers import ArraySliceDep
 import numpy as np
 
 
@@ -153,17 +157,21 @@ def _add_offset_to_slices(func, offset):
     return func_with_offset
 
 
-def _put_map_blocks(chunk, block_info=None, store=None, array_name=None, offset=()):
-    """Adapt `put` to `map_blocks` interface."""
-    put = store.put_chunk_noraise
-    if offset:
-        put = _add_offset_to_slices(put, offset)
-    # Turn block info into slices specification
-    slices = tuple(slice(*loc) for loc in block_info[0]["array-location"])
-    success = put(array_name, slices, chunk)
-    # Turn scalar output into ndarray with same ndims as chunk
-    singleton_shape = chunk.ndim * (1,)
-    return np.full(singleton_shape, success)
+def _scalar_to_chunk(func):
+    """Modify chunk get/put/has to turn a scalar return value into a chunk.
+
+    This modifies the given function so that it returns its result as an
+    ndarray with the same number of (singleton) dimensions as the corresponding
+    chunk to enable assembly into a dask array.
+    """
+
+    def func_returning_chunk(array_name, slices, *args, **kwargs):
+        """Turn scalar return value into chunk of appropriate dimension."""
+        value = func(array_name, slices, *args, **kwargs)
+        singleton_shape = len(slices) * (1,)
+        return np.full(singleton_shape, value)
+
+    return func_returning_chunk
 
 
 def npy_header_and_body(chunk):
@@ -550,13 +558,27 @@ class ChunkStore:
             Dask array of objects indicating success of transfer of each chunk
             (None indicates success, otherwise there is an exception object)
         """
-        return da.map_blocks(
-            _put_map_blocks,
-            array,
-            name=f'store-{array_name}-{offset}',
-            dtype=object,
-            chunks=array.ndim * (1,),
-            store=self,
-            array_name=array_name,
-            offset=offset,
+        # Make out_name unique to avoid clashes and caches
+        out_name = f'store-{array_name}-{offset}-{uuid.uuid4().hex}'
+        put = _scalar_to_chunk(self.put_chunk_noraise)
+        if offset:
+            put = _add_offset_to_slices(put, offset)
+        out_ind = tuple(range(array.ndim))
+        layer = core_blockwise(
+            # Function signature: put(array_name, slices, chunk)
+            put,
+            # Output: we want all output chunks
+            out_name, out_ind,
+            # Arg 1: the same array name is passed to all tasks, so no out_ind
+            array_name, None,
+            # Arg 2: produce slice spec per chunk on the fly
+            ArraySliceDep(array.chunks), out_ind,
+            # Arg 3: this represents a chunk of `array`
+            array.name, out_ind,
+            # We need to tell blockwise about the external array's shape
+            numblocks={array.name: array.numblocks},
         )
+        dask_graph = HighLevelGraph.from_collections(out_name, layer, [array])
+        # The success array has one element per chunk in the input array
+        out_chunks = tuple(len(c) * (1,) for c in array.chunks)
+        return da.Array(dask_graph, out_name, out_chunks, object)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -24,7 +24,7 @@ from numpy.testing import assert_array_equal
 
 from katdal.chunkstore import (BadChunk, ChunkNotFound, ChunkStore,
                                PlaceholderChunk, StoreUnavailable,
-                               generate_chunks)
+                               generate_chunks, _prune_chunks)
 
 
 class TestGenerateChunks:
@@ -89,6 +89,20 @@ class TestGenerateChunks:
                                  dims_to_split=(1, 17), power_of_two=True,
                                  max_dim_elements={0: 2, 1: 50})
         assert_equal(chunks, ((10,), 1024 * (8,), (144,)))
+
+
+def test_prune_chunks():
+    """Test the `_prune_chunks` internal function."""
+    chunks = ((10, 10, 10, 10), (2, 2, 2), (40,))
+    # The chunk start-stop boundaries on each axis are:
+    # ((0, 10, 20, 30, 40), (0, 2, 4, 6), (0, 40))
+    index = np.s_[13:34, :4, 10:]
+    new_chunks, new_index, new_offset = _prune_chunks(chunks, index)
+    # The new chunk start-stop boundaries on each axis are:
+    # ((10, 20, 30, 40), (0, 2, 4), (0, 40))
+    assert_equal(new_chunks, ((10, 10, 10), (2, 2), (40,)))
+    assert_equal(new_index, np.s_[3:24, 0:4, 10:40])
+    assert_equal(new_offset, (10, 0, 0))
 
 
 class TestChunkStore:

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -244,7 +244,7 @@ class ChunkStoreTestBase:
             else:
                 return chunk
 
-        return da.map_blocks(map_blocks_func, array)
+        return da.map_blocks(map_blocks_func, array, dtype=array.dtype)
 
     def test_dask_array_put_parts_get_whole(self):
         # Split big array into quarters along existing chunks and reassemble

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -103,6 +103,7 @@ def test_prune_chunks():
     assert_equal(new_chunks, ((10, 10, 10), (2, 2), (40,)))
     assert_equal(new_index, np.s_[3:24, 0:4, 10:40])
     assert_equal(new_offset, (10, 0, 0))
+    assert_raises(IndexError, _prune_chunks, chunks, np.s_[13:34:2, ::-1, :])
 
 
 class TestChunkStore:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy >= 1.12.0', 'katpoint >= 0.9, < 1', 'h5py >= 2.3',
-                        'numba', 'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 1.2.1',
+                        'numba', 'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 2021.1.0',
                         'requests >= 2.18.0', 'pyjwt >= 2', 'cityhash >= 0.2.2'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='katdal',
       setup_requires=['katversion'],
       use_katversion=True,
       install_requires=['numpy >= 1.12.0', 'katpoint >= 0.9, < 1', 'h5py >= 2.3',
-                        'numba', 'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 2021.1.0',
+                        'numba', 'katsdptelstate[rdb] >= 0.10', 'dask[array] >= 1.2.1',
                         'requests >= 2.18.0', 'pyjwt >= 2', 'cityhash >= 0.2.2'],
       extras_require={
           'ms': ['python-casacore >= 2.2.1'],


### PR DESCRIPTION
The latest dask has renamed `da.core.getem` to `da.core.graph_from_arraylike` with a different interface (see dask/dask#7417). Revisit the `ChunkStore.{get|put}_dask_array` machinery to replace `getem`.

~~For the "get" case we stick with `getem` in older dasks, and switch to `graph_from_arraylike` in newer ones.~~
For the "get" case we revert to `da.from_array` with a custom arraylike object and getter function.

For the "put" case we switch to `da.map_blocks` all around (but we would ideally like to use `blockwise` in the future).

More rationale follows 😄 