### PR TITLE
SPR1-2912: Select multiple targets with the same name

### DIFF
--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -27,9 +27,24 @@ from katdal.sensordata import SensorCache
 from katdal.spectral_window import SpectralWindow
 
 
+ANTENNAS = [
+    Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -8.264 -207.29 8.5965'),
+    Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -3419.5845 -1840.48 16.3825')
+]
+CORRPRODS = [
+    ('m000h', 'm000h'), ('m000v', 'm000v'),
+    ('m063h', 'm063h'), ('m063v', 'm063v'),
+    ('m000h', 'm063h'), ('m000v', 'm063v')
+]
+SUBARRAY = Subarray(ANTENNAS, CORRPRODS)
+SPW = SpectralWindow(
+    centre_freq=1284e6, channel_width=0, num_chans=16, sideband=1, bandwidth=856e6
+)
+
+
 class MinimalDataSet(DataSet):
     """Minimal data set containing a single target track."""
-    def __init__(self, target, subarray, spectral_window, timestamps):
+    def __init__(self, target, timestamps, subarray=SUBARRAY, spectral_window=SPW):
         super().__init__(name='test', ref_ant='array')
         num_dumps = len(timestamps)
         num_chans = spectral_window.num_chans
@@ -114,19 +129,10 @@ def test_selection_to_list():
 class TestVirtualSensors:
     def setup_method(self):
         self.target = Target('PKS1934-638, radec, 19:39, -63:42')
-        self.antennas = [Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
-                                 '-8.264 -207.29 8.5965'),
-                         Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, '
-                                 '-3419.5845 -1840.48 16.3825')]
-        corrprods = [('m000h', 'm000h'), ('m000v', 'm000v'),
-                     ('m063h', 'm063h'), ('m063v', 'm063v'),
-                     ('m000h', 'm063h'), ('m000v', 'm063v')]
-        subarray = Subarray(self.antennas, corrprods)
-        spw = SpectralWindow(centre_freq=1284e6, channel_width=0, num_chans=16,
-                             sideband=1, bandwidth=856e6)
         # Pick a time when the source is up as that seems more realistic
         self.timestamps = 1234667890.0 + 1.0 * np.arange(10)
-        self.dataset = MinimalDataSet(self.target, subarray, spw, self.timestamps)
+        self.dataset = MinimalDataSet(self.target, self.timestamps)
+        self.antennas = self.dataset.subarrays[0].ants
         self.array_ant = self.dataset.sensor.get('Antennas/array/antenna')[0]
 
     def test_timestamps(self):

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -16,6 +16,8 @@
 
 """Tests for :py:mod:`katdal.dataset`."""
 
+import logging
+
 import numpy as np
 import pytest
 from katpoint import Antenna, Target, Timestamp, rad2deg
@@ -208,77 +210,95 @@ class TestVirtualSensors:
         assert_array_equal(self.dataset.w[:, 5], w)
 
 
-class TestSelection:
-    def setup_method(self):
-        self.targets = [
-            # It would have been nice to have radec = 19:39, -63:42 but then
-            # selection by description string does not work because the catalogue's
-            # description string pads it out to radec = 19:39:00.00, -63:42:00.0.
-            # (XXX Maybe fix Target comparison in katpoint to support this?)
-            Target('J1939-6342 | PKS1934-638, radec bpcal, 19:39:25.03, -63:42:45.6'),
-            Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
-            Target('J0408-6545 | PKS 0408-65, radec bpcal, 4:08:20.38, -65:45:09.1'),
-            Target('J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4'),
-        ]
-        # Ensure that len(timestamps) is an integer multiple of len(targets)
-        self.timestamps = 1234667890.0 + 1.0 * np.arange(12)
-        self.dataset = MinimalDataSet(self.targets, self.timestamps)
-
-    def test_selecting_antenna(self):
-        self.dataset.select(ants='~m000')
-        assert_array_equal(
-            self.dataset.corr_products,
-            [('m063h', 'm063h'), ('m063v', 'm063v')])
-
-    @pytest.mark.parametrize(
-        'scans,dumps',
-        [
-             ('track', [1, 2, 4, 5, 7, 8, 10, 11]),
-             ('slew', [0, 3, 6, 9]),
-             ('~slew', [1, 2, 4, 5, 7, 8, 10, 11]),
-             (('track', 'slew'), np.arange(12)),
-             (('track', '~slew'), [1, 2, 4, 5, 7, 8, 10, 11]),
-             (1, [1, 2]),
-             ([1, 3, 4], [1, 2, 4, 5, 6]),
-        ]
-    )
-    def test_select_scans(self, scans, dumps):
-        self.dataset.select(scans=scans)
-        assert_array_equal(self.dataset.dumps, dumps)
-
-    @pytest.mark.parametrize(
-        'compscans,dumps',
-        [
-             ('track', np.arange(12)),
-             ('~track', []),
-             (1, [3, 4, 5]),
-             ([1, 3], [3, 4, 5, 9, 10, 11]),
-        ]
-    )
-    def test_select_compscans(self, compscans, dumps):
-        self.dataset.select(compscans=compscans)
-        assert_array_equal(self.dataset.dumps, dumps)
+@pytest.fixture
+def dataset():
+    """A basic dataset used to test the selection mechanism."""
+    targets = [
+        # It would have been nice to have radec = 19:39, -63:42 but then
+        # selection by description string does not work because the catalogue's
+        # description string pads it out to radec = 19:39:00.00, -63:42:00.0.
+        # (XXX Maybe fix Target comparison in katpoint to support this?)
+        Target('J1939-6342 | PKS1934-638, radec bpcal, 19:39:25.03, -63:42:45.6'),
+        Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
+        Target('J0408-6545 | PKS 0408-65, radec bpcal, 4:08:20.38, -65:45:09.1'),
+        Target('J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4'),
+    ]
+    # Ensure that len(timestamps) is an integer multiple of len(targets)
+    timestamps = 1234667890.0 + 1.0 * np.arange(12)
+    return MinimalDataSet(targets, timestamps)
 
 
-    @pytest.mark.parametrize(
-        'targets,dumps',
-        [
-            ('PKS1934-638', [0, 1, 2]),
-            (('J0408-6545', 'Cen B'), [6, 7, 8, 9, 10, 11]),
-            ('J1939-6342, radec gaincal, 19:39, -63:42', []),
-            ('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6', [3, 4, 5]),
-            (Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'), [3, 4, 5]),
-            (
-                [
-                    Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
-                    'J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4',
-                ],
-                [3, 4, 5, 9, 10, 11]
-            ),
+def test_selecting_antenna(dataset):
+    dataset.select(ants='~m000')
+    assert_array_equal(
+        dataset.corr_products,
+        [('m063h', 'm063h'), ('m063v', 'm063v')])
+
+
+@pytest.mark.parametrize(
+    'scans,expected_dumps',
+    [
+            ('track', [1, 2, 4, 5, 7, 8, 10, 11]),
+            ('slew', [0, 3, 6, 9]),
+            ('~slew', [1, 2, 4, 5, 7, 8, 10, 11]),
+            (('track', 'slew'), np.arange(12)),
+            (('track', '~slew'), [1, 2, 4, 5, 7, 8, 10, 11]),
+            (1, [1, 2]),
+            ([1, 3, 4], [1, 2, 4, 5, 6]),
+            # Empty selections
+            ('scan', []),
+            (-1, []),
+            (100, []),
+    ]
+)
+def test_select_scans(dataset, scans, expected_dumps):
+    dataset.select(scans=scans)
+    assert_array_equal(dataset.dumps, expected_dumps)
+
+
+@pytest.mark.parametrize(
+    'compscans,expected_dumps',
+    [
+            ('track', np.arange(12)),
             (1, [3, 4, 5]),
             ([1, 3], [3, 4, 5, 9, 10, 11]),
-        ]
-    )
-    def test_select_targets(self, targets, dumps):
-        self.dataset.select(targets=targets)
-        assert_array_equal(self.dataset.dumps, dumps)
+            # Empty selections
+            ('~track', []),
+            (-1, []),
+            (100, []),
+    ]
+)
+def test_select_compscans(dataset, compscans, expected_dumps):
+    dataset.select(compscans=compscans)
+    assert_array_equal(dataset.dumps, expected_dumps)
+
+
+@pytest.mark.parametrize(
+    'targets,expected_dumps',
+    [
+        ('PKS1934-638', [0, 1, 2]),
+        (('J0408-6545', 'Cen B'), [6, 7, 8, 9, 10, 11]),
+        ('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6', [3, 4, 5]),
+        (Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'), [3, 4, 5]),
+        (
+            [
+                Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
+                'J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4',
+            ],
+            [3, 4, 5, 9, 10, 11]
+        ),
+        (1, [3, 4, 5]),
+        ([1, 3], [3, 4, 5, 9, 10, 11]),
+        # Empty selections
+        ('Moon', []),
+        ('J1939-6342, radec gaincal, 19:39, -63:42', []),
+        (Target('Sun, special'), []),
+    ]
+)
+def test_select_targets(caplog, dataset, targets, expected_dumps):
+    with caplog.at_level(logging.WARNING, logger='katdal.dataset'):
+        dataset.select(targets=targets)
+    # If the target is not found, check that a warning is logged
+    if len(expected_dumps) == 0:
+        assert 'Skipping unknown selected target' in caplog.text
+    assert_array_equal(dataset.dumps, expected_dumps)

--- a/katdal/test/test_dataset.py
+++ b/katdal/test/test_dataset.py
@@ -277,6 +277,7 @@ def test_select_compscans(dataset, compscans, expected_dumps):
     'targets,expected_dumps',
     [
         ('PKS1934-638', [0, 1, 2]),
+        ('J1939-6342', [0, 1, 2, 3, 4, 5]),
         (('J0408-6545', 'Cen B'), [6, 7, 8, 9, 10, 11]),
         ('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6', [3, 4, 5]),
         (Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'), [3, 4, 5]),


### PR DESCRIPTION
A `katpoint.Catalogue` can have multiple different targets with the same name, usually differing in tags only. The DataSet selection mechanism [`d.select(targets="name")`] still used a dict-style lookup for target names though, which is constrained to return a single target: the last target with the given name.

This would normally not be a big issue as there are other ways to select targets. It became a problem after #269 (released in katdal 0.18 in April 2021) which added field selection to `mvftoms.py`. This now always selects targets by name, even if the user wants all the targets and the selection is therefore unnecessary. This caused folks to lose e.g. a flux or bpcal calibrator in the MS conversion if they used the same target as a gain calibrator later on in the observation.

Fix this by ensuring all targets with a given name are picked up in the selection.