### PR TITLE
SPR1-2990: Change underscores in S3 bucket names to dashes

### DIFF
--- a/katdal/averager.py
+++ b/katdal/averager.py
@@ -46,8 +46,8 @@ def _average_visibilities(vis, weight, flag, timeav, chanav, flagav):
         vis_sum = np.empty(bl_step, vis.dtype)
         vis_weight_sum = np.empty(bl_step, vis.dtype)
         weight_sum = np.empty(bl_step, weight.dtype)
-        flag_any = np.empty(bl_step, dtype=bool)
-        flag_all = np.empty(bl_step, dtype=bool)
+        flag_any = np.empty(bl_step, dtype=np.bool_)
+        flag_all = np.empty(bl_step, dtype=np.bool_)
         for av_t in range(0, av_n_time):
             tstart = av_t * timeav
             for bstart in range(0, n_bl, bl_step):

--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -727,13 +727,13 @@ class S3ChunkStore(ChunkStore):
         """See the docstring of :meth:`ChunkStore.mark_complete`."""
         self.create_array(array_name)
         obj_name = self.join(array_name, 'complete')
-        url = urllib.parse.urljoin(self._url, obj_name)
+        url = self.make_url(obj_name)
         self.request('PUT', url, chunk_name=obj_name, data=b'')
 
     def is_complete(self, array_name):
         """See the docstring of :meth:`ChunkStore.is_complete`."""
         obj_name = self.join(array_name, 'complete')
-        url = urllib.parse.urljoin(self._url, obj_name)
+        url = self.make_url(obj_name)
         try:
             self.request('GET', url, chunk_name=obj_name)
         except ChunkNotFound:

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -351,7 +351,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
             rdb_path = self.store.join(suggestion, cbid, rdb_filename)
         else:
             rdb_path = self.store.join(cbid, rdb_filename)
-        rdb_url = urllib.parse.urljoin(self.store_url, rdb_path)
+        rdb_url = self.store.make_url(rdb_path)
         self.store.create_array(cbid)
         self.store.request('PUT', rdb_url, data=rdb_data)
         # Check that data source can be constructed from URL (with auto chunk store)
@@ -370,7 +370,7 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         with pytest.raises(StoreUnavailable):
             self.store.get_chunk(f'{BUCKET}-empty/x', slices, dtype)
         # Check that the standard bucket has not been verified yet
-        bucket_url = urllib.parse.urljoin(self.store._url, BUCKET)
+        bucket_url = self.store.make_url(BUCKET)
         assert bucket_url not in self.store._verified_buckets
         # Check that the standard bucket remains verified after initial check
         self.test_chunk_non_existent()
@@ -754,10 +754,10 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         data = b'x' * 1000
         cbid = PREFIX
         path = self.store.join(cbid, f'test_recovery_from_{condition}.bin')
-        url = urllib.parse.urljoin(self.store_url, path)
+        url = self.store.make_url(path)
         self.store.create_array(cbid)
         self.store.request('PUT', url, data=data)
         suggestion = f'please-{condition}-read-after-400-bytes-for-0.52-seconds'
-        url = urllib.parse.urljoin(self.store_url, self.store.join(suggestion, path))
+        url = self.store.make_url(self.store.join(suggestion, path))
         retrieved_data = self.store.request('GET', url, process=_read_object)
         assert retrieved_data == data

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -55,6 +55,7 @@ from urllib3.util.retry import Retry
 
 from katdal.chunkstore import ChunkNotFound, StoreUnavailable
 from katdal.chunkstore_s3 import (
+    _CHUNK_EXTENSION,
     _DEFAULT_SERVER_GLITCHES,
     InvalidToken,
     S3ChunkStore,
@@ -619,7 +620,7 @@ class TestS3ChunkStoreToken(TestS3ChunkStore):
         suggestion = 'please-respond-with-500-for-0.2-seconds'
         chunk, slices, array_name = self._put_chunk(suggestion)
         chunk_name, _ = self.store.chunk_metadata(array_name, slices, dtype=chunk.dtype)
-        url = self.store._chunk_url(chunk_name)
+        url = self.store.make_url(chunk_name + _CHUNK_EXTENSION)
         response = self.store.request('GET', url, ignored_errors=(500,), retries=0, stream=True)
         assert response.status_code == 500
 


### PR DESCRIPTION
Before 19 December 2018 the MeerKAT Ceph archive had underscores in its S3 bucket names, even though it was in violation of the S3 spec. Since October 2023 the archive runs a stricter version of Ceph and those older buckets were renamed to use dashes / hyphens instead. The metadata in the corresponding RDB files still refer to bucket names with underscores though.

Use the `S3ChunkStore.make_url` method as a centralised tool to build URLs from paths, fixing the underscores in the bucket names in the process. All store URLs should emanate from this method.

Some alternatives I considered:
  - Fix the vis prefix in the RDB file or as it comes out in telstate (downside: the prefix applies to NPY stores as well and there are also flag bucket prefixes to consider - maybe still an option...)
  - Fix the URL inside the already centralised `S3ChunkStore.request` (downside: some URLs with underscores are floating around, which could hamper debugging as they are invalid)