### PR TITLE
SPR1-3236: Refresh for Python 3.13 and NumPy 2.0

### DIFF
--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -137,7 +137,7 @@ def create_gain(pol, ant, multi_channel=False, targets=False, fluxes=False):
         gains *= (-1) ** np.arange(len(GAIN_EVENTS))
     if multi_channel:
         gains = np.outer(gains, create_bandpass(pol, ant))
-        gains /= np.abs(gains)
+        gains /= np.nan_to_num(np.abs(gains), nan=1.0)
     if ant == BAD_GAIN_ANT:
         gains[:] = INVALID_GAIN
     bad_events = [GAIN_EVENTS.index(dump) for dump in BAD_GAIN_DUMPS]

--- a/katdal/test/test_applycal.py
+++ b/katdal/test/test_applycal.py
@@ -29,7 +29,8 @@ from katdal.applycal import (INVALID_GAIN, add_applycal_sensors,
                              apply_weights_correction,
                              calc_bandpass_correction, calc_correction,
                              calc_delay_correction, calc_gain_correction,
-                             calibrate_flux, complex_interp, get_cal_product)
+                             calibrate_flux, complex_interp, get_cal_product,
+                             quiet_reciprocal)
 from katdal.categorical import (CategoricalData, ComparableArrayWrapper,
                                 sensor_to_categorical)
 from katdal.flags import POSTPROC
@@ -216,7 +217,7 @@ def bandpass_corrections(pol, ant):
                             left=INVALID_GAIN, right=INVALID_GAIN)
     else:
         bp = np.full(N_CHANS, INVALID_GAIN)
-    return np.reciprocal(bp)
+    return quiet_reciprocal(bp)
 
 
 def gain_corrections(pol, ant, multi_channel=False, targets=False, fluxes=False):
@@ -240,7 +241,7 @@ def gain_corrections(pol, ant, multi_channel=False, targets=False, fluxes=False)
                 smooth_gains[on_target, chan] = np.complex64(1.0)
             else:
                 smooth_gains[on_target, chan] = INVALID_GAIN
-    return np.reciprocal(smooth_gains)
+    return quiet_reciprocal(smooth_gains)
 
 
 def corrections_per_corrprod(dumps, channels, cal_products):

--- a/katdal/test/test_chunkstore.py
+++ b/katdal/test/test_chunkstore.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2023, National Research Foundation (SARAO)
+# Copyright (c) 2017-2023,2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -255,6 +255,8 @@ class ChunkStoreTestBase:
     def test_chunk_zero_size(self):
         # Try a chunk with zero size
         self.put_get_chunk('y', (slice(4, 7), slice(3, 3), slice(0, 2)))
+
+    def test_chunk_zero_dim(self):
         # Try an empty slice on a zero-dimensional array (but why?)
         self.put_get_chunk('z', ())
 

--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2023, National Research Foundation (SARAO)
+# Copyright (c) 2017-2023,2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -306,6 +306,10 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         if name.startswith(PREFIX):
             return name
         return self.store.join(BUCKET, name)
+
+    @pytest.mark.skipif(sys.version_info >= (3, 12), reason="0-dim chunks not supported")
+    def test_chunk_zero_dim(self):
+        self.put_get_chunk('z', ())
 
     def test_chunk_non_existent(self):
         # An empty bucket will trigger StoreUnavailable so put something in there first

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,8 @@
 cffi==1.15.1                           # via cryptography
 coverage
 cryptography==38.0.3
+packaging
 pycparser==2.21                        # via cffi
+pyparsing                              # via packaging
 pytest
 pytest-cov


### PR DESCRIPTION
- [broken tests] Don't put zero-dimensional arrays (i.e. `np.array(1.0)`) into `S3ChunkStore` if on Python 3.12. This is only for testing corner cases anyway and no functionality is lost.
- [broken tests] Replace puzzling `float32` timestamps with proper `float64` ones (uncovered thanks to NumPy 2.0 data type promotion changes).
- [broken tests] Work around Dask slicing bug dask/dask#11993 for now (another corner case scenario).
- [warnings] Don't divide by NaNs when normalising gains.
- [warnings] Suppress `"invalid value"` warnings when `np.reciprocal` is applied to zeros and NaNs.
