### PR TITLE
SPP1-189: Make TestS3ChunkStore more flexible

### DIFF
--- a/katdal/test/test_chunkstore_s3.py
+++ b/katdal/test/test_chunkstore_s3.py
@@ -264,15 +264,21 @@ class TestS3ChunkStore(ChunkStoreTestBase):
         return url, kwargs
 
     @classmethod
-    def setup_class(cls):
-        """Start minio service running on temp dir, and ChunkStore on that."""
+    def setup_class(cls, **kwargs):
+        """Start minio service running on temp dir, and ChunkStore on that.
+
+        Parameters
+        ----------
+        kwargs : dict, optional
+            Extra keyword arguments passed to :class:`katdal.chunkstore_s3.S3ChunkStore`
+        """
         cls.arrays = generate_arrays()
         cls.credentials = ('access*key', 'secret*key')
         cls.tempdir = tempfile.mkdtemp()
         cls.minio = None
         try:
             cls.s3_url = cls.start_minio('127.0.0.1')
-            cls.store_url, cls.store_kwargs = cls.prepare_store_args(cls.s3_url)
+            cls.store_url, cls.store_kwargs = cls.prepare_store_args(cls.s3_url, **kwargs)
             cls.store = S3ChunkStore(cls.store_url, **cls.store_kwargs)
             # Ensure that pagination is tested
             cls.store.list_max_keys = 3


### PR DESCRIPTION
It is convenient to start a local S3 server using `TestS3ChunkStore`. I use this to benchmark Zarr, for example. It would be nice to open buckets with anonymous read support as they are on the real archive. This enables the Zarr HTTP filesystem backend (instead of s3fs), a lighter interface with simple support for our bearer tokens.

The `public_read` parameter to `S3ChunkStore` does this, and is passed into `TestS3ChunkStore.prepare_store_args` within the `setup_class` call. Make it possible to add more parameters this way, by adding `**kwargs` to `setup_class`.