### PR TITLE
SPR1-2367: Remove IMAGING_WEIGHT column from MS

### DIFF
--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -228,16 +228,6 @@ def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
     dmgroup_spec[dm_group] = dmspec(desc["desc"])
     additional_columns.append(desc)
 
-    dm_group = 'ImagingWeight'
-    shape = [nchan]
-    desc = tables.tablecreatearraycoldesc(
-        "IMAGING_WEIGHT", 0,
-        comment="Weight set by imaging task (e.g. uniform weighting)",
-        options=4, valuetype='float', shape=shape, ndim=len(shape),
-        datamanagergroup=dm_group, datamanagertype='TiledColumnStMan')
-    dmgroup_spec[dm_group] = dmspec(desc["desc"])
-    additional_columns.append(desc)
-
     # Add MODEL_DATA and CORRECTED_DATA if requested
     if model_data:
         dm_group = 'ModelData'
@@ -388,8 +378,6 @@ def populate_main_dict(uvw_coordinates, vis_data, flag_data, weight_data, timest
     # https://casadocs.readthedocs.io/en/stable/notebooks/data_weights.html
     # for further details
     main_dict['SIGMA_SPECTRUM'] = weight_data ** -0.5
-    # Weight set by imaging task (e.g. uniform weighting) (float, 1-dim)
-    # main_dict['IMAGING_WEIGHT'] = np.ones((num_vis_samples, 1), dtype=np.float32)
     # The sampling interval (double)
     main_dict['INTERVAL'] = integrate_length * np.ones(num_vis_samples)
     # The model data column (complex, 3-dim)

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -42,6 +42,7 @@ def open_table(name, readonly=False, verbose=False, **kwargs):
     return tables.table(name, readonly=readonly, ack=verbose, **kwargs)
 
 
+# TODO: change interface to `create_ms(filename, nchan, npol, model_data=False)`
 def create_ms(filename, table_desc=None, dm_info=None):
     """Create an empty MS with the default expected sub-tables and columns."""
     with tables.default_ms(filename, table_desc, dm_info) as main_table:
@@ -100,24 +101,35 @@ MS_TO_NP_TYPE_MAP = {
 }
 
 
+# TODO: make this private and remove `nbl` parameter
 def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
-    """
-    Creates Table Description and Data Manager Information objects that
-    describe a MeasurementSet suitable for holding MeerKAT data.
+    """Describe the structure of a MeerKAT MeasurementSet.
 
-    Creates additional DATA, IMAGING_WEIGHT and possibly
-    MODEL_DATA and CORRECTED_DATA columns.
+    This creates Table Description and Data Manager Information objects
+    that describe a MeasurementSet suitable for holding MeerKAT data,
+    adding various large columns (DATA, WEIGHT_SPECTRUM, SIGMA_SPECTRUM,
+    and possibly MODEL_DATA and CORRECTED_DATA). The output can be used
+    as input to :func:`casacore.tables.default_ms` to create a new empty MS.
 
     Columns are given fixed shapes defined by the arguments to this function.
 
-    :param nbl: Number of baselines.
-    :param nchan: Number of channels.
-    :param ncorr: Number of correlation products.
-    :param model_data: Boolean indicated whether MODEL_DATA and CORRECTED_DATA
-                        should be added to the Measurement Set.
-    :return: Returns a tuple containing a table description describing
-            the extra columns and hypercolumns, as well as a Data Manager
-            description.
+    Parameters
+    ----------
+    nbl : int
+        Number of baselines (not used)
+    nchan : int
+        Number of frequency channels
+    ncorr : int
+        Number of polarisation correlation products (e.g. HH, VV, HV, VH)
+    model_data : bool, optional
+        True if MODEL_DATA and CORRECTED_DATA columns should be added to MS
+
+    Returns
+    -------
+    desc : dict mapping str to dict
+        Table description describing the extra columns and hypercolumns
+    dminfo : dict mapping str to dict
+        Data Manager Information description
     """
     # Columns that will be modified. We want to keep things like their
     # keywords, dims and shapes.


### PR DESCRIPTION
This column is initialised full of zeroes and just takes up space (4 bytes per main table entry, i.e. time-frequency-baseline cell, so about 6-12% overhead). It can be recreated in CASA at a later stage.

The column is a leftover of good old `blank.ms`, which included it along with `MODEL_DATA` and `CORRECTED_DATA`. The latter two columns were made optional in the sneaky 41af4b8 as part of #75 in version 0.9, but this one was missed.

Testing an MS produced by the new code would be much appreciated.