### PR TITLE
SPR1-2674: Move unit tests from nose to pytest

### DIFF
--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -46,8 +46,8 @@ def _average_visibilities(vis, weight, flag, timeav, chanav, flagav):
         vis_sum = np.empty(bl_step, vis.dtype)
         vis_weight_sum = np.empty(bl_step, vis.dtype)
         weight_sum = np.empty(bl_step, weight.dtype)
-        flag_any = np.empty(bl_step, np.bool_)
-        flag_all = np.empty(bl_step, np.bool_)
+        flag_any = np.empty(bl_step, dtype=bool)
+        flag_all = np.empty(bl_step, dtype=bool)
         for av_t in range(0, av_n_time):
             tstart = av_t * timeav
             for bstart in range(0, n_bl, bl_step):

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -318,7 +318,7 @@ class CategoricalData:
             # Convert slice notation to the corresponding sequence of dump indices
             key = list(range(*key.indices(self.events[-1])))
         # Convert sequence of bools (one per dump) to sequence of indices where key is True
-        elif np.asarray(key).dtype == np.bool and len(np.asarray(key)) == self.events[-1]:
+        elif np.asarray(key).dtype == bool and len(np.asarray(key)) == self.events[-1]:
             key = np.nonzero(key)[0]
         indices = self._lookup(key)
         # Interpret indices as either a sequence of ints or a single int
@@ -352,7 +352,7 @@ class CategoricalData:
     def _bool_per_dump(self, bool_per_value):
         """Turn list of bools per unique value into an array of bools per dump."""
         bool_per_event = np.atleast_1d(np.array(bool_per_value)[self.indices])
-        bool_per_dump = np.empty(self.events[-1], dtype=np.bool)
+        bool_per_dump = np.empty(self.events[-1], dtype=bool)
         for n, (start, end) in enumerate(zip(self.events[:-1], self.events[1:])):
             bool_per_dump[start:end] = bool_per_event[n]
         return bool_per_dump

--- a/katdal/categorical.py
+++ b/katdal/categorical.py
@@ -197,7 +197,7 @@ def unique_in_order(elements, return_inverse=False):
         if return_inverse:
             inverse = [lookup[element] for element in elements]
     # Force inverse to int dtype in case it is an empty array (float otherwise)
-    return (unique_elements, np.array(inverse, dtype=np.int)) \
+    return (unique_elements, np.array(inverse, dtype=int)) \
         if return_inverse else unique_elements
 
 

--- a/katdal/concatdata.py
+++ b/katdal/concatdata.py
@@ -151,7 +151,7 @@ class ConcatenatedLazyIndexer(LazyIndexer):
             # Anything else is advanced indexing via bool or integer sequences
             keep_head = np.atleast_1d(keep_head)
             # A boolean mask is simpler to handle (no repeated or out-of-order indexing) - partition mask over indexers
-            if keep_head.dtype == np.bool and len(keep_head) == len(self):
+            if keep_head.dtype == bool and len(keep_head) == len(self):
                 chunks = []
                 for ind in range(len(self.indexers)):
                     chunk_start = indexer_starts[ind]
@@ -519,7 +519,7 @@ class ConcatenatedDataSet(DataSet):
         self.dump_period = dump_periods[0]
         self._segments = np.cumsum([0] + [len(d.sensor.timestamps) for d in datasets])
         # Keep main time selection mask at top level and ensure that underlying datasets use slice views of main one
-        self._set_keep(time_keep=np.ones(self._segments[-1], dtype=np.bool))
+        self._set_keep(time_keep=np.ones(self._segments[-1], dtype=bool))
         self.start_time = min([d.start_time for d in datasets])
         self.end_time = max([d.end_time for d in datasets])
 

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -418,14 +418,14 @@ class DataSet:
         self.spw = -1
         self.channel_width = 0.0
         self.freqs = self.channel_freqs = np.empty(0)
-        self.channels = np.empty(0, dtype=np.int)
+        self.channels = np.empty(0, dtype=int)
 
         self.dump_period = 0.0
         self.sensor = {}
         self.catalogue = katpoint.Catalogue()
         self.start_time = katpoint.Timestamp(0.0)
         self.end_time = katpoint.Timestamp(0.0)
-        self.dumps = np.empty(0, dtype=np.int)
+        self.dumps = np.empty(0, dtype=int)
         self.scan_indices = []
         self.compscan_indices = []
         self.target_indices = []

--- a/katdal/dataset.py
+++ b/katdal/dataset.py
@@ -742,11 +742,11 @@ class DataSet:
                 self._selection.pop(key, None)
         # Since the number of freqs / corrprods may change due to spw / subarray, create these flags afresh
         if 'F' in reset:
-            self._freq_keep = np.ones(self.spectral_windows[self.spw].num_chans, dtype=np.bool)
+            self._freq_keep = np.ones(self.spectral_windows[self.spw].num_chans, dtype=bool)
             for key in freq_selectors:
                 self._selection.pop(key, None)
         if 'B' in reset:
-            self._corrprod_keep = np.ones(len(self.subarrays[self.subarray].corr_products), dtype=np.bool)
+            self._corrprod_keep = np.ones(len(self.subarrays[self.subarray].corr_products), dtype=bool)
             for key in corrprod_selectors:
                 self._selection.pop(key, None)
         # Now add the new selection criteria to the list (after the existing ones were kept or culled)
@@ -755,10 +755,10 @@ class DataSet:
         for k, v in self._selection.items():
             # Selections that affect time axis
             if k == 'dumps':
-                if np.asarray(v).dtype == np.bool:
+                if np.asarray(v).dtype == bool:
                     self._time_keep &= v
                 else:
-                    dump_keep = np.zeros(len(self._time_keep), dtype=np.bool)
+                    dump_keep = np.zeros(len(self._time_keep), dtype=bool)
                     dump_keep[v] = True
                     self._time_keep &= dump_keep
             elif k == 'timerange':
@@ -768,7 +768,7 @@ class DataSet:
                 self._time_keep &= (self.sensor.timestamps[:] <= end_time)
             elif k in ('scans', 'compscans'):
                 scans = _selection_to_list(v)
-                scan_keep = np.zeros(len(self._time_keep), dtype=np.bool)
+                scan_keep = np.zeros(len(self._time_keep), dtype=bool)
                 scan_sensor = self.sensor.get('Observation/scan_state' if k == 'scans' else 'Observation/label')
                 scan_index_sensor = self.sensor.get(f'Observation/{k[:-1]}_index')
                 for scan in scans:
@@ -781,7 +781,7 @@ class DataSet:
                 self._time_keep &= scan_keep
             elif k == 'targets':
                 targets = v if is_iterable(v) else [v]
-                target_keep = np.zeros(len(self._time_keep), dtype=np.bool)
+                target_keep = np.zeros(len(self._time_keep), dtype=bool)
                 target_index_sensor = self.sensor.get('Observation/target_index')
                 for t in targets:
                     try:
@@ -799,10 +799,10 @@ class DataSet:
                 self._time_keep &= target_keep
             # Selections that affect frequency axis
             elif k == 'channels':
-                if np.asarray(v).dtype == np.bool:
+                if np.asarray(v).dtype == bool:
                     self._freq_keep &= v
                 else:
-                    chan_keep = np.zeros(len(self._freq_keep), dtype=np.bool)
+                    chan_keep = np.zeros(len(self._freq_keep), dtype=bool)
                     chan_keep[v] = True
                     self._freq_keep &= chan_keep
             elif k == 'freqrange':
@@ -824,10 +824,10 @@ class DataSet:
                         all_corrprods = self.subarrays[self.subarray].corr_products
                         v = v.tolist()
                         v = np.array([list(cp) in v for cp in all_corrprods])
-                    if np.asarray(v).dtype == np.bool:
+                    if np.asarray(v).dtype == bool:
                         self._corrprod_keep &= v
                     else:
-                        cp_keep = np.zeros(len(self._corrprod_keep), dtype=np.bool)
+                        cp_keep = np.zeros(len(self._corrprod_keep), dtype=bool)
                         cp_keep[v] = True
                         self._corrprod_keep &= cp_keep
             elif k == 'ants':
@@ -852,7 +852,7 @@ class DataSet:
                 # Proceed if we have a selection
                 if len(pols) > 0:
                     # If given a selection assume we keep nothing
-                    keep = np.zeros(self._corrprod_keep.shape, dtype=np.bool)
+                    keep = np.zeros(self._corrprod_keep.shape, dtype=bool)
 
                     # or separate polarisation selections together
                     for polAB in pols:

--- a/katdal/h5datav1.py
+++ b/katdal/h5datav1.py
@@ -131,7 +131,7 @@ class H5DataV1(DataSet):
         self.dump_period = 1.0 / corr_group.attrs['dump_rate_hz']
         self._segments = np.cumsum([0] + [len(s['timestamps']) for s in self._scan_groups])
         num_dumps = self._segments[-1]
-        self._time_keep = np.ones(num_dumps, dtype=np.bool)
+        self._time_keep = np.ones(num_dumps, dtype=bool)
         data_timestamps = self.timestamps
         if data_timestamps[0] < 1e9:
             logger.warning("File '%s' has invalid first correlator timestamp (%f)", filename, data_timestamps[0])
@@ -421,7 +421,7 @@ class H5DataV1(DataSet):
         """
         # Tell the user that there are no flags in the h5 file
         logger.warning("No flags in HDF5 v1 data files, returning array of zero flags")
-        falses = LazyTransform('falses', lambda data, keep: np.zeros_like(data, dtype=np.bool), dtype=np.bool)
+        falses = LazyTransform('falses', lambda data, keep: np.zeros_like(data, dtype=bool), dtype=bool)
         return ConcatenatedLazyIndexer(self._vis_indexers(), transforms=[falses])
 
     @property

--- a/katdal/h5datav2.py
+++ b/katdal/h5datav2.py
@@ -231,7 +231,7 @@ class H5DataV2(DataSet):
         data_timestamps += 0.5 * self.dump_period + self.time_offset
         if data_timestamps[0] < 1e9:
             logger.warning("File '%s' has invalid first correlator timestamp (%f)", filename, data_timestamps[0])
-        self._time_keep = np.ones(num_dumps, dtype=np.bool)
+        self._time_keep = np.ones(num_dumps, dtype=bool)
         self.start_time = katpoint.Timestamp(data_timestamps[0] - 0.5 * self.dump_period)
         self.end_time = katpoint.Timestamp(data_timestamps[-1] + 0.5 * self.dump_period)
         self._keepdims = keepdims
@@ -563,7 +563,7 @@ class H5DataV2(DataSet):
         time_keep = self._time_keep
         # If there is a duplicate final dump, these lengths don't match -> ignore last dump in file
         if len(time_keep) == len(dataset) - 1:
-            time_keep = np.zeros(len(dataset), dtype=np.bool)
+            time_keep = np.zeros(len(dataset), dtype=bool)
             time_keep[:len(self._time_keep)] = self._time_keep
         stage1 = (time_keep, self._freq_keep, self._corrprod_keep)
 
@@ -646,7 +646,7 @@ class H5DataV2(DataSet):
             """Use flagmask to blank out the flags we don't want."""
             # Then convert uint8 to bool -> if any flag bits set, flag is set
             return np.bool_(np.bitwise_and(self._flags_select, flags))
-        extract = LazyTransform('extract_flags', transform, dtype=np.bool)
+        extract = LazyTransform('extract_flags', transform, dtype=bool)
         return self._vislike_indexer(self._flags, extract)
 
     @property

--- a/katdal/h5datav3.py
+++ b/katdal/h5datav3.py
@@ -320,7 +320,7 @@ class H5DataV3(DataSet):
         self._timestamps += offset_to_middle_of_dump + self.time_offset
         if self._timestamps[0] < 1e9:
             logger.warning("File '%s' has invalid first correlator timestamp (%f)", filename, self._timestamps[0])
-        self._time_keep = np.ones(num_dumps, dtype=np.bool)
+        self._time_keep = np.ones(num_dumps, dtype=bool)
         self.start_time = katpoint.Timestamp(self._timestamps[0] - 0.5 * self.dump_period)
         self.end_time = katpoint.Timestamp(self._timestamps[-1] + 0.5 * self.dump_period)
         # Populate sensor cache with all HDF5 datasets below TelescopeModel group that fit the description of a sensor
@@ -976,7 +976,7 @@ class H5DataV3(DataSet):
         time_keep = self._time_keep
         # If there is a duplicate final dump, these lengths don't match -> ignore last dump in file
         if len(time_keep) == len(dataset) - 1:
-            time_keep = np.zeros(len(dataset), dtype=np.bool)
+            time_keep = np.zeros(len(dataset), dtype=bool)
             time_keep[:len(self._time_keep)] = self._time_keep
         stage1 = (time_keep, self._freq_keep, self._corrprod_keep)[:dims]
 
@@ -1083,7 +1083,7 @@ class H5DataV3(DataSet):
             """Use flagmask to blank out the flags we don't want."""
             # Then convert uint8 to bool -> if any flag bits set, flag is set
             return np.bool_(np.bitwise_and(self._flags_select, flags))
-        extract = LazyTransform('extract_flags', transform, dtype=np.bool)
+        extract = LazyTransform('extract_flags', transform, dtype=bool)
         return self._vislike_indexer(self._flags, extract)
 
     @property

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -299,7 +299,7 @@ class LazyIndexer:
             else:
                 dim_keep = np.atleast_1d(dim_keep)
                 # Turn boolean mask into integer indices (True means keep that index), or None if all is True
-                if dim_keep.dtype == np.bool and len(dim_keep) == dim_len:
+                if dim_keep.dtype == bool and len(dim_keep) == dim_len:
                     dim_keep = np.nonzero(dim_keep)[0] if not dim_keep.all() else None
             self._lookup.append(dim_keep)
         # Shape of data array after first-stage indexing and before transformation
@@ -391,7 +391,7 @@ class LazyIndexer:
                 # Anything else is advanced indexing via bool or integer sequences
                 dim_keep = np.atleast_1d(dim_keep)
                 # Turn boolean mask into integer indices (True means keep that index)
-                if dim_keep.dtype == np.bool and len(dim_keep) == dim_len:
+                if dim_keep.dtype == bool and len(dim_keep) == dim_len:
                     dim_keep = np.nonzero(dim_keep)[0]
                 elif not np.all(dim_keep == np.unique(dim_keep)):
                     raise TypeError('LazyIndexer cannot handle duplicate or unsorted advanced integer indices')

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -95,7 +95,7 @@ MS_TO_NP_TYPE_MAP = {
     'INT': np.int32,
     'FLOAT': np.float32,
     'DOUBLE': np.float64,
-    'BOOLEAN': np.bool,
+    'BOOLEAN': np.bool_,
     'COMPLEX': np.complex64,
     'DCOMPLEX': np.complex128
 }

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -270,7 +270,7 @@ class H5TelstateSensorGetter(RecordSensorGetter):
         values = [_h5_telstate_unpack(s) for s in self._data['value']]
         # Figure out dtype and wrap any objects
         dtype = infer_dtype(values)
-        if dtype == np.object:
+        if dtype == object:
             values = [ComparableArrayWrapper(value) for value in values]
         return SensorData(self.name, timestamp, to_str(np.asarray(values)))
 
@@ -378,7 +378,7 @@ class TelstateSensorGetter(SensorGetter):
     def get(self):
         values, times = zip(*self._telstate.get_range(self.name, st=0))
         dtype = infer_dtype(values)
-        if dtype == np.object:
+        if dtype == object:
             values = [ComparableArrayWrapper(v) for v in values]
         return SensorData(self.name, np.asarray(times), np.asarray(values))
 
@@ -485,7 +485,7 @@ def dummy_sensor_getter(name, value=None, dtype=np.float64, timestamp=0.0):
             value = False
     else:
         dtype = infer_dtype([value])
-    if dtype == np.object:
+    if dtype == object:
         value = ComparableArrayWrapper(value)
     return SimpleSensorGetter(name, np.array([timestamp]), np.array([value]))
 

--- a/katdal/sensordata.py
+++ b/katdal/sensordata.py
@@ -214,7 +214,7 @@ def telstate_decode(raw, no_decode=()):
     The return value is also passed through :func:`to_str`.
     """
     if isinstance(raw, (np.void, np.ndarray)):
-        return to_str(katsdptelstate.decode_value(raw.tostring()))
+        return to_str(katsdptelstate.decode_value(raw.tobytes()))
     raw_str = to_str(raw)
     if raw_str in no_decode:
         return raw_str

--- a/katdal/test/conftest.py
+++ b/katdal/test/conftest.py
@@ -29,10 +29,8 @@ def pytest_runtest_makereport(item, call):
         and report.passed
         and not minimum <= report.duration <= maximum
     ):
-        time_range = [minimum, maximum]
         # Mark test as failed and report the timing discrepancy
         report.outcome = 'failed'
-        report.longrepr = f"""
-        Test took {report.duration:g} seconds, which is outside the range {time_range}
-        """
+        report.longrepr = (f"\nTest took {report.duration:g} seconds, "
+                           f"which is outside the range [{minimum:g}, {maximum:g}]\n")
     return report

--- a/katdal/test/conftest.py
+++ b/katdal/test/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+check_durations = False
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--check-durations",
+        action="store_true",
+        help="Verify how long some tests run (the ones with @duration decorator)",
+    )
+
+
+def pytest_configure(config):
+    # Save option at module level to be imported into standard function decorator,
+    # which seems much simpler than the fixture route.
+    global check_durations
+    check_durations = config.getoption("--check-durations", default=False)

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -21,8 +21,8 @@ from functools import partial
 import dask.array as da
 import katpoint
 import numpy as np
-from nose.tools import assert_raises
 from numpy.testing import assert_allclose, assert_array_equal
+import pytest
 
 from katdal.applycal import (INVALID_GAIN, add_applycal_sensors,
                              apply_flags_correction, apply_vis_correction,
@@ -354,7 +354,7 @@ class TestCalProductAccess:
             del cache[f'Calibration/Products/{CAL_STREAM}/B']
         # All parts gone triggers a KeyError
         del cache[CAL_STREAM + '_product_B' + str(BANDPASS_PARTS - 1)]
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             get_cal_product(cache, CAL_STREAM, 'B')
 
     def test_get_cal_product_gain(self):
@@ -461,17 +461,17 @@ class TestVirtualCorrectionSensors:
 
     def test_unknown_inputs_and_products(self):
         known_input = ANTS[0] + POLS[0]
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/K/unknown')
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/unknown/{known_input}')
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get(f'Calibration/Corrections/{CAL_STREAM}/K_unknown/{known_input}')
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get('Calibration/Corrections/unknown/K/' + known_input)
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get(f'Calibration/Products/{CAL_STREAM}/K_unknown')
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get('Calibration/Products/unknown/K')
 
     def test_indirect_cal_product(self):
@@ -541,7 +541,7 @@ class TestCalcCorrection:
             chunks, self.cache, CORRPRODS, [], FREQS, {'cal': CAL_FREQS})
         assert final_cal_products == []
         assert corrections is None
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             calc_correction(chunks, self.cache, CORRPRODS, ['INVALID'], FREQS,
                             {'cal': CAL_FREQS})
         unknown = CAL_STREAM + '.UNKNOWN'
@@ -551,7 +551,7 @@ class TestCalcCorrection:
         assert final_cal_products == []
         assert corrections is None
         cal_products = CAL_PRODUCTS + [unknown]
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             calc_correction(chunks, self.cache, CORRPRODS, cal_products, FREQS,
                             {'cal': CAL_FREQS}, skip_missing_products=False)
         final_cal_products, corrections = calc_correction(

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -21,7 +21,7 @@ from functools import partial
 import dask.array as da
 import katpoint
 import numpy as np
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_raises
 from numpy.testing import assert_allclose, assert_array_equal
 
 from katdal.applycal import (INVALID_GAIN, add_applycal_sensors,
@@ -261,7 +261,7 @@ def corrections_per_corrprod(dumps, channels, cal_products):
 def assert_categorical_data_equal(actual, desired):
     """Assert that two :class:`CategoricalData` objects are equal."""
     assert_array_equal(actual.events, desired.events)
-    assert_equal(len(actual.unique_values), len(desired.unique_values))
+    assert len(actual.unique_values) == len(desired.unique_values)
     for a, d in zip(actual.unique_values, desired.unique_values):
         assert_array_equal(a, d)
 
@@ -301,7 +301,7 @@ class TestComplexInterp:
     def test_complex64_interpolation(self):
         yi = self.yi_unit.astype(np.complex64)
         y = complex_interp(self.x, self.xi, yi)
-        assert_equal(y.dtype, yi.dtype)
+        assert y.dtype == yi.dtype
         assert_allclose(np.abs(y), 1.0, rtol=1e-7)
 
     def test_left_right(self):
@@ -423,12 +423,12 @@ class TestVirtualCorrectionSensors:
         n_virtuals_before = len(cache.virtual)
         add_applycal_sensors(cache, {}, [], CAL_STREAM, gaincal_flux=None)
         n_virtuals_after = len(cache.virtual)
-        assert_equal(n_virtuals_after, n_virtuals_before)
+        assert n_virtuals_after == n_virtuals_before
         attrs = ATTRS.copy()
         del attrs['center_freq']
         add_applycal_sensors(self.cache, attrs, FREQS, CAL_STREAM, gaincal_flux=None)
         n_virtuals_after = len(cache.virtual)
-        assert_equal(n_virtuals_after, n_virtuals_before)
+        assert n_virtuals_after == n_virtuals_before
 
     def test_delay_sensors(self, stream=CAL_STREAM):
         for n, ant in enumerate(ANTS):
@@ -526,7 +526,7 @@ class TestCalcCorrection:
         chunks = da.core.normalize_chunks((10, 5, -1), shape)
         final_cal_products, corrections = calc_correction(
             chunks, self.cache, CORRPRODS, CAL_PRODUCTS, FREQS, {'cal': CAL_FREQS})
-        assert_equal(set(final_cal_products), set(CAL_PRODUCTS))
+        assert set(final_cal_products) == set(CAL_PRODUCTS)
         corrections = corrections[dump:dump+1, channels].compute()
         expected_corrections = corrections_per_corrprod([dump], channels,
                                                         final_cal_products)
@@ -539,8 +539,8 @@ class TestCalcCorrection:
         chunks = da.core.normalize_chunks((10, 5, -1), shape)
         final_cal_products, corrections = calc_correction(
             chunks, self.cache, CORRPRODS, [], FREQS, {'cal': CAL_FREQS})
-        assert_equal(final_cal_products, [])
-        assert_equal(corrections, None)
+        assert final_cal_products == []
+        assert corrections is None
         with assert_raises(ValueError):
             calc_correction(chunks, self.cache, CORRPRODS, ['INVALID'], FREQS,
                             {'cal': CAL_FREQS})
@@ -548,8 +548,8 @@ class TestCalcCorrection:
         final_cal_products, corrections = calc_correction(
             chunks, self.cache, CORRPRODS, [unknown], FREQS, {'cal': CAL_FREQS},
             skip_missing_products=True)
-        assert_equal(final_cal_products, [])
-        assert_equal(corrections, None)
+        assert final_cal_products == []
+        assert corrections is None
         cal_products = CAL_PRODUCTS + [unknown]
         with assert_raises(KeyError):
             calc_correction(chunks, self.cache, CORRPRODS, cal_products, FREQS,
@@ -557,7 +557,7 @@ class TestCalcCorrection:
         final_cal_products, corrections = calc_correction(
             chunks, self.cache, CORRPRODS, cal_products, FREQS, {'cal': CAL_FREQS},
             skip_missing_products=True)
-        assert_equal(set(final_cal_products), set(CAL_PRODUCTS))
+        assert set(final_cal_products) == set(CAL_PRODUCTS)
         corrections = corrections[dump:dump+1, channels].compute()
         expected_corrections = corrections_per_corrprod([dump], channels,
                                                         final_cal_products)

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -268,7 +268,7 @@ def assert_categorical_data_equal(actual, desired):
 
 class TestComplexInterp:
     """Test the :func:`~katdal.applycal.complex_interp` function."""
-    def setup(self):
+    def setup_method(self):
         self.xi = np.arange(1., 10.)
         self.yi_unit = np.exp(2j * np.pi * self.xi / 10.)
         rs = np.random.RandomState(1234)
@@ -317,7 +317,7 @@ class TestComplexInterp:
 
 class TestCalProductAccess:
     """Test the :func:`~katdal.applycal.*_cal_product` functions."""
-    def setup(self):
+    def setup_method(self):
         self.cache = create_sensor_cache()
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
@@ -370,7 +370,7 @@ class TestCalProductAccess:
 
 class TestCorrectionPerInput:
     """Test the :func:`~katdal.applycal.calc_*_correction` functions."""
-    def setup(self):
+    def setup_method(self):
         self.cache = create_sensor_cache()
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
@@ -414,7 +414,7 @@ class TestCorrectionPerInput:
 
 class TestVirtualCorrectionSensors:
     """Test :func:`~katdal.applycal.add_applycal_sensors` function."""
-    def setup(self):
+    def setup_method(self):
         self.cache = create_sensor_cache()
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 
@@ -485,7 +485,7 @@ class TestVirtualCorrectionSensors:
 class TestCalibrateFlux:
     """Test :func:`~katdal.applycal.calibrate_flux` function."""
 
-    def setup(self):
+    def setup_method(self):
         gains = create_product(create_gain)
         self.sensor = create_categorical_sensor(GAIN_EVENTS, gains, INVALID_GAIN)
         calibrated_gains = create_product(partial(create_gain, fluxes=True))
@@ -513,7 +513,7 @@ class TestCalibrateFlux:
 
 class TestCalcCorrection:
     """Test :func:`~katdal.applycal.calc_correction` function."""
-    def setup(self):
+    def setup_method(self):
         self.cache = create_sensor_cache()
         # Include fluxcal, which is also done in corrections_per_corrprod
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM,
@@ -566,7 +566,7 @@ class TestCalcCorrection:
 
 class TestApplyCal:
     """Test :func:`~katdal.applycal.apply_vis_correction` and friends"""
-    def setup(self):
+    def setup_method(self):
         self.cache = create_sensor_cache()
         add_applycal_sensors(self.cache, ATTRS, FREQS, CAL_STREAM, gaincal_flux=None)
 

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -103,7 +103,8 @@ def test_prune_chunks():
     assert new_chunks == ((10, 10, 10), (2, 2), (40,))
     assert new_index == np.s_[3:24, 0:4, 10:40]
     assert new_offset == (10, 0, 0)
-    pytest.raises(IndexError, _prune_chunks, chunks, np.s_[13:34:2, ::-1, :])
+    with pytest.raises(IndexError):
+        _prune_chunks(chunks, np.s_[13:34:2, ::-1, :])
 
 
 class TestChunkStore:
@@ -111,26 +112,34 @@ class TestChunkStore:
 
     def test_put_get(self):
         store = ChunkStore()
-        pytest.raises(NotImplementedError, store.get_chunk, 1, 2, 3)
-        pytest.raises(NotImplementedError, store.put_chunk, 1, 2, 3)
+        with pytest.raises(NotImplementedError):
+            store.get_chunk(1, 2, 3)
+        with pytest.raises(NotImplementedError):
+            store.put_chunk(1, 2, 3)
 
     def test_metadata_validation(self):
         store = ChunkStore()
         # Bad slice specifications
-        pytest.raises(TypeError, store.chunk_metadata, "x", 3)
-        pytest.raises(TypeError, store.chunk_metadata, "x", [3, 2])
-        pytest.raises(TypeError, store.chunk_metadata, "x", slice(10))
-        pytest.raises(TypeError, store.chunk_metadata, "x", [slice(10)])
-        pytest.raises(TypeError, store.chunk_metadata, "x", [slice(0, 10, 2)])
+        with pytest.raises(TypeError):
+            store.chunk_metadata("x", 3)
+        with pytest.raises(TypeError):
+            store.chunk_metadata("x", [3, 2])
+        with pytest.raises(TypeError):
+            store.chunk_metadata("x", slice(10))
+        with pytest.raises(TypeError):
+            store.chunk_metadata("x", [slice(10)])
+        with pytest.raises(TypeError):
+            store.chunk_metadata("x", [slice(0, 10, 2)])
         # Chunk mismatch
-        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
-                      chunk=np.ones(11))
-        pytest.raises(BadChunk, store.chunk_metadata, "x", (), chunk=np.ones(5))
+        with pytest.raises(BadChunk):
+            store.chunk_metadata("x", [slice(0, 10, 1)], chunk=np.ones(11))
+        with pytest.raises(BadChunk):
+            store.chunk_metadata("x", (), chunk=np.ones(5))
         # Bad dtype
-        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
-                      chunk=np.array(10 * [{}]))
-        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 2)],
-                      dtype=np.dtype(object))
+        with pytest.raises(BadChunk):
+            store.chunk_metadata("x", [slice(0, 10, 1)], chunk=np.array(10 * [{}]))
+        with pytest.raises(BadChunk):
+            store.chunk_metadata("x", [slice(0, 2)], dtype=np.dtype(object))
 
     def test_standard_errors(self):
         error_map = {ZeroDivisionError: StoreUnavailable,
@@ -213,7 +222,8 @@ class ChunkStoreTestBase:
         dtype = np.dtype(float)
         args = (array_name, slices, dtype)
         shape = tuple(s.stop - s.start for s in slices)
-        pytest.raises(ChunkNotFound, self.store.get_chunk, *args)
+        with pytest.raises(ChunkNotFound):
+            self.store.get_chunk(*args)
         zeros = self.store.get_chunk_or_default(*args)
         assert_array_equal(zeros, np.zeros(shape, dtype))
         assert zeros.dtype == dtype
@@ -230,7 +240,8 @@ class ChunkStoreTestBase:
         s = (slice(3, 5),)
         self.put_get_chunk('x', s)
         # Stored object has fewer bytes than expected (and wrong dtype)
-        pytest.raises(BadChunk, self.store.get_chunk, name, s, self.arrays['y'].dtype)
+        with pytest.raises(BadChunk):
+            self.store.get_chunk(name, s, self.arrays['y'].dtype)
 
     def test_chunk_float_3dim_and_too_large(self):
         # Check basic put + get on 3-D float
@@ -238,7 +249,8 @@ class ChunkStoreTestBase:
         s = (slice(3, 7), slice(2, 5), slice(1, 2))
         self.put_get_chunk('y', s)
         # Stored object has more bytes than expected (and wrong dtype)
-        pytest.raises(BadChunk, self.store.get_chunk, name, s, self.arrays['x'].dtype)
+        with pytest.raises(BadChunk):
+            self.store.get_chunk(name, s, self.arrays['x'].dtype)
 
     def test_chunk_zero_size(self):
         # Try a chunk with zero size

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -130,7 +130,7 @@ class TestChunkStore:
         assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
                       chunk=np.array(10 * [{}]))
         assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 2)],
-                      dtype=np.dtype(np.object))
+                      dtype=np.dtype(object))
 
     def test_standard_errors(self):
         error_map = {ZeroDivisionError: StoreUnavailable,
@@ -210,7 +210,7 @@ class ChunkStoreTestBase:
     def test_chunk_non_existent(self):
         array_name = self.array_name('haha')
         slices = (slice(0, 1),)
-        dtype = np.dtype(np.float)
+        dtype = np.dtype(float)
         args = (array_name, slices, dtype)
         shape = tuple(s.stop - s.start for s in slices)
         assert_raises(ChunkNotFound, self.store.get_chunk, *args)

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -147,7 +147,7 @@ class TestChunkStore:
 def generate_arrays():
     """Generate arrays with differently sized dtypes and dimensions as test data."""
     return dict(
-        x=np.ones(10, dtype=np.bool),
+        x=np.ones(10, dtype=bool),
         y=np.arange(96.).reshape(8, 6, 2),
         z=np.array(2.),
         big_y=np.arange(960.).reshape(8, 60, 2),

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -18,8 +18,8 @@
 
 import dask.array as da
 import numpy as np
-from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
+import pytest
 
 from katdal.chunkstore import (BadChunk, ChunkNotFound, ChunkStore,
                                PlaceholderChunk, StoreUnavailable,
@@ -103,7 +103,7 @@ def test_prune_chunks():
     assert new_chunks == ((10, 10, 10), (2, 2), (40,))
     assert new_index == np.s_[3:24, 0:4, 10:40]
     assert new_offset == (10, 0, 0)
-    assert_raises(IndexError, _prune_chunks, chunks, np.s_[13:34:2, ::-1, :])
+    pytest.raises(IndexError, _prune_chunks, chunks, np.s_[13:34:2, ::-1, :])
 
 
 class TestChunkStore:
@@ -111,35 +111,35 @@ class TestChunkStore:
 
     def test_put_get(self):
         store = ChunkStore()
-        assert_raises(NotImplementedError, store.get_chunk, 1, 2, 3)
-        assert_raises(NotImplementedError, store.put_chunk, 1, 2, 3)
+        pytest.raises(NotImplementedError, store.get_chunk, 1, 2, 3)
+        pytest.raises(NotImplementedError, store.put_chunk, 1, 2, 3)
 
     def test_metadata_validation(self):
         store = ChunkStore()
         # Bad slice specifications
-        assert_raises(TypeError, store.chunk_metadata, "x", 3)
-        assert_raises(TypeError, store.chunk_metadata, "x", [3, 2])
-        assert_raises(TypeError, store.chunk_metadata, "x", slice(10))
-        assert_raises(TypeError, store.chunk_metadata, "x", [slice(10)])
-        assert_raises(TypeError, store.chunk_metadata, "x", [slice(0, 10, 2)])
+        pytest.raises(TypeError, store.chunk_metadata, "x", 3)
+        pytest.raises(TypeError, store.chunk_metadata, "x", [3, 2])
+        pytest.raises(TypeError, store.chunk_metadata, "x", slice(10))
+        pytest.raises(TypeError, store.chunk_metadata, "x", [slice(10)])
+        pytest.raises(TypeError, store.chunk_metadata, "x", [slice(0, 10, 2)])
         # Chunk mismatch
-        assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
+        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
                       chunk=np.ones(11))
-        assert_raises(BadChunk, store.chunk_metadata, "x", (), chunk=np.ones(5))
+        pytest.raises(BadChunk, store.chunk_metadata, "x", (), chunk=np.ones(5))
         # Bad dtype
-        assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
+        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 10, 1)],
                       chunk=np.array(10 * [{}]))
-        assert_raises(BadChunk, store.chunk_metadata, "x", [slice(0, 2)],
+        pytest.raises(BadChunk, store.chunk_metadata, "x", [slice(0, 2)],
                       dtype=np.dtype(object))
 
     def test_standard_errors(self):
         error_map = {ZeroDivisionError: StoreUnavailable,
                      LookupError: ChunkNotFound}
         store = ChunkStore(error_map)
-        with assert_raises(StoreUnavailable):
+        with pytest.raises(StoreUnavailable):
             with store._standard_errors():
                 1 / 0
-        with assert_raises(ChunkNotFound):
+        with pytest.raises(ChunkNotFound):
             with store._standard_errors():
                 {}['ha']
 
@@ -213,7 +213,7 @@ class ChunkStoreTestBase:
         dtype = np.dtype(float)
         args = (array_name, slices, dtype)
         shape = tuple(s.stop - s.start for s in slices)
-        assert_raises(ChunkNotFound, self.store.get_chunk, *args)
+        pytest.raises(ChunkNotFound, self.store.get_chunk, *args)
         zeros = self.store.get_chunk_or_default(*args)
         assert_array_equal(zeros, np.zeros(shape, dtype))
         assert zeros.dtype == dtype
@@ -230,7 +230,7 @@ class ChunkStoreTestBase:
         s = (slice(3, 5),)
         self.put_get_chunk('x', s)
         # Stored object has fewer bytes than expected (and wrong dtype)
-        assert_raises(BadChunk, self.store.get_chunk, name, s, self.arrays['y'].dtype)
+        pytest.raises(BadChunk, self.store.get_chunk, name, s, self.arrays['y'].dtype)
 
     def test_chunk_float_3dim_and_too_large(self):
         # Check basic put + get on 3-D float
@@ -238,7 +238,7 @@ class ChunkStoreTestBase:
         s = (slice(3, 7), slice(2, 5), slice(1, 2))
         self.put_get_chunk('y', s)
         # Stored object has more bytes than expected (and wrong dtype)
-        assert_raises(BadChunk, self.store.get_chunk, name, s, self.arrays['x'].dtype)
+        pytest.raises(BadChunk, self.store.get_chunk, name, s, self.arrays['x'].dtype)
 
     def test_chunk_zero_size(self):
         # Try a chunk with zero size
@@ -286,7 +286,7 @@ class ChunkStoreTestBase:
 
             pull = self.store.get_dask_array(array_name, dask_array.chunks,
                                              dask_array.dtype, offset, errors='raise')
-            with assert_raises(ChunkNotFound):
+            with pytest.raises(ChunkNotFound):
                 pull.compute()
 
             pull = self.store.get_dask_array(array_name, dask_array.chunks,

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -20,7 +20,6 @@ import time
 
 import numpy as np
 import dask.array as da
-from nose.tools import assert_less
 
 from katdal.chunkstore_dict import DictChunkStore
 from katdal.test.test_chunkstore import ChunkStoreTestBase
@@ -49,7 +48,7 @@ def test_basic_overheads():
     dx = store1.get_dask_array('x', chunks, float)
     py = store2.put_dask_array('y', dx)
     setup_duration = time.process_time() - start_time
-    assert_less(setup_duration, 1.0)
+    assert setup_duration < 1.0
     # Use basic array copy as a reference
     start_time = time.process_time()
     y[:] = x
@@ -58,5 +57,5 @@ def test_basic_overheads():
     start_time = time.process_time()
     success = py.compute()
     dask_duration = time.process_time() - start_time
-    assert_less(dask_duration, 10 * copy_duration)
+    assert dask_duration < 10 * copy_duration
     np.testing.assert_equal(success, None)

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -26,7 +26,7 @@ from katdal.test.test_chunkstore import ChunkStoreTestBase
 
 
 class TestDictChunkStore(ChunkStoreTestBase):
-    def setup(self):
+    def setup_method(self):
         self.store = DictChunkStore(**vars(self))
         # This store is prepopulated so missing chunks can't be checked
         self.preloaded_chunks = True

--- a/katdal/test/test_chunkstore_dict.py
+++ b/katdal/test/test_chunkstore_dict.py
@@ -22,12 +22,13 @@ import numpy as np
 import dask.array as da
 
 from katdal.chunkstore_dict import DictChunkStore
-from katdal.test.test_chunkstore import ChunkStoreTestBase
+from katdal.test.test_chunkstore import ChunkStoreTestBase, generate_arrays
 
 
 class TestDictChunkStore(ChunkStoreTestBase):
     def setup_method(self):
-        self.store = DictChunkStore(**vars(self))
+        self.arrays = generate_arrays()
+        self.store = DictChunkStore(**self.arrays)
         # This store is prepopulated so missing chunks can't be checked
         self.preloaded_chunks = True
 

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -49,7 +49,8 @@ class TestNpyFileChunkStore(ChunkStoreTestBase):
                 shutil.rmtree(entry.path)
 
     def test_store_unavailable(self):
-        pytest.raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')
+        with pytest.raises(StoreUnavailable):
+            NpyFileChunkStore('hahahahahaha')
 
 
 class TestNpyFileChunkStoreDirectWrite(TestNpyFileChunkStore):

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -21,7 +21,7 @@ import shutil
 import tempfile
 
 from nose import SkipTest
-from nose.tools import assert_raises
+import pytest
 
 from katdal.chunkstore import StoreUnavailable
 from katdal.chunkstore_npy import NpyFileChunkStore
@@ -49,7 +49,7 @@ class TestNpyFileChunkStore(ChunkStoreTestBase):
                 shutil.rmtree(entry.path)
 
     def test_store_unavailable(self):
-        assert_raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')
+        pytest.raises(StoreUnavailable, NpyFileChunkStore, 'hahahahahaha')
 
 
 class TestNpyFileChunkStoreDirectWrite(TestNpyFileChunkStore):

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -41,7 +41,7 @@ class TestNpyFileChunkStore(ChunkStoreTestBase):
     def teardown_class(cls):
         shutil.rmtree(cls.tempdir)
 
-    def setup(self):
+    def setup_method(self):
         # Clean out data created by previous tests
         for entry in os.scandir(self.tempdir):
             if not entry.name.startswith('.') and entry.is_dir():

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -20,7 +20,6 @@ import os
 import shutil
 import tempfile
 
-from nose import SkipTest
 import pytest
 
 from katdal.chunkstore import StoreUnavailable
@@ -64,5 +63,5 @@ class TestNpyFileChunkStoreDirectWrite(TestNpyFileChunkStore):
             cls.store = NpyFileChunkStore(cls.tempdir, direct_write=True)
         except StoreUnavailable as e:
             if 'not supported' in str(e):
-                raise SkipTest(str(e))
+                pytest.skip(str(e))
             raise

--- a/katdal/test/test_chunkstore_npy.py
+++ b/katdal/test/test_chunkstore_npy.py
@@ -25,7 +25,7 @@ from nose.tools import assert_raises
 
 from katdal.chunkstore import StoreUnavailable
 from katdal.chunkstore_npy import NpyFileChunkStore
-from katdal.test.test_chunkstore import ChunkStoreTestBase
+from katdal.test.test_chunkstore import ChunkStoreTestBase, generate_arrays
 
 
 class TestNpyFileChunkStore(ChunkStoreTestBase):
@@ -34,6 +34,7 @@ class TestNpyFileChunkStore(ChunkStoreTestBase):
     @classmethod
     def setup_class(cls):
         """Create temp dir to store NPY files and build ChunkStore on that."""
+        cls.arrays = generate_arrays()
         cls.tempdir = tempfile.mkdtemp()
         cls.store = NpyFileChunkStore(cls.tempdir)
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -338,7 +338,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
 
     def test_missing_or_empty_buckets(self):
         slices = (slice(0, 1),)
-        dtype = np.dtype(np.float)
+        dtype = np.dtype(float)
         # Without create_array the bucket is missing
         with assert_raises(StoreUnavailable):
             self.store.get_chunk(f'{BUCKET}-missing/x', slices, dtype)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -338,7 +338,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         y = reader.get_chunk('public/x', slices, x.dtype)
         np.testing.assert_array_equal(x, y)
 
-    @duration(0.1)
+    @duration(0.0, 0.1 + TEST_DURATION_TOLERANCE)
     def test_store_unavailable_unresponsive_server(self):
         host = '127.0.0.1'
         with get_free_port(host) as port:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -75,7 +75,7 @@ RETRY = Retry(connect=1, read=3, status=3, backoff_factor=0.1,
               raise_on_status=False, status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 READ_PAUSE = 0.1
-TEST_DURATION_TOLERANCE = 0.2
+TEST_DURATION_TOLERANCE = 0.3
 # Dummy private key for ES256 algorithm (taken from PyJWT unit tests)
 JWT_PRIVATE_KEY = """
 -----BEGIN PRIVATE KEY-----
@@ -617,7 +617,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         # 0.9 - success!
         self.store.get_chunk(array_name, slices, chunk.dtype)
 
-    @duration(0.9, 0.9 + 0.4)
+    @duration(1.0)
     def test_persistent_server_errors(self):
         chunk, slices, array_name = self._put_chunk(
             'please-respond-with-502-for-1.2-seconds')
@@ -647,7 +647,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
         assert_array_equal(chunk_retrieved, chunk, 'Truncated read not recovered')
 
-    @duration(0.6, 0.6 + 0.4)
+    @duration(0.6)
     def test_persistent_truncated_reads(self):
         chunk, slices, array_name = self._put_chunk(
             'please-truncate-read-after-60-bytes-for-0.8-seconds')

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -47,8 +47,7 @@ import numpy as np
 import requests
 from katsdptelstate.rdb_writer import RDBWriter
 from nose import SkipTest
-from nose.tools import (assert_equal, assert_in, assert_not_in, assert_raises,
-                        timed)
+from nose.tools import assert_raises, timed
 from numpy.testing import assert_array_equal
 from urllib3.util.retry import Retry
 
@@ -111,7 +110,7 @@ class TestReadArray:
         out = read_array(fp)
         np.testing.assert_equal(array, out)
         # Check that Fortran order was preserved
-        assert_equal(array.strides, out.strides)
+        assert array.strides == out.strides
 
     def testSimple(self):
         self._test(np.arange(20))
@@ -175,7 +174,7 @@ class TestTokenUtils:
         payload = {'exp': 9234567890, 'iss': 'kat', 'prefix': ['123']}
         token = encode_jwt(payload)
         claims = decode_jwt(token)
-        assert_equal(payload, claims)
+        assert payload == claims
         # Token has invalid characters
         assert_raises(InvalidToken, decode_jwt, '** bad token **')
         # Token has invalid structure
@@ -202,7 +201,7 @@ class TestTokenUtils:
         # Check that it works without expiry date too
         del payload['exp']
         claims = decode_jwt(encode_jwt(payload))
-        assert_equal(payload, claims)
+        assert payload == claims
 
 
 class TestS3ChunkStore(ChunkStoreTestBase):
@@ -348,10 +347,10 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             self.store.get_chunk(f'{BUCKET}-empty/x', slices, dtype)
         # Check that the standard bucket has not been verified yet
         bucket_url = urllib.parse.urljoin(self.store._url, BUCKET)
-        assert_not_in(bucket_url, self.store._verified_buckets)
+        assert bucket_url not in self.store._verified_buckets
         # Check that the standard bucket remains verified after initial check
         self.test_chunk_non_existent()
-        assert_in(bucket_url, self.store._verified_buckets)
+        assert bucket_url in self.store._verified_buckets
 
 
 class _TokenHTTPProxyHandler(http.server.BaseHTTPRequestHandler):

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -55,6 +55,7 @@ from katdal.chunkstore_s3 import (_DEFAULT_SERVER_GLITCHES, InvalidToken,
                                   S3ChunkStore, TruncatedRead, _AWSAuth,
                                   AuthorisationFailed, decode_jwt, read_array)
 from katdal.datasources import TelstateDataSource
+from katdal.test.conftest import check_durations
 from katdal.test.s3_utils import MissingProgram, S3Server, S3User
 from katdal.test.test_chunkstore import ChunkStoreTestBase, generate_arrays
 from katdal.test.test_datasources import (assert_telstate_data_source_equal,
@@ -227,6 +228,7 @@ def duration(minimum, maximum=None):
           time.sleep(.4)
 
     The default `maximum` differs from `minimum` by a small tolerance.
+    The check only happens if the module-level variable `check_durations` is True.
     """
     if maximum is None:
         maximum = minimum + TEST_DURATION_TOLERANCE
@@ -236,7 +238,7 @@ def duration(minimum, maximum=None):
             start = time.time()
             result = func(*arg, **kw)
             duration = time.time() - start
-            if not minimum <= duration <= maximum:
+            if check_durations and not minimum <= duration <= maximum:
                 raise UnexpectedDuration(f"Test took {duration:g} seconds, which is "
                                          f"outside the range [{minimum:g}, {maximum:g}]")
             return result

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -46,7 +46,6 @@ import katsdptelstate
 import numpy as np
 import requests
 from katsdptelstate.rdb_writer import RDBWriter
-from nose import SkipTest
 from nose.tools import timed
 import pytest
 from numpy.testing import assert_array_equal
@@ -229,7 +228,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             # as the socket held open by get_free_port, Mac OS is not.
             cls.minio = S3Server(host, port, pathlib.Path(cls.tempdir), S3User(*cls.credentials))
         except MissingProgram as exc:
-            raise SkipTest(str(exc))
+            pytest.skip(str(exc))
         return cls.minio.url
 
     @classmethod

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -252,7 +252,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             cls.minio.close()
         shutil.rmtree(cls.tempdir)
 
-    def setup(self):
+    def setup_method(self):
         # The server is a class-level fixture (for efficiency), so state can
         # leak between tests. Prevent that by removing any existing objects.
         # It's easier to do that by manipulating the filesystem directly than

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -235,9 +235,9 @@ def duration(minimum, maximum=None):
 
     def decorate(func):
         def newfunc(*arg, **kw):
-            start = time.time()
+            start = time.monotonic()
             result = func(*arg, **kw)
-            duration = time.time() - start
+            duration = time.monotonic() - start
             if check_durations and not minimum <= duration <= maximum:
                 raise UnexpectedDuration(f"Test took {duration:g} seconds, which is "
                                          f"outside the range [{minimum:g}, {maximum:g}]")

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -57,7 +57,7 @@ from katdal.chunkstore_s3 import (_DEFAULT_SERVER_GLITCHES, InvalidToken,
                                   AuthorisationFailed, decode_jwt, read_array)
 from katdal.datasources import TelstateDataSource
 from katdal.test.s3_utils import MissingProgram, S3Server, S3User
-from katdal.test.test_chunkstore import ChunkStoreTestBase
+from katdal.test.test_chunkstore import ChunkStoreTestBase, generate_arrays
 from katdal.test.test_datasources import (assert_telstate_data_source_equal,
                                           make_fake_data_source)
 
@@ -233,6 +233,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
     @classmethod
     def setup_class(cls):
         """Start minio service running on temp dir, and ChunkStore on that."""
+        cls.arrays = generate_arrays()
         cls.credentials = ('access*key', 'secret*key')
         cls.tempdir = tempfile.mkdtemp()
         cls.minio = None
@@ -553,7 +554,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         var_name = 'x'
         slices = (slice(3, 5),)
         array_name = self.array_name(var_name)
-        chunk = getattr(self, var_name)[slices]
+        chunk = self.arrays[var_name][slices]
         self.store.create_array(array_name)
         self.store.put_chunk(array_name, slices, chunk)
         return chunk, slices, self.store.join(array_name, suggestion)

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -17,7 +17,7 @@
 """Tests for :py:mod:`katdal.concatdata`."""
 
 import numpy as np
-from nose.tools import assert_raises
+import pytest
 
 from katdal.categorical import CategoricalData
 from katdal.concatdata import ConcatenatedSensorCache
@@ -102,7 +102,7 @@ class TestConcatenatedSensorCache:
         np.testing.assert_array_equal(values.value, [3.0])
 
     def test_missing_sensor(self):
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache['sir_not_appearing_in_this_cache']
 
     def test_partially_extract(self):

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -17,7 +17,7 @@
 """Tests for :py:mod:`katdal.concatdata`."""
 
 import numpy as np
-from nose.tools import assert_equal, assert_in, assert_not_in, assert_raises
+from nose.tools import assert_raises
 
 from katdal.categorical import CategoricalData
 from katdal.concatdata import ConcatenatedSensorCache
@@ -63,7 +63,7 @@ class TestConcatenatedSensorCache:
 
     def test_categorical(self):
         data = self.cache.get('cat')
-        assert_equal(data.unique_values, ['hello', 'world', 'again'])
+        assert data.unique_values == ['hello', 'world', 'again']
         H = 'hello'
         W = 'world'
         A = 'again'
@@ -114,7 +114,7 @@ class TestConcatenatedSensorCache:
         data = CategoricalData(['x', 'y', 'x'], [0, 2, 4, 8])
         self.cache['dog'] = data
         ans = self.cache.get('dog')
-        assert_equal(data.unique_values, ans.unique_values)
+        assert data.unique_values == ans.unique_values
         np.testing.assert_array_equal(data.events, ans.events)
         np.testing.assert_array_equal(data.indices, ans.indices)
 
@@ -125,14 +125,14 @@ class TestConcatenatedSensorCache:
         np.testing.assert_array_equal(data, ans)
 
     def test_len(self):
-        assert_equal(len(self.cache), 4)
+        assert len(self.cache) == 4
 
     def test_keys(self):
-        assert_equal(sorted(self.cache.keys()), ['cat', 'float_missing', 'foo', 'int_missing'])
+        assert sorted(self.cache.keys()) == ['cat', 'float_missing', 'foo', 'int_missing']
 
     def test_contains(self):
-        assert_in('cat', self.cache)
-        assert_in('float_missing', self.cache)
-        assert_in('int_missing', self.cache)
-        assert_not_in('dog', self.cache)
-        assert_not_in('', self.cache)
+        assert 'cat' in self.cache
+        assert 'float_missing' in self.cache
+        assert 'int_missing' in self.cache
+        assert 'dog' not in self.cache
+        assert '' not in self.cache

--- a/katdal/test/test_concatdata.py
+++ b/katdal/test/test_concatdata.py
@@ -33,7 +33,7 @@ class TestConcatenatedSensorCache:
             cache_data[name] = sd
         return SensorCache(cache_data, timestamps, 2.0)
 
-    def setup(self):
+    def setup_method(self):
         self.timestamps1 = np.arange(100.0, 110.0, 2.0)
         self.timestamps2 = np.arange(1000.0, 1006.0, 2.0)
         sensors1 = [

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -112,7 +112,7 @@ def test_selection_to_list():
 
 
 class TestVirtualSensors:
-    def setup(self):
+    def setup_method(self):
         self.target = Target('PKS1934-638, radec, 19:39, -63:42')
         self.antennas = [Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
                                  '-8.264 -207.29 8.5965'),

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -59,9 +59,9 @@ class MinimalDataSet(DataSet):
         sensors['Observation/label'] = constant_sensor('track')
 
         self._timestamps = timestamps
-        self._time_keep = np.full(num_dumps, True, dtype=np.bool_)
-        self._freq_keep = np.full(num_chans, True, dtype=np.bool_)
-        self._corrprod_keep = np.full(num_corrprods, True, dtype=np.bool_)
+        self._time_keep = np.full(num_dumps, True, dtype=bool)
+        self._freq_keep = np.full(num_chans, True, dtype=bool)
+        self._corrprod_keep = np.full(num_corrprods, True, dtype=bool)
         self.dump_period = dump_period
         self.start_time = Timestamp(timestamps[0] - 0.5 * dump_period)
         self.end_time = Timestamp(timestamps[-1] + 0.5 * dump_period)

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 from katpoint import Antenna, Target, Timestamp, rad2deg
-from nose.tools import assert_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from katdal.categorical import CategoricalData
@@ -80,36 +79,36 @@ class MinimalDataSet(DataSet):
 
 def test_parse_url_or_path():
     # Normal URLs and empty strings pass right through
-    assert_equal(parse_url_or_path('https://archive/file').geturl(), 'https://archive/file')
-    assert_equal(parse_url_or_path('').geturl(), '')
+    assert parse_url_or_path('https://archive/file').geturl() == 'https://archive/file'
+    assert parse_url_or_path('').geturl() == ''
     # Relative paths are turned into absolute paths and gain a 'file' scheme
     relative_file_url = parse_url_or_path('dir/filename.rdb')
-    assert_equal(relative_file_url.scheme, 'file')
+    assert relative_file_url.scheme == 'file'
     parts = relative_file_url.path.rpartition('dir/filename.rdb')
     assert len(parts[0]) > 0
-    assert_equal(parts[1], 'dir/filename.rdb')
+    assert parts[1] == 'dir/filename.rdb'
     assert len(parts[2]) == 0
     # Absolute paths remain the same (just gaining a 'file' scheme)
     absolute_file_url = parse_url_or_path('/dir/filename.rdb')
-    assert_equal(absolute_file_url.scheme, 'file')
-    assert_equal(absolute_file_url.path, '/dir/filename.rdb')
+    assert absolute_file_url.scheme == 'file'
+    assert absolute_file_url.path == '/dir/filename.rdb'
 
 
 def test_selection_to_list():
     # Empty
-    assert_equal(_selection_to_list(''), [])
-    assert_equal(_selection_to_list([]), [])
+    assert _selection_to_list('') == []
+    assert _selection_to_list([]) == []
     # Names
-    assert_equal(_selection_to_list('a,b,c'), ['a', 'b', 'c'])
-    assert_equal(_selection_to_list('a, b,c'), ['a', 'b', 'c'])
-    assert_equal(_selection_to_list(['a', 'b', 'c']), ['a', 'b', 'c'])
-    assert_equal(_selection_to_list(('a', 'b', 'c')), ['a', 'b', 'c'])
-    assert_equal(_selection_to_list('a'), ['a'])
+    assert _selection_to_list('a,b,c') == ['a', 'b', 'c']
+    assert _selection_to_list('a, b,c') == ['a', 'b', 'c']
+    assert _selection_to_list(['a', 'b', 'c']) == ['a', 'b', 'c']
+    assert _selection_to_list(('a', 'b', 'c')) == ['a', 'b', 'c']
+    assert _selection_to_list('a') == ['a']
     # Objects
-    assert_equal(_selection_to_list([1, 2, 3]), [1, 2, 3])
-    assert_equal(_selection_to_list(1), [1])
+    assert _selection_to_list([1, 2, 3]) == [1, 2, 3]
+    assert _selection_to_list(1) == [1]
     # Groups
-    assert_equal(_selection_to_list('all', all=['a', 'b']), ['a', 'b'])
+    assert _selection_to_list('all', all=['a', 'b']) == ['a', 'b']
 
 
 class TestVirtualSensors:
@@ -132,7 +131,7 @@ class TestVirtualSensors:
 
     def test_timestamps(self):
         mjd = Timestamp(self.timestamps[0]).to_mjd()
-        assert_equal(self.dataset.mjd[0], mjd)
+        assert self.dataset.mjd[0] == mjd
         lst = self.array_ant.local_sidereal_time(self.timestamps)
         # Convert LST from radians (katpoint) to hours (katdal)
         assert_array_equal(self.dataset.lst, lst * (12 / np.pi))

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -124,12 +124,12 @@ def assert_telstate_data_source_equal(source1, source2):
 
 
 class TestTelstateDataSource:
-    def setup(self):
+    def setup_method(self):
         self.tempdir = tempfile.mkdtemp()
         self.store = NpyFileChunkStore(self.tempdir)
         self.telstate = katsdptelstate.TelescopeState()
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.tempdir)
 
     def test_basic_timestamps(self):

--- a/katdal/test/test_datasources.py
+++ b/katdal/test/test_datasources.py
@@ -24,7 +24,7 @@ import urllib.parse
 import katsdptelstate
 import numpy as np
 from katsdptelstate.rdb_writer import RDBWriter
-from nose.tools import assert_raises
+import pytest
 
 from katdal.chunkstore_npy import NpyFileChunkStore
 from katdal.datasources import (DataSourceNotFound, TelstateDataSource,
@@ -154,11 +154,11 @@ class TestTelstateDataSource:
     def test_bad_preselect(self):
         view, cbid, sn, l0_data, l1_flags_data = \
             make_fake_data_source(self.telstate, self.store, (20, 64, 40))
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             TelstateDataSource(view, cbid, sn, self.store, preselect=dict(dumps=np.s_[[1, 2]]))
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             TelstateDataSource(view, cbid, sn, self.store, preselect=dict(dumps=np.s_[5:0:-1]))
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             TelstateDataSource(view, cbid, sn, self.store, preselect=dict(frequencies=np.s_[:]))
 
     def test_preselect(self):
@@ -249,7 +249,7 @@ class TestTelstateDataSource:
         l1_flags_shape = (20, 8, 40)
         view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, l0_shape,
                                                      l1_flags_shape=l1_flags_shape)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             TelstateDataSource(view, cbid, sn, self.store)
 
     def test_van_vleck(self):
@@ -265,7 +265,7 @@ class TestTelstateDataSource:
         expected_vis = correct_autocorr_quantisation(raw_vis, view['bls_ordering'])
         np.testing.assert_array_equal(corrected_vis.compute(), expected_vis.compute())
         # Check parameter validation
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             TelstateDataSource(view, cbid, sn, self.store, van_vleck='blah')
 
     def test_construction_from_url(self):
@@ -289,9 +289,9 @@ class TestTelstateDataSource:
         source_from_url = TelstateDataSource.from_url(url, chunk_store=self.store)
         assert_telstate_data_source_equal(source_from_url, source_direct)
         # Check invalid URLs
-        with assert_raises(DataSourceNotFound):
+        with pytest.raises(DataSourceNotFound):
             open_data_source('ftp://unsupported')
-        with assert_raises(DataSourceNotFound):
+        with pytest.raises(DataSourceNotFound):
             open_data_source(rdb_filename[:-4])
         source_name = f'{cbid}_{sn}'
         assert source_from_file.name == source_name

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -66,7 +66,7 @@ class TestRangeToSlice:
 
 class TestSimplifyIndex:
     """Test the :func:`~katdal.lazy_indexer._simplify_index` function."""
-    def setup(self):
+    def setup_method(self):
         self.shape = (3, 4, 5)
         self.data = np.arange(np.product(self.shape)).reshape(self.shape)
 
@@ -176,7 +176,7 @@ UNEVEN = [False, True, True, True, False, False, True, True, False, True]
 
 class TestDaskGetitem:
     """Test the :func:`~katdal.lazy_indexer.dask_getitem` function."""
-    def setup(self):
+    def setup_method(self):
         shape = (10, 20, 30, 40)
         self.data = np.arange(np.product(shape)).reshape(shape)
         self.data_dask = da.from_array(self.data, chunks=(2, 5, 2, 5))
@@ -246,7 +246,7 @@ class TestDaskGetitem:
 
 class TestDaskLazyIndexer:
     """Test the :class:`~katdal.lazy_indexer.DaskLazyIndexer` class."""
-    def setup(self):
+    def setup_method(self):
         shape = (10, 20, 30)
         self.data = np.arange(np.product(shape)).reshape(shape)
         self.data_dask = da.from_array(self.data, chunks=(1, 4, 5), name='x')

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -21,7 +21,7 @@ from numbers import Integral
 
 import dask.array as da
 import numpy as np
-from nose.tools import assert_raises
+import pytest
 
 from katdal.lazy_indexer import (DaskLazyIndexer, _dask_oindex,
                                  _range_to_slice, _simplify_index,
@@ -52,15 +52,15 @@ class TestRangeToSlice:
         self._check_slice(0, 10, 5)   # any two elements (has stop = 2 * step)
 
     def test_negative_elements(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             _range_to_slice([-1, -2, -3, -4])
 
     def test_zero_increments(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             _range_to_slice([1, 1, 1, 1])
 
     def test_uneven_increments(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             _range_to_slice([1, 1, 2, 3, 5, 8, 13])
 
 
@@ -77,10 +77,10 @@ class TestSimplifyIndex:
         np.testing.assert_array_equal(actual, expected)
 
     def _test_index_error(self, indices):
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             simplified = _simplify_index(indices, self.data.shape)
             self.data[simplified]
-        with assert_raises(IndexError):
+        with pytest.raises(IndexError):
             self.data[indices]
 
     def test_1d(self):

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -21,7 +21,7 @@ from numbers import Integral
 
 import dask.array as da
 import numpy as np
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_raises
 
 from katdal.lazy_indexer import (DaskLazyIndexer, _dask_oindex,
                                  _range_to_slice, _simplify_index,
@@ -39,7 +39,7 @@ class TestRangeToSlice:
         s = slice(start, stop, step)
         length = max(start, 0 if stop is None else stop) + 1
         r = slice_to_range(s, length)
-        assert_equal(_range_to_slice(r), s)
+        assert _range_to_slice(r) == s
 
     def test_basic_slices(self):
         # For testing both `start` and `stop` need to be non-negative
@@ -264,7 +264,7 @@ class TestDaskLazyIndexer:
         indexer = DaskLazyIndexer(self.data_dask, transforms=transforms)
         expected = 'x | transform1 | <lambda> | Transform3 | transform1'
         expected += f' -> {indexer.shape} {indexer.dtype}'
-        assert_equal(str(indexer), expected)
+        assert str(indexer) == expected
         # Simply exercise repr - no need to check result
         repr(indexer)
 

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -209,7 +209,7 @@ class TestDaskGetitem:
         self._test_with(np.s_[[0], [-1, -2, -3, -4, -5], :, [8, 6, 4, 2, 0]])
 
     def test_evenly_spaced_booleans(self):
-        pick_one = np.zeros(40, dtype=np.bool_)
+        pick_one = np.zeros(40, dtype=bool)
         pick_one[6] = True
         self._test_with(np.s_[:, [True, False] * 10, pick_one[:30], :])
         self._test_with(np.s_[:, [False, True] * 10, :, pick_one])

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -99,7 +99,7 @@ class TestSensorCache:
             cache_data[name] = sd
         return cache_data
 
-    def setup(self):
+    def setup_method(self):
         self.cache = SensorCache(self._cache_data(), timestamps=np.arange(10.), dump_period=1.0)
 
     def test_extract_float(self):

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from unittest import mock
 
 import numpy as np
-from nose.tools import assert_raises
+import pytest
 
 from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter,
                                remove_duplicates_and_invalid_values,
@@ -168,11 +168,11 @@ class TestSensorCache:
         assert calculate_value.call_count == 1
         # If your parameter values contain underscores, don't use it as delimiter
         params = {'ant': 'm000', 'param1': 'one', 'param2': 'two_three'}
-        with assert_raises(AssertionError):
+        with pytest.raises(AssertionError):
             self.cache.get(template.format(**params))
         template = 'Antennas/{ant}/{param1}/{param2}'
         # The updated template has not yet been added to the cache
-        with assert_raises(KeyError):
+        with pytest.raises(KeyError):
             self.cache.get(template.format(**params))
         self.cache.virtual[template] = _check_sensor
         value = self.cache.get(template.format(**params))

--- a/katdal/test/test_sensordata.py
+++ b/katdal/test/test_sensordata.py
@@ -20,8 +20,7 @@ from collections import OrderedDict
 from unittest import mock
 
 import numpy as np
-from nose.tools import (assert_equal, assert_in, assert_is_instance,
-                        assert_not_in, assert_raises)
+from nose.tools import assert_raises
 
 from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter,
                                remove_duplicates_and_invalid_values,
@@ -29,8 +28,8 @@ from katdal.sensordata import (SensorCache, SensorData, SimpleSensorGetter,
 
 
 def assert_equal_typed(a, b):
-    assert_equal(a, b)
-    assert_equal(type(a), type(b))
+    assert a == b
+    assert type(a) == type(b)
 
 
 class TestToStr:
@@ -118,28 +117,28 @@ class TestSensorCache:
             self._cache_data(), timestamps=np.arange(10.), dump_period=1.0,
             aliases={'zz': 'at'})
         # Check that adding the alias didn't lead to extraction
-        assert_is_instance(self.cache.get('czz', extract=False), SimpleSensorGetter)
+        assert isinstance(self.cache.get('czz', extract=False), SimpleSensorGetter)
         np.testing.assert_array_equal(self.cache['czz'], self.cache['cat'])
 
     def test_len(self):
-        assert_equal(len(self.cache), 2)
+        assert len(self.cache) == 2
 
     def test_keys(self):
-        assert_equal(sorted(self.cache.keys()), ['cat', 'foo'])
+        assert sorted(self.cache.keys()) == ['cat', 'foo']
 
     def test_contains(self):
-        assert_in('cat', self.cache)
-        assert_in('foo', self.cache)
-        assert_not_in('dog', self.cache)
+        assert 'cat' in self.cache
+        assert 'foo' in self.cache
+        assert 'dog' not in self.cache
         template = 'Antennas/{ant}/{param1}_{param2}'
         self.cache.virtual[template] = lambda x: None
-        assert_not_in(template, self.cache)
+        assert template not in self.cache
 
     def test_setitem_delitem(self):
         self.cache['bar'] = SimpleSensorGetter('bar', np.array([1.0]), np.array([0.0]))
         np.testing.assert_array_equal(self.cache['bar'], np.zeros(10))
         del self.cache['bar']
-        assert_not_in('bar', self.cache)
+        assert 'bar' not in self.cache
 
     def test_sensor_time_offset(self):
         data = self.cache.get('foo', extract=True, time_offset=-1.0)
@@ -150,7 +149,7 @@ class TestSensorCache:
 
         def _check_sensor(cache, name, **kwargs):
             """Check that virtual sensor function gets the expected parameters."""
-            assert_equal(kwargs, params)
+            assert kwargs == params
             calculate_value()
             value = kwargs['param2']
             cache[name] = value
@@ -161,12 +160,12 @@ class TestSensorCache:
         template = 'Antennas/{ant}/{param1}_{param2}'
         self.cache.virtual[template] = _check_sensor
         value = self.cache.get(template.format(**params))
-        assert_equal(value, params['param2'])
-        assert_equal(calculate_value.call_count, 1)
+        assert value == params['param2']
+        assert calculate_value.call_count == 1
         # Check that the value was taken from the cache the second time around
         value = self.cache.get(template.format(**params))
-        assert_equal(value, params['param2'])
-        assert_equal(calculate_value.call_count, 1)
+        assert value == params['param2']
+        assert calculate_value.call_count == 1
         # If your parameter values contain underscores, don't use it as delimiter
         params = {'ant': 'm000', 'param1': 'one', 'param2': 'two_three'}
         with assert_raises(AssertionError):
@@ -177,8 +176,8 @@ class TestSensorCache:
             self.cache.get(template.format(**params))
         self.cache.virtual[template] = _check_sensor
         value = self.cache.get(template.format(**params))
-        assert_equal(value, params['param2'])
-        assert_equal(calculate_value.call_count, 2)
+        assert value == params['param2']
+        assert calculate_value.call_count == 2
 
     # TODO: more tests required:
     # - extract=False
@@ -194,6 +193,6 @@ def test_sensor_cleanup():
     status = np.array(['unknown', 'nominal', 'nominal', 'nominal', 'warn', 'error', 'nominal'])
     dirty = SensorData('test', timestamp, value, status)
     clean = remove_duplicates_and_invalid_values(dirty)
-    assert_equal(clean.status, None)
+    assert clean.status is None
     np.testing.assert_array_equal(clean.value, np.array(['a', 'b', 'd']))
     np.testing.assert_array_equal(clean.timestamp, np.array([0.0, 2.0, 3.0]))

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -23,7 +23,7 @@ from katdal.spectral_window import SpectralWindow
 
 
 class TestSpectralWindow:
-    def setUp(self):
+    def setup_method(self):
         self.lsb = SpectralWindow(1000.0, 10.0, 6, sideband=-1, product='lsb')
         self.usb = SpectralWindow(1000.0, 10.0, 6, sideband=1, band='X')
         self.odd = SpectralWindow(1000.0, 10.0, 5, sideband=1)

--- a/katdal/test/test_spectral_window.py
+++ b/katdal/test/test_spectral_window.py
@@ -17,7 +17,6 @@
 """Tests for :py:mod:`katdal.spectral_window`."""
 
 import numpy as np
-from nose.tools import assert_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from katdal.spectral_window import SpectralWindow
@@ -35,10 +34,10 @@ class TestSpectralWindow:
                                       bandwidth=230.0)
 
     def test_width_properties(self):
-        assert_equal(self.lsb.channel_width, 10.0)
-        assert_equal(self.lsb.bandwidth, 60.0)
-        assert_equal(self.inexact.channel_width, 230.0 / 14)
-        assert_equal(self.inexact.bandwidth, 230.0)
+        assert self.lsb.channel_width == 10.0
+        assert self.lsb.bandwidth == 60.0
+        assert self.inexact.channel_width == 230.0 / 14
+        assert self.inexact.bandwidth == 230.0
 
     def test_channel_freqs(self):
         assert_array_equal(self.lsb.channel_freqs,
@@ -50,8 +49,8 @@ class TestSpectralWindow:
         assert_array_almost_equal(self.inexact.channel_freqs,
                                   np.arange(14) * 230.0 / 14 + 885.0)
         # Check that the exactly representable values are exact
-        assert_equal(self.inexact.channel_freqs[0], 885.0)
-        assert_equal(self.inexact.channel_freqs[7], 1000.0)
+        assert self.inexact.channel_freqs[0] == 885.0
+        assert self.inexact.channel_freqs[7] == 1000.0
 
     def test_repr(self):
         # Just a smoke test to check that it doesn't crash
@@ -61,14 +60,14 @@ class TestSpectralWindow:
     def test_subrange(self):
         lsb_sub = self.lsb.subrange(0, 3)
         assert_array_equal(lsb_sub.channel_freqs, [1030.0, 1020.0, 1010.0])
-        assert_equal(lsb_sub.product, self.lsb.product)
+        assert lsb_sub.product == self.lsb.product
         usb_sub = self.usb.subrange(2, 6)
         assert_array_equal(usb_sub.channel_freqs,
                            [990.0, 1000.0, 1010.0, 1020.0])
-        assert_equal(usb_sub.band, self.usb.band)
+        assert usb_sub.band == self.usb.band
         # Check that updated bandwidth doesn't have rounding errors
         inexact_sub = self.inexact.subrange(0, 7)
-        assert_equal(inexact_sub.bandwidth, 115.0)
+        assert inexact_sub.bandwidth == 115.0
 
     def test_rechannelise_same(self):
         lsb = self.lsb.rechannelise(6)

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -24,7 +24,7 @@ import tempfile
 
 import dask.array as da
 import numpy as np
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
 
 from katdal.chunkstore import generate_chunks
@@ -114,11 +114,11 @@ class TestChunkStoreVisFlagsWeights:
         store, chunk_info, data, weights = self._make_basic_dataset()
         # Check that data is as expected when accessed via VisFlagsWeights
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info)
-        assert_equal(vfw.shape, data['correlator_data'].shape)
+        assert vfw.shape == data['correlator_data'].shape
         assert_array_equal(vfw.vis.compute(), data['correlator_data'])
         assert_array_equal(vfw.flags.compute(), data['flags'])
         assert_array_equal(vfw.weights.compute(), weights)
-        assert_equal(vfw.unscaled_weights, None)
+        assert vfw.unscaled_weights is None
 
     def test_index(self):
         # Put fake dataset into chunk store
@@ -220,7 +220,7 @@ class TestChunkStoreVisFlagsWeights:
         # Check that data is as expected when accessed via VisFlagsWeights
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info, corrprods,
                                         stored_weights_are_scaled=False)
-        assert_equal(vfw.shape, data['correlator_data'].shape)
+        assert vfw.shape == data['correlator_data'].shape
         assert_array_equal(vfw.vis.compute(), data['correlator_data'])
         assert_array_equal(vfw.flags.compute(), data['flags'])
         assert_array_equal(vfw.weights.compute(), stored_weights * expected_scale)
@@ -229,7 +229,7 @@ class TestChunkStoreVisFlagsWeights:
         # Check that scaled raw weights are also accepted
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info, corrprods,
                                         stored_weights_are_scaled=True)
-        assert_equal(vfw.shape, data['correlator_data'].shape)
+        assert vfw.shape == data['correlator_data'].shape
         assert_array_equal(vfw.vis.compute(), data['correlator_data'])
         assert_array_equal(vfw.flags.compute(), data['flags'])
         assert_array_equal(vfw.weights.compute(), stored_weights)
@@ -253,8 +253,8 @@ class TestChunkStoreVisFlagsWeights:
                 chunk_name, shape = store.chunk_metadata(array_name, culled_slice)
                 os.remove(os.path.join(store.path, chunk_name) + '.npy')
         vfw = ChunkStoreVisFlagsWeights(store, chunk_info)
-        assert_equal(vfw.store, store)
-        assert_equal(vfw.vis_prefix, prefix)
+        assert vfw.store == store
+        assert vfw.vis_prefix == prefix
         # Check that (only) missing chunks have been replaced by zeros
         vis = data['correlator_data']
         for culled_slice in missing_chunks['correlator_data']:

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -43,9 +43,9 @@ def test_vis_flags_weights():
         VisFlagsWeights(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 4)))
 
 
-def ramp(shape, offset=1.0, slope=1.0, dtype=np.float_):
+def ramp(shape, offset=1.0, slope=1.0, dtype=np.float64):
     """Generate a multidimensional ramp of values of the given dtype."""
-    x = offset + slope * np.arange(np.prod(shape), dtype=np.float_)
+    x = offset + slope * np.arange(np.prod(shape), dtype=np.float64)
     return x.astype(dtype).reshape(shape)
 
 

--- a/katdal/test/test_vis_flags_weights.py
+++ b/katdal/test/test_vis_flags_weights.py
@@ -24,8 +24,8 @@ import tempfile
 
 import dask.array as da
 import numpy as np
-from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
+import pytest
 
 from katdal.chunkstore import generate_chunks
 from katdal.chunkstore_npy import NpyFileChunkStore
@@ -37,9 +37,9 @@ from katdal.vis_flags_weights import (ChunkStoreVisFlagsWeights,
 
 
 def test_vis_flags_weights():
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         VisFlagsWeights(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 4)))
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         VisFlagsWeights(np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 3)), np.ones((1, 2, 4)))
 
 
@@ -178,7 +178,7 @@ class TestChunkStoreVisFlagsWeights:
         corrected_vfw = ChunkStoreVisFlagsWeights(store, chunk_info, corrprods, van_vleck='autocorr')
         assert_array_equal(corrected_vfw.vis.compute(), expected_vis)
         # Check parameter validation
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             ChunkStoreVisFlagsWeights(store, chunk_info, corrprods, van_vleck='blah')
 
     def test_weight_power_scale(self):

--- a/katdal/vis_flags_weights.py
+++ b/katdal/vis_flags_weights.py
@@ -190,8 +190,10 @@ def correct_autocorr_quantisation(vis, corrprods, levels=None):
                                            quantised_autocorr_table, true_autocorr_table)
         return out
 
-    return da.blockwise(_correct_autocorr_quant, 'ijk', vis, 'ijk', dtype=np.complex64,
-                        name='van-vleck-autocorr-' + vis.name)
+    return da.blockwise(_correct_autocorr_quant, 'ijk', vis, 'ijk',
+                        name='van-vleck-autocorr-' + vis.name,
+                        dtype=vis.dtype,
+                        meta=np.empty(vis.ndim * (0,), vis.dtype))
 
 
 @numba.jit(nopython=True, nogil=True)

--- a/katdal/visdatav4.py
+++ b/katdal/visdatav4.py
@@ -276,7 +276,7 @@ class VisibilityDataV4(DataSet):
         half_dump = 0.5 * self.dump_period
         self.start_time = katpoint.Timestamp(source.timestamps[0] - half_dump)
         self.end_time = katpoint.Timestamp(source.timestamps[-1] + half_dump)
-        self._time_keep = np.full(num_dumps, True, dtype=np.bool_)
+        self._time_keep = np.full(num_dumps, True, dtype=bool)
         all_dumps = [0, num_dumps]
 
         # Assemble sensor cache
@@ -638,7 +638,7 @@ class VisibilityDataV4(DataSet):
             def bitwise_and(flags): return da.bitwise_and(select, flags)
             flag_transforms.append(bitwise_and)
         # View uint8 as bool (can still be undone by flags.view(np.uint8))
-        def view_as_bool(flags): return flags.view(np.bool_)
+        def view_as_bool(flags): return flags.view(bool)
         flag_transforms.append(view_as_bool)
         self._flags = DaskLazyIndexer(self._raw_flags, transforms=flag_transforms)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    expected_duration(seconds): The expected duration of a test, in seconds.

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,4 @@ setup(name='katdal',
           's3': [],
           's3credentials': ['botocore']
       },
-      tests_require=['nose', 'cryptography'])
+      tests_require=['nose', 'cryptography', 'pytest'])

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,4 @@ setup(name='katdal',
           's3': [],
           's3credentials': ['botocore']
       },
-      tests_require=['nose', 'cryptography', 'pytest'])
+      tests_require=['cryptography', 'pytest'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 cffi==1.15.1                           # via cryptography
+coverage
 cryptography==38.0.3
 pycparser==2.21                        # via cffi
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,7 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 cffi==1.15.1                           # via cryptography
-coverage
 cryptography==38.0.3
-nose
 pycparser==2.21                        # via cffi
 pytest
+pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ coverage
 cryptography==38.0.3
 nose
 pycparser==2.21                        # via cffi
+pytest


### PR DESCRIPTION
Nose hasn’t been updated in 7 years and finally does not run on Python 3.10 anymore. This makes it irritating to test katdal, which now needs a Python 3.9 environment just for testing.

Convert all the tests to pytest. Try the nose2pytest script to help with this.

In the process, make the duration checks optional on Jenkins (where it frequently fails with large discrepancies).

Also resolve a bunch (269 928!) of NumPy deprecation warnings.
