### PR TITLE
SPR1-1401: Fix the handling of 403 errors

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -537,11 +537,9 @@ class S3ChunkStore(ChunkStore):
                     if content_type in ('application/xml', 'text/xml', 'text/plain'):
                         msg += f'\nDetails of server response: {response.text}'
                     # Raise the appropriate exception
-                    if status == 401:
+                    if status in (401, 403):
                         raise AuthorisationFailed(msg)
-                    elif status in (403, 404):
-                        # Ceph RGW returns 403 for missing keys due to our bucket policy
-                        # (see https://tracker.ceph.com/issues/38638 for discussion)
+                    elif status == 404:
                         raise S3ObjectNotFound(msg)
                     elif self._retries.is_retry(method, status):
                         raise S3ServerGlitch(msg, status)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -55,7 +55,7 @@ from urllib3.util.retry import Retry
 from katdal.chunkstore import ChunkNotFound, StoreUnavailable
 from katdal.chunkstore_s3 import (_DEFAULT_SERVER_GLITCHES, InvalidToken,
                                   S3ChunkStore, TruncatedRead, _AWSAuth,
-                                  decode_jwt, read_array)
+                                  AuthorisationFailed, decode_jwt, read_array)
 from katdal.datasources import TelstateDataSource
 from katdal.test.s3_utils import MissingProgram, S3Server, S3User
 from katdal.test.test_chunkstore import ChunkStoreTestBase
@@ -283,9 +283,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         x = np.arange(5)
         self.store.create_array('private/x')
         self.store.put_chunk('private/x', slices, x)
-        # Ceph RGW returns 403 for missing chunks too so we see ChunkNotFound
-        # The ChunkNotFound then triggers a bucket list that raises StoreUnavailable
-        with assert_raises(StoreUnavailable):
+        with assert_raises(AuthorisationFailed):
             reader.get_chunk('private/x', slices, x.dtype)
 
         # Now a public-read array


### PR DESCRIPTION
The original MeerKAT Ceph RADOS Gateway returned a 403 (Forbidden) for missing objects due to a bug in the interaction with the bucket policy. We therefore treated 403 as 404 and raised `ChunkNotFound`. See #273, 09e100d and 5a7790c for more details.

The current gateway has fixed this, and missing objects now return 404 as expected. Treat 403 the same as 401 and raise `AuthorisationFailed` instead.

I could not find any external user code that caught the old exception, so the update seems safe to roll out.