### PR TITLE
SPR1-1944: Fix bad Bad Chunk bug in DaskLazyIndexer optimisation

### DIFF
--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -117,11 +117,11 @@ class TestChunkStore:
     def test_metadata_validation(self):
         store = ChunkStore()
         # Bad slice specifications
-        assert_raises(BadChunk, store.chunk_metadata, "x", 3)
-        assert_raises(BadChunk, store.chunk_metadata, "x", [3, 2])
-        assert_raises(BadChunk, store.chunk_metadata, "x", slice(10))
-        assert_raises(BadChunk, store.chunk_metadata, "x", [slice(10)])
-        assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 2)])
+        assert_raises(TypeError, store.chunk_metadata, "x", 3)
+        assert_raises(TypeError, store.chunk_metadata, "x", [3, 2])
+        assert_raises(TypeError, store.chunk_metadata, "x", slice(10))
+        assert_raises(TypeError, store.chunk_metadata, "x", [slice(10)])
+        assert_raises(TypeError, store.chunk_metadata, "x", [slice(0, 10, 2)])
         # Chunk mismatch
         assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
                       chunk=np.ones(11))
@@ -242,7 +242,7 @@ class ChunkStoreTestBase:
     def test_put_chunk_noraise(self):
         name = self.array_name('x')
         self.store.create_array(name)
-        result = self.store.put_chunk_noraise(name, (1, 2), [])
+        result = self.store.put_chunk_noraise(name, (slice(1, 2),), np.ones(4))
         assert_is_instance(result, BadChunk)
 
     def test_dask_array_basic(self):


### PR DESCRIPTION
Previously, if the `slices` parameter found on many ChunkStore methods (aka the "chunk ID") was not a sequence of unit-stride `slice` objects with explicit `start` and `stop` attributes, a `BadChunk` was raised. The base class of `BadChunk` is `ValueError`, however, while an incorrect type for `slices` should be a `TypeError` instead.

This came to a head with the recent rework of the dask machinery in the chunk store, in quite a convoluted way... When a single dump is selected in `DaskLazyIndexer`, an extra step of `dask.optimization.cull` is performed. This tries to find some shortcuts during `__getitem__` which ends up calling `__getitem__(0)` on the new `_ArrayLikeGetter` class. Dask `cull` would have tried something else if this raised a `KeyError`, `IndexError` or `TypeError`, but `BadChunk` sails right through.

**Solution:** Turn an invalid `slices` parameter into a plain `TypeError` instead of a `BadChunk` to make `dask` happy and to clarify the purpose of `BadChunk`.

Add unit tests that perform `dataset.vis[0]` as faithfully as possible without invoking `VisibilityDataV4` itself (no unit tests for that yet...). It does pretty much everything at the L0 level (i.e. just not applycal). This should prevent being blindsided by similar dasky bugs in the future.