### PR TITLE
SPR1-2997: Fix np.product deprecation (and improve unit tests)

### DIFF
--- a/katdal/chunkstore_s3.py
+++ b/katdal/chunkstore_s3.py
@@ -155,7 +155,7 @@ def read_array(fp):
         raise ValueError(f'Unsupported .npy version {version}')
     if dtype.hasobject:
         raise ValueError('Object arrays are not supported')
-    count = int(np.product(shape))
+    count = int(np.prod(shape))
     data = np.ndarray(count, dtype=dtype)
     # For HTTPResponse it works to just pass in `data` directly, but the
     # wrapping is added for the benefit of any other implementation that

--- a/katdal/lazy_indexer.py
+++ b/katdal/lazy_indexer.py
@@ -135,7 +135,7 @@ def dask_getitem(x, indices):
     # ensure_dict, which copies all the keys, presumably to speed up the
     # case where most keys are retained. A lazy indexer is normally used to
     # fetch a small part of the data.
-    if np.product(out.numblocks) < 0.5 * np.product(x.numblocks):
+    if np.prod(out.numblocks) < 0.5 * np.prod(x.numblocks):
         dsk = dask.optimization.cull(out.dask, out.__dask_keys__())[0]
         out.dask = dask.highlevelgraph.HighLevelGraph.from_collections(out.name, dsk)
     return out

--- a/katdal/ms_async.py
+++ b/katdal/ms_async.py
@@ -41,7 +41,7 @@ class RawArray:
     def __init__(self, shape, dtype):
         self.shape = shape
         self.dtype = np.dtype(dtype)
-        size = self.dtype.itemsize * int(np.product(shape))
+        size = self.dtype.itemsize * int(np.prod(shape))
         self.storage = multiprocessing.sharedctypes.RawArray('c', size)
 
     def asarray(self):

--- a/katdal/ms_extra.py
+++ b/katdal/ms_extra.py
@@ -167,7 +167,7 @@ def kat_ms_desc_and_dminfo(nbl, nchan, ncorr, model_data=False):
 
         # Try bump up the number of rows in our tiles while they're
         # below the memory limit for the tile
-        while np.product(rev_shape + [2*ntilerows])*nbytes < tile_mem_limit:
+        while np.prod(rev_shape + [2*ntilerows])*nbytes < tile_mem_limit:
             ntilerows *= 2
 
         return {"DEFAULTTILESHAPE": np.int32(rev_shape + [ntilerows])}

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -81,12 +81,13 @@ BUCKET = 'katdal_unittest'
 # Also authorise this prefix for tests that will make their own buckets
 PREFIX = '1234567890'
 # Pick quick but different timeouts and retries for unit tests:
-#  - The effective connect timeout is 5.0 (initial) + 5.0 (1 retry) = 10 seconds
+#  - The effective connect timeout is 4.0 (initial) + 4.0 (retry #1)
+#    + 0.2 (backoff) + 4.0 (retry #2) + 0.4 (backoff) + 4.0 (retry #3) = 16.6 seconds
 #  - The effective read timeout is 2.0 + 3 * 2.0 + 0.1 * (0 + 2 + 4) = 8.6 seconds
 #  - The effective status timeout is 0.1 * (0 + 2) = 0.2 seconds, or
 #    3 * 0.1 + 0.2 = 0.5 second if the suggestions use SUGGESTED_STATUS_DELAY
-TIMEOUT = (5.0, 2.0)
-RETRY = Retry(connect=1, read=3, status=2, backoff_factor=0.1,
+TIMEOUT = (4.0, 2.0)
+RETRY = Retry(connect=3, read=3, status=2, backoff_factor=0.1,
               status_forcelist=_DEFAULT_SERVER_GLITCHES)
 SUGGESTED_STATUS_DELAY = 0.1
 READ_PAUSE = 0.1

--- a/katdal/test/test_lazy_indexer.py
+++ b/katdal/test/test_lazy_indexer.py
@@ -68,7 +68,7 @@ class TestSimplifyIndex:
     """Test the :func:`~katdal.lazy_indexer._simplify_index` function."""
     def setup_method(self):
         self.shape = (3, 4, 5)
-        self.data = np.arange(np.product(self.shape)).reshape(self.shape)
+        self.data = np.arange(np.prod(self.shape)).reshape(self.shape)
 
     def _test_with(self, indices):
         expected = self.data[indices]
@@ -178,7 +178,7 @@ class TestDaskGetitem:
     """Test the :func:`~katdal.lazy_indexer.dask_getitem` function."""
     def setup_method(self):
         shape = (10, 20, 30, 40)
-        self.data = np.arange(np.product(shape)).reshape(shape)
+        self.data = np.arange(np.prod(shape)).reshape(shape)
         self.data_dask = da.from_array(self.data, chunks=(2, 5, 2, 5))
 
     def _test_with(self, indices, normalised_indices=None):
@@ -248,7 +248,7 @@ class TestDaskLazyIndexer:
     """Test the :class:`~katdal.lazy_indexer.DaskLazyIndexer` class."""
     def setup_method(self):
         shape = (10, 20, 30)
-        self.data = np.arange(np.product(shape)).reshape(shape)
+        self.data = np.arange(np.prod(shape)).reshape(shape)
         self.data_dask = da.from_array(self.data, chunks=(1, 4, 5), name='x')
 
     def test_str_repr(self):

--- a/scripts/mvf_read_benchmark.py
+++ b/scripts/mvf_read_benchmark.py
@@ -65,8 +65,8 @@ for st in range(0, f.shape[0], args.time):
     current_time = time.time()
     elapsed = current_time - last_time
     last_time = current_time
-    size = np.product(vis.shape) * 10
+    size = np.prod(vis.shape) * 10
     logging.info('Loaded %d dumps (%.3f MB/s)', vis.shape[0], size / elapsed / 1e6)
-size = np.product(f.shape) * 10
+size = np.prod(f.shape) * 10
 elapsed = time.time() - start
 logging.info('Loaded %d bytes in %.3f s (%.3f MB/s)', size, elapsed, size / elapsed / 1e6)


### PR DESCRIPTION
Replace `np.product` with `np.prod`. This is deprecated as of NumPy 1.25 and will be removed in NumPy 2.0.

Also improve the tests:
  - Have more connect retries during token-based S3 store tests to suppress "connection reset by peer" errors.
  - Improve complex array comparisons and use this to sort out failing tests on Apple's arm64.
