### PR TITLE
SPR1-2674: Fix unit tests on Jenkins

### DIFF
--- a/katdal/test/s3_utils.py
+++ b/katdal/test/s3_utils.py
@@ -122,7 +122,7 @@ class S3Server:
 
         with contextlib.ExitStack() as exit_stack:
             exit_stack.callback(self._process.terminate)
-            health_url = urllib.parse.urljoin(self.url, '/minio/health/live')
+            health_url = urllib.parse.urljoin(self.url, '/minio/health/ready')
             for i in range(100):
                 try:
                     with requests.get(health_url) as resp:

--- a/katdal/test/s3_utils.py
+++ b/katdal/test/s3_utils.py
@@ -104,8 +104,8 @@ class S3Server:
 
         env = os.environ.copy()
         env['MINIO_BROWSER'] = 'off'
-        env['MINIO_ACCESS_KEY'] = self.user.access_key
-        env['MINIO_SECRET_KEY'] = self.user.secret_key
+        env['MINIO_ROOT_USER'] = self.user.access_key
+        env['MINIO_ROOT_PASSWORD'] = self.user.secret_key
         try:
             self._process = subprocess.Popen(
                 [

--- a/katdal/test/s3_utils.py
+++ b/katdal/test/s3_utils.py
@@ -126,7 +126,12 @@ class S3Server:
             for i in range(100):
                 try:
                     with requests.get(health_url) as resp:
-                        if resp.ok:
+                        if (
+                            # Server is up...
+                            resp.ok
+                            # and initialised, therefore ready for requests
+                            and resp.headers.get('X-Minio-Server-Status') != 'offline'
+                        ):
                             break
                 except requests.ConnectionError:
                     pass

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -188,7 +188,10 @@ class ChunkStoreTestBase:
         push = self.store.put_dask_array(array_name, dask_array, offset)
         results = push.compute()
         divisions_per_dim = [len(c) for c in dask_array.chunks]
-        assert_array_equal(results, np.full(divisions_per_dim, None))
+        try:
+            assert_array_equal(results, np.full(divisions_per_dim, None))
+        except AssertionError as exc:
+            raise AssertionError(f"Bad put_dask_array: {var_name} {slices} {results.tolist()}") from exc
 
     def get_dask_array(self, var_name, slices=()):
         """Get (part of) an array from store via dask and compare."""

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -76,6 +76,14 @@ RETRY = Retry(connect=1, read=1, status=3, backoff_factor=0.1,
               raise_on_status=False, status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 READ_PAUSE = 0.1
+# Dummy private key for ES256 algorithm (taken from PyJWT unit tests)
+JWT_PRIVATE_KEY = """
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2nninfu2jMHDwAbn
+9oERUhRADS6duQaJEadybLaa0YShRANCAAQfMBxRZKUYEdy5/fLdGI2tYj6kTr50
+PZPt8jOD23rAR7dhtNpG1ojqopmH0AH5wEXadgk8nLCT4cAPK59Qp9Ek
+-----END PRIVATE KEY-----
+"""
 
 
 @contextlib.contextmanager
@@ -154,13 +162,9 @@ class TestReadArray:
         self._truncate_and_fail_to_read(-1, 2)
 
 
-def encode_jwt(header, payload, signature=86 * 'x'):
-    """Generate JWT token with encoded signature (dummy ES256 one by default)."""
-    # Don't specify algorithm='ES256' here since that needs cryptography package
-    # This generates an Unsecured JWS without a signature: '<header>.<payload>.'
-    header_payload = jwt.encode(payload, '', algorithm='none', headers=header)
-    # Now tack on a signature that nominally matches the header
-    return header_payload + signature
+def encode_jwt(header, payload):
+    """Generate JWT token with encoded signature (expects ES256 algorithm)."""
+    return jwt.encode(payload, JWT_PRIVATE_KEY, headers=header)
 
 
 class TestTokenUtils:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -68,11 +68,11 @@ BUCKET = 'katdal-unittest'
 PREFIX = '1234567890'
 # Pick quick but different timeouts and retries for unit tests:
 #  - The effective connect timeout is 5.0 (initial) + 5.0 (1 retry) = 10 seconds
-#  - The effective read timeout is 0.4 + 0.4 = 0.8 seconds
+#  - The effective read timeout is 2.0 + 3 * 2.0 + 0.1 * (0 + 2 + 4) = 8.6 seconds
 #  - The effective status timeout is 0.1 * (0 + 2 + 4) = 0.6 seconds, or
 #    4 * 0.1 + 0.6 = 1.0 second if the suggestions use SUGGESTED_STATUS_DELAY
-TIMEOUT = (5.0, 0.4)
-RETRY = Retry(connect=1, read=1, status=3, backoff_factor=0.1,
+TIMEOUT = (5.0, 2.0)
+RETRY = Retry(connect=1, read=3, status=3, backoff_factor=0.1,
               raise_on_status=False, status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 READ_PAUSE = 0.1

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -264,6 +264,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
                 shutil.rmtree(entry.path)
         # Also get rid of the cache of verified buckets
         self.store._verified_buckets.clear()
+        print(f"Chunk store: {self.store_url}, S3 server: {self.s3_url}")
 
     def array_name(self, name):
         """Ensure that bucket is authorised and has valid name."""

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -458,6 +458,10 @@ class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):
             if key.lower() not in HOP_HEADERS.union({'date', 'server'}):
                 self.send_header(key, value)
         self.end_headers()
+        # Quit early if there is no data to write to avoid broken pipes (since the client
+        # might stop listening if it knows nothing more is coming, like in a PUT response).
+        if len(content) == 0:
+            return
         if pause:
             self.wfile.write(content[:glitch_location])
             # The wfile object should be an unbuffered _SocketWriter but flush anyway

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,4 @@ setup(name='katdal',
           's3': [],
           's3credentials': ['botocore']
       },
-      tests_require=['nose'])
+      tests_require=['nose', 'cryptography'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,7 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
+cffi==1.15.1                           # via cryptography
 coverage
+cryptography==38.0.3
 nose
+pycparser==2.21                        # via cffi


### PR DESCRIPTION
Since around May 2020 (v0.17 or so) the failure rate of unit tests on Jenkins has gone up a lot. Interestingly, these issues do not occur on my MacBook Pro or on an equivalent Docker container used outside Jenkins (with identical MinIO version etc).

The failures are mostly attributed to:

  - broken pipes in token proxy server
  - read timeouts on MinIO (especially large dask array activity)
  - 503 errors on MinIO startup (typically manifests during `test_chunk_bool_1dim_and_too_small` test)
  - duration check failures (not addressed yet)

While we are at it, make the tests pass with the latest PyJWT.