### PR TITLE
SPP1-213: The first mvftoms unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ __pycache__
 pip-log.txt
 
 # Unit test / coverage reports
-.coverage
+.coverage*
 .tox
 nosetests.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011,2013,2016-2023,2026 National Research Foundation (SARAO)
+# Copyright (c) 2011,2013,2016-2023,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test = [
     "cryptography",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
 ]
 
 [project.urls]

--- a/src/katdal/__init__.py
+++ b/src/katdal/__init__.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2011-2021,2026 National Research Foundation (SARAO)
+# Copyright (c) 2011-2021,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katdal/ms_extra.py
+++ b/src/katdal/ms_extra.py
@@ -24,17 +24,8 @@ import os
 import os.path
 from copy import deepcopy
 
-import casacore
 import numpy as np
 from casacore import tables
-from pkg_resources import parse_version
-
-# Perform python-casacore version checks
-pyc_ver = parse_version(casacore.__version__)
-req_ver = parse_version("2.2.1")
-if not pyc_ver >= req_ver:
-    raise ImportError(f"python-casacore {req_ver} is required, but the current version is {pyc_ver}. "
-                      f"Note that python-casacore {req_ver} requires at least casacore 2.3.0.")
 
 
 def open_table(name, readonly=False, verbose=False, **kwargs):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ pycparser==2.21                        # via cffi
 pyparsing                              # via packaging
 pytest
 pytest-cov
+pytest-mock==3.12.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@
 ################################################################################
 
 import pytest
+import numpy as np
+from katpoint import Target
+from minimal_dataset import MinimalDataSet
 
 TEST_DURATION_TOLERANCE = 0.1
 
@@ -50,3 +53,21 @@ def pytest_runtest_makereport(item, call):
         report.longrepr = (f"\nTest took {report.duration:g} seconds, "
                            f"which is outside the range [{minimum:g}, {maximum:g}]\n")
     return report
+
+
+@pytest.fixture
+def dataset():
+    """A basic dataset used to test the selection mechanism."""
+    targets = [
+        # It would have been nice to have radec = 19:39, -63:42 but then
+        # selection by description string does not work because the catalogue's
+        # description string pads it out to radec = 19:39:00.00, -63:42:00.0.
+        # (XXX Maybe fix Target comparison in katpoint to support this?)
+        Target('J1939-6342 | PKS1934-638, radec bpcal, 19:39:25.03, -63:42:45.6'),
+        Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
+        Target('J0408-6545 | PKS 0408-65, radec bpcal, 4:08:20.38, -65:45:09.1'),
+        Target('J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4'),
+    ]
+    # Ensure that len(timestamps) is an integer multiple of len(targets)
+    timestamps = 1234667890.0 + 1.0 * np.arange(12)
+    return MinimalDataSet(targets, timestamps)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2023, National Research Foundation (SARAO)
+# Copyright (c) 2023,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,5 +69,5 @@ def dataset():
         Target('J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4'),
     ]
     # Ensure that len(timestamps) is an integer multiple of len(targets)
-    timestamps = 1234667890.0 + 1.0 * np.arange(12)
+    timestamps = 1234667890.0 + 1.0 * np.arange(3 * len(targets))
     return MinimalDataSet(targets, timestamps)

--- a/tests/minimal_dataset.py
+++ b/tests/minimal_dataset.py
@@ -21,6 +21,7 @@ from katpoint import Antenna, Timestamp
 
 from katdal.categorical import CategoricalData
 from katdal.dataset import DEFAULT_VIRTUAL_SENSORS, DataSet, Subarray
+from katdal.lazy_indexer import LazyIndexer
 from katdal.sensordata import SensorCache
 from katdal.spectral_window import SpectralWindow
 
@@ -60,6 +61,7 @@ class MinimalDataSet(DataSet):
     """
     def __init__(self, targets, timestamps, subarray=SUBARRAY, spectral_window=SPW):
         super().__init__(name='test', ref_ant='array')
+        self.version = '4.0'
         num_dumps = len(timestamps)
         num_chans = spectral_window.num_chans
         num_corrprods = len(subarray.corr_products)
@@ -120,7 +122,26 @@ class MinimalDataSet(DataSet):
         self.catalogue.add(targets)
         self.catalogue.antenna = array_ant
         self.select(spw=0, subarray=0)
+        self._vis = np.zeros(self.shape, dtype=np.complex64)
+        self._flags = np.zeros(self.shape, dtype=bool)
+        self._weights = np.zeros(self.shape, dtype=np.float32)
+
+    @property
+    def _stage1(self):
+        return (self._time_keep, self._freq_keep, self._corrprod_keep)
 
     @property
     def timestamps(self):
         return self._timestamps[self._time_keep]
+
+    @property
+    def vis(self):
+        return LazyIndexer(self._vis, self._stage1)
+
+    @property
+    def flags(self):
+        return LazyIndexer(self._flags, self._stage1)
+
+    @property
+    def weights(self):
+        return LazyIndexer(self._weights, self._stage1)

--- a/tests/minimal_dataset.py
+++ b/tests/minimal_dataset.py
@@ -1,0 +1,126 @@
+###############################################################################
+# Copyright (c) 2019,2021-2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+"""A minimal DataSet that is useful for unit tests."""
+
+import numpy as np
+from katpoint import Antenna, Timestamp
+
+from katdal.categorical import CategoricalData
+from katdal.dataset import DEFAULT_VIRTUAL_SENSORS, DataSet, Subarray
+from katdal.sensordata import SensorCache
+from katdal.spectral_window import SpectralWindow
+
+
+ANTENNAS = [
+    Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -8.264 -207.29 8.5965'),
+    Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -3419.5845 -1840.48 16.3825')
+]
+CORRPRODS = [
+    ('m000h', 'm000h'), ('m000v', 'm000v'),
+    ('m063h', 'm063h'), ('m063v', 'm063v'),
+    ('m000h', 'm063h'), ('m000v', 'm063v')
+]
+SUBARRAY = Subarray(ANTENNAS, CORRPRODS)
+SPW = SpectralWindow(
+    centre_freq=1284e6, channel_width=0, num_chans=16, sideband=1, bandwidth=856e6
+)
+
+
+class MinimalDataSet(DataSet):
+    """Minimal data set containing a series of slews and tracks.
+
+    The timestamps are divided evenly into compound scans (one per target).
+    Each compound scan consists of a 1-dump slew followed by a track.
+
+    This has to be a derived class instead of a factory function or fixture
+    because :class:`DataSet` is abstract. (XXX Actually it only needs
+    timestamps to be implemented for these tests to work, so it is nearly
+    there.)
+
+    Parameters
+    ----------
+    targets : list of :class:`katpoint.Target`
+    timestamps : array of float
+    subarray : :class:`katdal.dataset.Subarray`
+    spectral_window : :class:`katdal.spectral_window.SpectralWindow`
+    """
+    def __init__(self, targets, timestamps, subarray=SUBARRAY, spectral_window=SPW):
+        super().__init__(name='test', ref_ant='array')
+        num_dumps = len(timestamps)
+        num_chans = spectral_window.num_chans
+        num_corrprods = len(subarray.corr_products)
+        dump_period = timestamps[1] - timestamps[0]
+
+        num_compscans = len(targets)
+        num_dumps_per_compscan = num_dumps // num_compscans
+        assert num_dumps_per_compscan * num_compscans == num_dumps, \
+            "len(timestamps) should be an integer multiple of len(targets)"
+        compscan_starts = np.arange(0, num_dumps, num_dumps_per_compscan)
+        compscan_events = np.r_[compscan_starts, num_dumps]
+        # Each slew contains just 1 dump to make things simple
+        scan_events = sorted(np.r_[compscan_starts, compscan_starts + 1, num_dumps])
+        target_sensor = CategoricalData(targets, compscan_events)
+
+        def constant_sensor(value):
+            return CategoricalData([value], [0, num_dumps])
+
+        self.subarrays = [subarray]
+        self.spectral_windows = [spectral_window]
+        sensors = {}
+        sensors['Observation/spw_index'] = constant_sensor(0)
+        sensors['Observation/subarray_index'] = constant_sensor(0)
+        for ant in subarray.ants:
+            sensors[f'Antennas/{ant.name}/antenna'] = constant_sensor(ant)
+            ant_az = []
+            ant_el = []
+            for segment, target in target_sensor.segments():
+                az, el = target.azel(timestamps[segment], ant)
+                ant_az.append(az)
+                ant_el.append(el)
+            sensors[f'Antennas/{ant.name}/az'] = np.concatenate(ant_az)
+            sensors[f'Antennas/{ant.name}/el'] = np.concatenate(ant_el)
+        array_ant = subarray.ants[0].array_reference_antenna()
+        sensors['Antennas/array/antenna'] = constant_sensor(array_ant)
+
+        compscan_sensor = CategoricalData(range(num_compscans), compscan_events)
+        label_sensor = CategoricalData(['track'] * num_compscans, compscan_events)
+        sensors['Observation/target'] = target_sensor
+        sensors['Observation/compscan_index'] = compscan_sensor
+        sensors['Observation/target_index'] = compscan_sensor
+        sensors['Observation/label'] = label_sensor
+        scan_sensor = CategoricalData(range(2 * num_compscans), scan_events)
+        state_sensor = CategoricalData(['slew', 'track'] * num_compscans, scan_events)
+        sensors['Observation/scan_index'] = scan_sensor
+        sensors['Observation/scan_state'] = state_sensor
+
+        self._timestamps = timestamps
+        self._time_keep = np.full(num_dumps, True, dtype=bool)
+        self._freq_keep = np.full(num_chans, True, dtype=bool)
+        self._corrprod_keep = np.full(num_corrprods, True, dtype=bool)
+        self.dump_period = dump_period
+        self.start_time = Timestamp(timestamps[0] - 0.5 * dump_period)
+        self.end_time = Timestamp(timestamps[-1] + 0.5 * dump_period)
+        self.sensor = SensorCache(sensors, timestamps, dump_period,
+                                  keep=self._time_keep,
+                                  virtual=DEFAULT_VIRTUAL_SENSORS)
+        self.catalogue.add(targets)
+        self.catalogue.antenna = array_ant
+        self.select(spw=0, subarray=0)
+
+    @property
+    def timestamps(self):
+        return self._timestamps[self._time_keep]

--- a/tests/minimal_dataset.py
+++ b/tests/minimal_dataset.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019,2021-2023, National Research Foundation (SARAO)
+# Copyright (c) 2019,2021-2023,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/tests/mock_casacore.py
+++ b/tests/mock_casacore.py
@@ -18,7 +18,6 @@ import sys
 from unittest import mock
 
 casacore = mock.MagicMock()
-casacore.__version__ = "3.5.0"
 casacore.tables = tables = mock.MagicMock()
 
 # The output of casacore.tables.required_ms_desc("MAIN")

--- a/tests/mock_casacore.py
+++ b/tests/mock_casacore.py
@@ -1,0 +1,279 @@
+################################################################################
+# Copyright (c) 2026, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import sys
+from unittest import mock
+
+casacore = mock.MagicMock()
+casacore.__version__ = "3.5.0"
+casacore.tables = tables = mock.MagicMock()
+
+# The output of casacore.tables.required_ms_desc("MAIN")
+REQUIRED_MS_DESC = {
+    "UVW": {
+        "valueType": "double",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 5,
+        "maxlen": 0,
+        "comment": "Vector with uvw coordinates (in meters)",
+        "ndim": 1,
+        "shape": [3],
+        "_c_order": True,
+        "keywords": {
+            "QuantumUnits": ["m", "m", "m"],
+            "MEASINFO": {"type": "uvw", "Ref": "ITRF"},
+        },
+    },
+    "FLAG": {
+        "valueType": "boolean",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The data flags, array of bools with same shape as data",
+        "ndim": 2,
+        "_c_order": True,
+        "keywords": {},
+    },
+    "FLAG_CATEGORY": {
+        "valueType": "boolean",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The flag category, NUM_CAT flags for each datum",
+        "ndim": 3,
+        "_c_order": True,
+        "keywords": {},
+    },
+    "WEIGHT": {
+        "valueType": "float",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Weight for each polarization spectrum",
+        "ndim": 1,
+        "_c_order": True,
+        "keywords": {},
+    },
+    "SIGMA": {
+        "valueType": "float",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Estimated rms noise for channel with unity bandpass response",
+        "ndim": 1,
+        "_c_order": True,
+        "keywords": {},
+    },
+    "ANTENNA1": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "ID of first antenna in interferometer",
+        "keywords": {},
+    },
+    "ANTENNA2": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "ID of second antenna in interferometer",
+        "keywords": {},
+    },
+    "ARRAY_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "ID of array or subarray",
+        "keywords": {},
+    },
+    "DATA_DESC_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The data description table index",
+        "keywords": {},
+    },
+    "EXPOSURE": {
+        "valueType": "double",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The effective integration time",
+        "keywords": {"QuantumUnits": ["s"]},
+    },
+    "FEED1": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The feed index for ANTENNA1",
+        "keywords": {},
+    },
+    "FEED2": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The feed index for ANTENNA2",
+        "keywords": {},
+    },
+    "FIELD_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Unique id for this pointing",
+        "keywords": {},
+    },
+    "FLAG_ROW": {
+        "valueType": "boolean",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Row flag - flag all data in this row if True",
+        "keywords": {},
+    },
+    "INTERVAL": {
+        "valueType": "double",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "The sampling interval",
+        "keywords": {"QuantumUnits": ["s"]},
+    },
+    "OBSERVATION_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "ID for this observation, index in OBSERVATION table",
+        "keywords": {},
+    },
+    "PROCESSOR_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Id for backend processor, index in PROCESSOR table",
+        "keywords": {},
+    },
+    "SCAN_NUMBER": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Sequential scan number from on-line system",
+        "keywords": {},
+    },
+    "STATE_ID": {
+        "valueType": "int",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "ID for this observing state",
+        "keywords": {},
+    },
+    "TIME": {
+        "valueType": "double",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Modified Julian Day",
+        "keywords": {
+            "QuantumUnits": ["s"],
+            "MEASINFO": {"type": "epoch", "Ref": "UTC"},
+        },
+    },
+    "TIME_CENTROID": {
+        "valueType": "double",
+        "dataManagerType": "StandardStMan",
+        "dataManagerGroup": "StandardStMan",
+        "option": 0,
+        "maxlen": 0,
+        "comment": "Modified Julian Day",
+        "keywords": {
+            "QuantumUnits": ["s"],
+            "MEASINFO": {"type": "epoch", "Ref": "UTC"},
+        },
+    },
+    "_define_hypercolumn_": {},
+    "_keywords_": {"MS_VERSION": 2.0},
+    "_private_keywords_": {},
+}
+tables.required_ms_desc.return_value = REQUIRED_MS_DESC
+
+
+# Based on the output of casacore.tables.tablecreatearraycoldesc("DATA", 0+0j)
+def mock_tablecreatearraycoldesc(
+    columnname,
+    value,
+    ndim=0,
+    shape=[],
+    datamanagertype="",
+    datamanagergroup="",
+    options=0,
+    maxlen=0,
+    comment="",
+    valuetype="",
+    keywords={},
+):
+    return {
+        "name": columnname,
+        "desc": {
+            "valueType": valuetype,
+            "dataManagerType": datamanagertype,
+            "dataManagerGroup": datamanagergroup,
+            "ndim": ndim,
+            "shape": shape,
+            "_c_order": True,
+            "option": options,
+            "maxlen": maxlen,
+            "comment": comment,
+            "keywords": keywords,
+        },
+    }
+
+
+tables.tablecreatearraycoldesc.side_effect = mock_tablecreatearraycoldesc
+
+mock_table = mock.MagicMock()
+mock_table.nrows.return_value = 0
+tables.table.return_value = mock_table
+
+sys.modules["casacore"] = casacore

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,115 +20,11 @@ import logging
 
 import numpy as np
 import pytest
-from katpoint import Antenna, Target, Timestamp, rad2deg
+from katpoint import Target, Timestamp, rad2deg
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from katdal.categorical import CategoricalData
-from katdal.dataset import (DEFAULT_VIRTUAL_SENSORS, DataSet, Subarray,
-                            _selection_to_list, parse_url_or_path)
-from katdal.sensordata import SensorCache
-from katdal.spectral_window import SpectralWindow
-
-
-ANTENNAS = [
-    Antenna('m000, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -8.264 -207.29 8.5965'),
-    Antenna('m063, -30:42:39.8, 21:26:38.0, 1086.6, 13.5, -3419.5845 -1840.48 16.3825')
-]
-CORRPRODS = [
-    ('m000h', 'm000h'), ('m000v', 'm000v'),
-    ('m063h', 'm063h'), ('m063v', 'm063v'),
-    ('m000h', 'm063h'), ('m000v', 'm063v')
-]
-SUBARRAY = Subarray(ANTENNAS, CORRPRODS)
-SPW = SpectralWindow(
-    centre_freq=1284e6, channel_width=0, num_chans=16, sideband=1, bandwidth=856e6
-)
-
-
-class MinimalDataSet(DataSet):
-    """Minimal data set containing a series of slews and tracks.
-
-    The timestamps are divided evenly into compound scans (one per target).
-    Each compound scan consists of a 1-dump slew followed by a track.
-
-    This has to be a derived class instead of a factory function or fixture
-    because :class:`DataSet` is abstract. (XXX Actually it only needs
-    timestamps to be implemented for these tests to work, so it is nearly
-    there.)
-
-    Parameters
-    ----------
-    targets : list of :class:`katpoint.Target`
-    timestamps : array of float
-    subarray : :class:`katdal.dataset.Subarray`
-    spectral_window : :class:`katdal.spectral_window.SpectralWindow`
-    """
-    def __init__(self, targets, timestamps, subarray=SUBARRAY, spectral_window=SPW):
-        super().__init__(name='test', ref_ant='array')
-        num_dumps = len(timestamps)
-        num_chans = spectral_window.num_chans
-        num_corrprods = len(subarray.corr_products)
-        dump_period = timestamps[1] - timestamps[0]
-
-        num_compscans = len(targets)
-        num_dumps_per_compscan = num_dumps // num_compscans
-        assert num_dumps_per_compscan * num_compscans == num_dumps, \
-            "len(timestamps) should be an integer multiple of len(targets)"
-        compscan_starts = np.arange(0, num_dumps, num_dumps_per_compscan)
-        compscan_events = np.r_[compscan_starts, num_dumps]
-        # Each slew contains just 1 dump to make things simple
-        scan_events = sorted(np.r_[compscan_starts, compscan_starts + 1, num_dumps])
-        target_sensor = CategoricalData(targets, compscan_events)
-
-        def constant_sensor(value):
-            return CategoricalData([value], [0, num_dumps])
-
-        self.subarrays = [subarray]
-        self.spectral_windows = [spectral_window]
-        sensors = {}
-        sensors['Observation/spw_index'] = constant_sensor(0)
-        sensors['Observation/subarray_index'] = constant_sensor(0)
-        for ant in subarray.ants:
-            sensors[f'Antennas/{ant.name}/antenna'] = constant_sensor(ant)
-            ant_az = []
-            ant_el = []
-            for segment, target in target_sensor.segments():
-                az, el = target.azel(timestamps[segment], ant)
-                ant_az.append(az)
-                ant_el.append(el)
-            sensors[f'Antennas/{ant.name}/az'] = np.concatenate(ant_az)
-            sensors[f'Antennas/{ant.name}/el'] = np.concatenate(ant_el)
-        array_ant = subarray.ants[0].array_reference_antenna()
-        sensors['Antennas/array/antenna'] = constant_sensor(array_ant)
-
-        compscan_sensor = CategoricalData(range(num_compscans), compscan_events)
-        label_sensor = CategoricalData(['track'] * num_compscans, compscan_events)
-        sensors['Observation/target'] = target_sensor
-        sensors['Observation/compscan_index'] = compscan_sensor
-        sensors['Observation/target_index'] = compscan_sensor
-        sensors['Observation/label'] = label_sensor
-        scan_sensor = CategoricalData(range(2 * num_compscans), scan_events)
-        state_sensor = CategoricalData(['slew', 'track'] * num_compscans, scan_events)
-        sensors['Observation/scan_index'] = scan_sensor
-        sensors['Observation/scan_state'] = state_sensor
-
-        self._timestamps = timestamps
-        self._time_keep = np.full(num_dumps, True, dtype=bool)
-        self._freq_keep = np.full(num_chans, True, dtype=bool)
-        self._corrprod_keep = np.full(num_corrprods, True, dtype=bool)
-        self.dump_period = dump_period
-        self.start_time = Timestamp(timestamps[0] - 0.5 * dump_period)
-        self.end_time = Timestamp(timestamps[-1] + 0.5 * dump_period)
-        self.sensor = SensorCache(sensors, timestamps, dump_period,
-                                  keep=self._time_keep,
-                                  virtual=DEFAULT_VIRTUAL_SENSORS)
-        self.catalogue.add(targets)
-        self.catalogue.antenna = array_ant
-        self.select(spw=0, subarray=0)
-
-    @property
-    def timestamps(self):
-        return self._timestamps[self._time_keep]
+from katdal.dataset import _selection_to_list, parse_url_or_path
+from minimal_dataset import MinimalDataSet
 
 
 def test_parse_url_or_path():
@@ -208,24 +104,6 @@ class TestVirtualSensors:
         assert_array_equal(self.dataset.u[:, 5], u)
         assert_array_equal(self.dataset.v[:, 5], v)
         assert_array_equal(self.dataset.w[:, 5], w)
-
-
-@pytest.fixture
-def dataset():
-    """A basic dataset used to test the selection mechanism."""
-    targets = [
-        # It would have been nice to have radec = 19:39, -63:42 but then
-        # selection by description string does not work because the catalogue's
-        # description string pads it out to radec = 19:39:00.00, -63:42:00.0.
-        # (XXX Maybe fix Target comparison in katpoint to support this?)
-        Target('J1939-6342 | PKS1934-638, radec bpcal, 19:39:25.03, -63:42:45.6'),
-        Target('J1939-6342, radec gaincal, 19:39:25.03, -63:42:45.6'),
-        Target('J0408-6545 | PKS 0408-65, radec bpcal, 4:08:20.38, -65:45:09.1'),
-        Target('J1346-6024 | Cen B, radec, 13:46:49.04, -60:24:29.4'),
-    ]
-    # Ensure that len(timestamps) is an integer multiple of len(targets)
-    timestamps = 1234667890.0 + 1.0 * np.arange(12)
-    return MinimalDataSet(targets, timestamps)
 
 
 def test_selecting_antenna(dataset):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2019,2021-2024, National Research Foundation (SARAO)
+# Copyright (c) 2018-2019,2021-2024,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/tests/test_mvftoms.py
+++ b/tests/test_mvftoms.py
@@ -34,7 +34,7 @@ def test_ms_extra_logic():
     assert mock_casacore.tables.default_ms.called
 
 
-def test_ms_async_writer(tmp_path):
+def test_ms_async_writer(tmp_path, mocker):
     """Test the ms_async writer process logic."""
     ms_name = str(tmp_path / "test.ms")
     options = mock.MagicMock(verbose=True, model_data=False)
@@ -62,64 +62,66 @@ def test_ms_async_writer(tmp_path):
     raw_flag = ms_async.RawArray((4, 1, 2, 16, 4), bool)
 
     # We need to mock ms_extra.open_table since it returns a mock that we want to control
-    with mock.patch("katdal.ms_extra.open_table") as mock_open:
-        table_mock = mock_open.return_value
-        table_mock.nrows.return_value = 0
-        table_mock.colnames.return_value = list(mock_casacore.REQUIRED_MS_DESC.keys()) + [
-            "DATA",
-            "WEIGHT_SPECTRUM",
-            "SIGMA_SPECTRUM",
-        ]
-        ms_async.ms_writer_process(
-            work_queue,
-            result_queue,
-            options,
-            antennas,
-            cp_info,
-            ms_name,
-            raw_vis,
-            raw_weight,
-            raw_flag,
-            start_row=0,
-        )
+    mock_open = mocker.patch("katdal.ms_extra.open_table")
+    table_mock = mock_open.return_value
+    table_mock.nrows.return_value = 0
+    table_mock.colnames.return_value = list(mock_casacore.REQUIRED_MS_DESC.keys()) + [
+        "DATA",
+        "WEIGHT_SPECTRUM",
+        "SIGMA_SPECTRUM",
+    ]
+
+    # The function under test (FUT)
+    ms_async.ms_writer_process(
+        work_queue,
+        result_queue,
+        options,
+        antennas,
+        cp_info,
+        ms_name,
+        raw_vis,
+        raw_weight,
+        raw_flag,
+        start_row=0,
+    )
 
     # Check if an error was put in the result queue
     for call in result_queue.put.call_args_list:
         obj = call[0][0]
         if isinstance(obj, Exception):
             raise obj
-
     assert table_mock.addrows.called
 
 
-def test_mvftoms_main(tmp_path, dataset):
+def test_mvftoms_main(tmp_path, mocker, dataset):
     """End-to-end test of the mvftoms script."""
     ms_name = str(tmp_path / "test.ms")
 
-    with mock.patch("katdal.open", return_value=dataset):
-        with mock.patch("sys.argv", ["mvftoms.py", "dummy.rdb", "-o", ms_name]):
-            # Mock multiprocessing.Process to run synchronously
-            with mock.patch("multiprocessing.Process") as mock_proc:
-                # Capture the target and args
-                def side_effect(*args, **kwargs):
-                    p = mock.MagicMock()
-                    return p
+    mocker.patch("katdal.open", return_value=dataset)
+    mocker.patch("sys.argv", ["mvftoms.py", "dummy.rdb", "-o", ms_name])
+    # Mock multiprocessing.Process to run synchronously
+    mock_proc = mocker.patch("multiprocessing.Process")
+    # Capture the target and args
+    def side_effect(*args, **kwargs):
+        p = mock.MagicMock()
+        return p
 
-                mock_proc.side_effect = side_effect
+    mock_proc.side_effect = side_effect
 
-                # We need to avoid the infinite loop in result_queue.get()
-                with mock.patch("multiprocessing.Queue") as mock_queue_cls:
-                    res_queue = mock_queue_cls.return_value
-                    # MinimalDataSet has 4 tracks (and 4 slews which are skipped)
-                    # For each track, result_queue.get() is called once.
-                    # Then in finally, it's called until it gets None.
-                    res_queue.get.side_effect = [mock.MagicMock(scan_size=1024)] * 4 + [None]
-                    # get_nowait is used to check for errors asynchronously
-                    res_queue.get_nowait.side_effect = queue.Empty
+    # We need to avoid the infinite loop in result_queue.get()
+    mock_queue_cls = mocker.patch("multiprocessing.Queue")
+    res_queue = mock_queue_cls.return_value
+    # MinimalDataSet has 4 tracks (and 4 slews which are skipped)
+    # For each track, result_queue.get() is called once.
+    # Then in finally, it's called until it gets None.
+    res_queue.get.side_effect = [mock.MagicMock(scan_size=1024)] * 4 + [None]
+    # get_nowait is used to check for errors asynchronously
+    res_queue.get_nowait.side_effect = queue.Empty
 
-                    try:
-                        mvftoms.main()
-                    except SystemExit:
-                        pass
+    # The function under test (FUT)
+    try:
+        mvftoms.main()
+    except SystemExit:
+        pass
 
     assert mock_casacore.tables.default_ms.called

--- a/tests/test_mvftoms.py
+++ b/tests/test_mvftoms.py
@@ -1,0 +1,125 @@
+################################################################################
+# Copyright (c) 2026, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import queue
+from unittest import mock
+
+import numpy as np
+from katpoint import Target
+import mock_casacore
+from minimal_dataset import ANTENNAS
+
+# Now that casacore has been mocked we can import these
+from katdal import ms_extra, ms_async
+from katdal.scripts import mvftoms
+
+
+def test_ms_extra_logic():
+    """Test that we can call create_ms without real casacore."""
+    desc, dminfo = ms_extra.kat_ms_desc_and_dminfo(nbl=6, nchan=16, ncorr=4)
+    ms_extra.create_ms("test.ms", desc, dminfo)
+    assert mock_casacore.tables.default_ms.called
+
+
+def test_ms_async_writer(tmp_path):
+    """Test the ms_async writer process logic."""
+    ms_name = str(tmp_path / "test.ms")
+    options = mock.MagicMock(verbose=True, model_data=False)
+    antennas = ANTENNAS
+    cp_info = mock.MagicMock(ant1_index=np.array([0, 0]), ant2_index=np.array([0, 1]))
+
+    work_queue = mock.Mock()
+    result_queue = mock.Mock()
+
+    # Mocking work_queue.get to return one item then None
+    target = Target("Sun, special")
+    item = ms_async.QueueItem(
+        slot=0,
+        target=target,
+        time_utc=np.array([100.0]),
+        dump_time_width=1.0,
+        field_id=0,
+        state_id=0,
+        scan_itr=1,
+    )
+    work_queue.get.side_effect = [item, None]
+
+    raw_vis = ms_async.RawArray((4, 1, 2, 16, 4), np.complex64)
+    raw_weight = ms_async.RawArray((4, 1, 2, 16, 4), np.float32)
+    raw_flag = ms_async.RawArray((4, 1, 2, 16, 4), bool)
+
+    # We need to mock ms_extra.open_table since it returns a mock that we want to control
+    with mock.patch("katdal.ms_extra.open_table") as mock_open:
+        table_mock = mock_open.return_value
+        table_mock.nrows.return_value = 0
+        table_mock.colnames.return_value = list(mock_casacore.REQUIRED_MS_DESC.keys()) + [
+            "DATA",
+            "WEIGHT_SPECTRUM",
+            "SIGMA_SPECTRUM",
+        ]
+        ms_async.ms_writer_process(
+            work_queue,
+            result_queue,
+            options,
+            antennas,
+            cp_info,
+            ms_name,
+            raw_vis,
+            raw_weight,
+            raw_flag,
+            start_row=0,
+        )
+
+    # Check if an error was put in the result queue
+    for call in result_queue.put.call_args_list:
+        obj = call[0][0]
+        if isinstance(obj, Exception):
+            raise obj
+
+    assert table_mock.addrows.called
+
+
+def test_mvftoms_main(tmp_path, dataset):
+    """End-to-end test of the mvftoms script."""
+    ms_name = str(tmp_path / "test.ms")
+
+    with mock.patch("katdal.open", return_value=dataset):
+        with mock.patch("sys.argv", ["mvftoms.py", "dummy.rdb", "-o", ms_name]):
+            # Mock multiprocessing.Process to run synchronously
+            with mock.patch("multiprocessing.Process") as mock_proc:
+                # Capture the target and args
+                def side_effect(*args, **kwargs):
+                    p = mock.MagicMock()
+                    return p
+
+                mock_proc.side_effect = side_effect
+
+                # We need to avoid the infinite loop in result_queue.get()
+                with mock.patch("multiprocessing.Queue") as mock_queue_cls:
+                    res_queue = mock_queue_cls.return_value
+                    # MinimalDataSet has 4 tracks (and 4 slews which are skipped)
+                    # For each track, result_queue.get() is called once.
+                    # Then in finally, it's called until it gets None.
+                    res_queue.get.side_effect = [mock.MagicMock(scan_size=1024)] * 4 + [None]
+                    # get_nowait is used to check for errors asynchronously
+                    res_queue.get_nowait.side_effect = queue.Empty
+
+                    try:
+                        mvftoms.main()
+                    except SystemExit:
+                        pass
+
+    assert mock_casacore.tables.default_ms.called

--- a/tests/test_mvftoms.py
+++ b/tests/test_mvftoms.py
@@ -101,12 +101,13 @@ def test_mvftoms_main(tmp_path, mocker, dataset):
     mocker.patch("sys.argv", ["mvftoms.py", "dummy.rdb", "-o", ms_name])
     # Mock multiprocessing.Process to run synchronously
     mock_proc = mocker.patch("multiprocessing.Process")
-    # Capture the target and args
-    def side_effect(*args, **kwargs):
+
+    def _side_effect(*args, **kwargs):
+        """Capture the target and args."""
         p = mock.MagicMock()
         return p
 
-    mock_proc.side_effect = side_effect
+    mock_proc.side_effect = _side_effect
 
     # We need to avoid the infinite loop in result_queue.get()
     mock_queue_cls = mocker.patch("multiprocessing.Queue")

--- a/tests/test_sensordata.py
+++ b/tests/test_sensordata.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018-2022, National Research Foundation (SARAO)
+# Copyright (c) 2018-2022,2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/tests/test_sensordata.py
+++ b/tests/test_sensordata.py
@@ -72,9 +72,9 @@ class TestToStr:
         np.testing.assert_array_equal(to_str(a), b)
 
 
-@mock.patch('katsdptelstate.encoding._allow_pickle', True)
-@mock.patch('katsdptelstate.encoding._warn_on_pickle', False)
-def test_telstate_decode():
+def test_telstate_decode(mocker):
+    mocker.patch('katsdptelstate.encoding._allow_pickle', True)
+    mocker.patch('katsdptelstate.encoding._warn_on_pickle', False)
     raw = "S'1'\n."
     assert telstate_decode(raw) == '1'
     assert telstate_decode(raw.encode()) == '1'


### PR DESCRIPTION
This adds unit tests for the MS machinery (`mvftoms` and by extension `ms_extra` and `ms_async`) for the first time.

Mock out `casacore` so that these tests can run on any platform. Promote the `dataset` fixture to `conftest.py` so that more tests can benefit.

Finally remove the thorn of `pkg_resources` that sparked this whole business (including SPP1-214 aka #393!) to address #379.
