### PR TITLE
SPR1-813: Handle truncated reads, socket timeouts and reset connections (aka glitches) in S3ChunkStore

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -186,6 +186,16 @@ def _read_chunk(response):
     return chunk
 
 
+def _read_object(response):
+    """Read bytes from content of HTTP response and check that it's all there."""
+    data = response.content
+    # Verify that all content has been consumed
+    bytes_left = response.raw.length_remaining
+    if bytes_left is not None and bytes_left > 0:
+        raise IncompleteRead(response.raw.tell(), bytes_left)
+    return data
+
+
 def _bucket_url(url):
     """Turn `url` into associated S3 bucket URL (first path component only)."""
     split_url = urllib.parse.urlsplit(url)

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from .chunkstore import ChunkStoreError
 from .chunkstore_npy import NpyFileChunkStore
-from .chunkstore_s3 import S3ChunkStore
+from .chunkstore_s3 import S3ChunkStore, _read_object
 from .dataset import parse_url_or_path
 from .sensordata import TelstateSensorGetter, TelstateToStr
 from .vis_flags_weights import ChunkStoreVisFlagsWeights
@@ -461,7 +461,7 @@ class TelstateDataSource(DataSource):
             telstate = katsdptelstate.TelescopeState()
             try:
                 rdb_store = S3ChunkStore(store_url, **kwargs)
-                rdb_data = rdb_store.request('GET', rdb_url, process=lambda r: r.content)
+                rdb_data = rdb_store.request('GET', rdb_url, process=_read_object)
                 telstate.load_from_file(io.BytesIO(rdb_data))
             except ChunkStoreError as e:
                 raise DataSourceNotFound(str(e)) from e

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -461,8 +461,8 @@ class TelstateDataSource(DataSource):
             telstate = katsdptelstate.TelescopeState()
             try:
                 rdb_store = S3ChunkStore(store_url, **kwargs)
-                with rdb_store.request('GET', rdb_url) as response:
-                    telstate.load_from_file(io.BytesIO(response.content))
+                rdb_data = rdb_store.complete_request('GET', rdb_url, process=lambda r: r.content)
+                telstate.load_from_file(io.BytesIO(rdb_data))
             except ChunkStoreError as e:
                 raise DataSourceNotFound(str(e)) from e
             # If the RDB file is opened via archive URL, use that URL and

--- a/katdal/datasources.py
+++ b/katdal/datasources.py
@@ -461,7 +461,7 @@ class TelstateDataSource(DataSource):
             telstate = katsdptelstate.TelescopeState()
             try:
                 rdb_store = S3ChunkStore(store_url, **kwargs)
-                rdb_data = rdb_store.complete_request('GET', rdb_url, process=lambda r: r.content)
+                rdb_data = rdb_store.request('GET', rdb_url, process=lambda r: r.content)
                 telstate.load_from_file(io.BytesIO(rdb_data))
             except ChunkStoreError as e:
                 raise DataSourceNotFound(str(e)) from e

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -672,11 +672,11 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 
-    @pytest.mark.expected_duration(0.6)
+    @pytest.mark.expected_duration(0.0)
     def test_persistent_early_reset_connections(self):
         chunk, slices, array_name = self._put_chunk(
-            'please-reset-connection-for-0.8-seconds')
-        with pytest.raises(ChunkNotFound):
+            'please-reset-connection-for-0.2-seconds')
+        with pytest.raises(StoreUnavailable):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 
     @pytest.mark.parametrize('nbytes', [60, 129])  # check both NPY header and array itself

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -113,9 +113,9 @@ def get_free_port(host):
 
 
 class TestReadArray:
-    def _test(self, array):
+    def _test(self, array, version=None):
         fp = io.BytesIO()
-        np.save(fp, array)
+        np.lib.format.write_array(fp, array, version, allow_pickle=False)
         fp.seek(0)
         out = read_array(fp)
         np.testing.assert_equal(array, out)
@@ -132,12 +132,7 @@ class TestReadArray:
         self._test(np.arange(20).reshape(4, 5, 1).T)
 
     def testV2(self):
-        # Make dtype that needs more than 64K to store, forcing .npy version 2.0
-        dtype = np.dtype([('a' * 70000, np.float32), ('b', np.float32)])
-        with warnings.catch_warnings():
-            # Suppress warning that V2 files can only be read by numpy >= 1.9
-            warnings.simplefilter('ignore', category=UserWarning)
-            self._test(np.zeros(100, dtype))
+        self._test(np.zeros(100), version=(2, 0))
 
     def testBadVersion(self):
         data = b'\x93NUMPY\x03\x04'     # Version 3.4

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -699,7 +699,6 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         chunk, slices, array_name = self._put_chunk(suggestion)
         with pytest.raises(ChunkNotFound) as excinfo:
             self.store.get_chunk(array_name, slices, chunk.dtype)
-        excinfo.match('Connection reset by peer')
         assert isinstance(excinfo.value, S3ServerGlitch)
 
     @pytest.mark.expected_duration(0.6)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -617,15 +617,15 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
 
     @pytest.mark.expected_duration(0.4)
     def test_recover_from_server_errors(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-respond-with-500-for-0.3-seconds')
+        suggestion = 'please-respond-with-500-for-0.3-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
         assert_array_equal(chunk_retrieved, chunk, 'Bad chunk after server error')
 
     @pytest.mark.expected_duration(0.5)
     def test_persistent_server_errors(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-respond-with-502-for-0.7-seconds')
+        suggestion = 'please-respond-with-502-for-0.7-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         # After 0.4 seconds the client gives up and returns with failure 0.1 s later
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
@@ -653,8 +653,8 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
 
     @pytest.mark.expected_duration(0.6)
     def test_persistent_truncated_reads(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-truncate-read-after-60-bytes-for-0.8-seconds')
+        suggestion = 'please-truncate-read-after-60-bytes-for-0.8-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         # After 0.6 seconds the client gives up
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
@@ -665,22 +665,22 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
 
     @pytest.mark.expected_duration(0.6)
     def test_recover_from_reset_connections(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-reset-read-after-129-bytes-for-0.4-seconds')
+        suggestion = 'please-reset-read-after-129-bytes-for-0.4-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         chunk_retrieved = self.store.get_chunk(array_name, slices, chunk.dtype)
         assert_array_equal(chunk_retrieved, chunk, 'Bad chunk after reset connection')
 
     @pytest.mark.expected_duration(0.6)
     def test_persistent_reset_connections(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-reset-read-after-129-bytes-for-0.8-seconds')
+        suggestion = 'please-reset-read-after-129-bytes-for-0.8-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 
     @pytest.mark.expected_duration(0.6)
     def test_persistent_early_reset_connections(self):
-        chunk, slices, array_name = self._put_chunk(
-            'please-reset-connection-for-0.8-seconds')
+        suggestion = 'please-reset-connection-for-0.8-seconds'
+        chunk, slices, array_name = self._put_chunk(suggestion)
         with pytest.raises(StoreUnavailable):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -670,10 +670,10 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 
-    @pytest.mark.expected_duration(0.0)
+    @pytest.mark.expected_duration(0.6)
     def test_persistent_early_reset_connections(self):
         chunk, slices, array_name = self._put_chunk(
-            'please-reset-connection-for-0.2-seconds')
+            'please-reset-connection-for-0.8-seconds')
         with pytest.raises(StoreUnavailable):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -50,12 +50,19 @@ import requests
 from katsdptelstate.rdb_writer import RDBWriter
 import pytest
 from numpy.testing import assert_array_equal
+from urllib3.exceptions import IncompleteRead
 from urllib3.util.retry import Retry
 
 from katdal.chunkstore import ChunkNotFound, StoreUnavailable
-from katdal.chunkstore_s3 import (_DEFAULT_SERVER_GLITCHES, InvalidToken,
-                                  S3ChunkStore, TruncatedRead, _AWSAuth,
-                                  AuthorisationFailed, decode_jwt, read_array)
+from katdal.chunkstore_s3 import (
+    _DEFAULT_SERVER_GLITCHES,
+    InvalidToken,
+    S3ChunkStore,
+    _AWSAuth,
+    AuthorisationFailed,
+    decode_jwt,
+    read_array
+)
 from katdal.datasources import TelstateDataSource
 from katdal.test.s3_utils import MissingProgram, S3Server, S3User
 from katdal.test.test_chunkstore import ChunkStoreTestBase, generate_arrays
@@ -150,7 +157,7 @@ class TestReadArray:
         fp.seek(*args)
         fp.truncate()
         fp.seek(0)
-        with pytest.raises(TruncatedRead):
+        with pytest.raises(IncompleteRead):
             read_array(fp)
 
     def testShort(self):

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -347,7 +347,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             rdb_path = self.store.join(cbid, rdb_filename)
         rdb_url = urllib.parse.urljoin(self.store_url, rdb_path)
         self.store.create_array(cbid)
-        self.store.complete_request('PUT', rdb_url, data=rdb_data)
+        self.store.request('PUT', rdb_url, data=rdb_data)
         # Check that data source can be constructed from URL (with auto chunk store)
         source_from_url = TelstateDataSource.from_url(rdb_url, **self.store_kwargs)
         source_direct = TelstateDataSource(view, cbid, sn, self.store)

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -351,7 +351,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         with open(temp_filename, mode='rb') as rdb_file:
             rdb_data = rdb_file.read()
         if suggestion:
-            rdb_path = self.store.join(cbid, suggestion, rdb_filename)
+            rdb_path = self.store.join(suggestion, cbid, rdb_filename)
         else:
             rdb_path = self.store.join(cbid, rdb_filename)
         rdb_url = urllib.parse.urljoin(self.store_url, rdb_path)
@@ -583,7 +583,8 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         elif url != cls.httpd.target:
             raise RuntimeError('Cannot use multiple target URLs with http proxy')
         # The token authorises the standard bucket and anything starting with PREFIX
-        token = encode_jwt({'prefix': [BUCKET, PREFIX]})
+        # (as well as suggestions prepended to the path)
+        token = encode_jwt({'prefix': [BUCKET, PREFIX, 'please']})
         kwargs.setdefault('token', token)
         return super().prepare_store_args(cls.proxy_url, credentials=None, **kwargs)
 
@@ -681,7 +682,6 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         with pytest.raises(ChunkNotFound):
             self.store.get_chunk(array_name, slices, chunk.dtype)
 
-    @pytest.mark.expected_duration(0.6)
     def test_rdb_support(self):
         super().test_rdb_support('please-truncate-read-after-1000-bytes-for-0.4-seconds')
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -73,7 +73,7 @@ PREFIX = '1234567890'
 #    3 * 0.1 + 0.2 = 0.5 second if the suggestions use SUGGESTED_STATUS_DELAY
 TIMEOUT = (5.0, 2.0)
 RETRY = Retry(connect=1, read=3, status=2, backoff_factor=0.1,
-              raise_on_status=False, status_forcelist=_DEFAULT_SERVER_GLITCHES)
+              status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 READ_PAUSE = 0.1
 # Dummy private key for ES256 algorithm (taken from PyJWT unit tests)


### PR DESCRIPTION
This improves the robustness of katdal's archive access.

While glitches where typically picked up while reading the response header, the response body had no such checks, as is the wont of the Requests library (only discovered that now 😅). Since the bulk of the data resides in the body, this meant that chunk transfers were rarely retried.

Fix this by integrating retries into the response reading too. Maintain a single `Retry` object per session, which is passed to the request, retrieved from the response and updated in case the response content has issues. Completely overhaul `S3ChunkStore.request`. Replace `TruncatedRead` with the more standard `IncompleteRead` exception. Retries can now be overridden per request.

This gets rid of the clunky fake 555 status code that treats truncated reads as status errors (they should be read errors instead).

Ensure that glitches are also handled when downloading data in non-streaming fashion via `response.content` (e.g. when downloading RDB files). Add a whole bunch of unit tests that verify glitch behaviour.

This addresses #296 and #362.

Review tip: There was quite an evolution as I tried and abandoned various approaches. I would start with the full diff and work backwards to specific commits to make sense of it.