### PR TITLE
SPP1-90: Log mvftoms conversion  to MS HISTORY subtable

### DIFF
--- a/src/katdal/ms_extra.py
+++ b/src/katdal/ms_extra.py
@@ -903,9 +903,7 @@ def populate_pointing_dict(num_antennas, observation_duration, start_time, phase
     return pointing_dict
 
 
-def populate_history_dict(times, applications, origins, messages,
-                          cli_command=None, app_params=None,
-                          priorities=None, object_ids=None, observation_ids=None):
+def populate_history_dict(times, applications, origins, messages, cli_command=None, app_params=None):
     """Construct a dictionary containing all standard columns for the HISTORY subtable.
 
     Parameters
@@ -922,12 +920,6 @@ def populate_history_dict(times, applications, origins, messages,
         CLI arguments vector per row
     app_params : sequence of list of str, optional
         Application parameters vector per row
-    priorities : sequence of str, optional
-        Priority strings (e.g., 'INFO')
-    object_ids : sequence of int, optional
-        Object IDs (default 0)
-    observation_ids : sequence of int, optional
-        Observation IDs (default -1)
 
     Returns
     -------
@@ -943,22 +935,16 @@ def populate_history_dict(times, applications, origins, messages,
         cli_command = [[""]] * n
     if app_params is None:
         app_params = [[""]] * n
-    if priorities is None:
-        priorities = ["INFO"] * n
-    if object_ids is None:
-        object_ids = [0] * n
-    if observation_ids is None:
-        observation_ids = [-1] * n
 
     history_dict = {}
-    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=object)
-    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=object)
-    history_dict['APPLICATION'] = np.asarray(applications, dtype=object)
-    history_dict['MESSAGE'] = np.asarray(messages, dtype=object)
-    history_dict['OBJECT_ID'] = np.asarray(object_ids, dtype=np.int32)
-    history_dict['OBSERVATION_ID'] = np.asarray(observation_ids, dtype=np.int32)
-    history_dict['ORIGIN'] = np.asarray(origins, dtype=object)
-    history_dict['PRIORITY'] = np.asarray(priorities, dtype=object)
+    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=str)
+    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=str)
+    history_dict['APPLICATION'] = np.asarray(applications, dtype=str)
+    history_dict['MESSAGE'] = np.asarray(messages, dtype=str)
+    history_dict['OBJECT_ID'] = np.zeros(n, dtype=np.int32)
+    history_dict['OBSERVATION_ID'] = np.full(n, -1, dtype=np.int32)
+    history_dict['ORIGIN'] = np.asarray(origins, dtype=str)
+    history_dict['PRIORITY'] = np.full(n, "INFO", dtype='U32')
     history_dict['TIME'] = np.asarray(times, dtype=np.float64)
 
     return history_dict

--- a/src/katdal/ms_extra.py
+++ b/src/katdal/ms_extra.py
@@ -903,6 +903,67 @@ def populate_pointing_dict(num_antennas, observation_duration, start_time, phase
     return pointing_dict
 
 
+def populate_history_dict(times, applications, origins, messages,
+                          cli_command=None, app_params=None,
+                          priorities=None, object_ids=None, observation_ids=None):
+    """Construct a dictionary containing all standard columns for the HISTORY subtable.
+
+    Parameters
+    ----------
+    times : sequence of float
+        Event times in MJD seconds
+    applications : sequence of str
+        Application names (e.g., 'mvftoms')
+    origins : sequence of str
+        Origin script/module names (e.g., 'mvftoms')
+    messages : sequence of str
+        Log and parameter history entries
+    cli_command : sequence of list of str, optional
+        CLI arguments vector per row
+    app_params : sequence of list of str, optional
+        Application parameters vector per row
+    priorities : sequence of str, optional
+        Priority strings (e.g., 'INFO')
+    object_ids : sequence of int, optional
+        Object IDs (default 0)
+    observation_ids : sequence of int, optional
+        Observation IDs (default -1)
+
+    Returns
+    -------
+    history_dict : dict
+        Dictionary mapping HISTORY column names to numpy arrays
+    """
+    n = len(times)
+    if not (len(applications) == len(origins) == len(messages) == n):
+        raise ValueError("All main input sequences must have the same length")
+
+    # Supply default column data if optional sequences are not provided
+    if cli_command is None:
+        cli_command = [[""]] * n
+    if app_params is None:
+        app_params = [[""]] * n
+    if priorities is None:
+        priorities = ["INFO"] * n
+    if object_ids is None:
+        object_ids = [0] * n
+    if observation_ids is None:
+        observation_ids = [-1] * n
+
+    history_dict = {}
+    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=object)
+    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=object)
+    history_dict['APPLICATION'] = np.asarray(applications, dtype=object)
+    history_dict['MESSAGE'] = np.asarray(messages, dtype=object)
+    history_dict['OBJECT_ID'] = np.asarray(object_ids, dtype=np.int32)
+    history_dict['OBSERVATION_ID'] = np.asarray(observation_ids, dtype=np.int32)
+    history_dict['ORIGIN'] = np.asarray(origins, dtype=object)
+    history_dict['PRIORITY'] = np.asarray(priorities, dtype=object)
+    history_dict['TIME'] = np.asarray(times, dtype=np.float64)
+
+    return history_dict
+
+
 def populate_ms_dict(uvw_coordinates, vis_data, timestamps, antenna1_index, antenna2_index,
                      integrate_length, center_frequencies, channel_bandwidths,
                      antenna_names, antenna_positions, antenna_diameter,

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -39,7 +39,6 @@ import katdal
 from katdal import averager, ms_async, ms_extra
 from katdal.flags import NAMES as FLAG_NAMES
 from katdal.lazy_indexer import DaskLazyIndexer
-from katdal.sensordata import telstate_decode
 
 SLOTS = 4    # Controls overlap between loading and writing
 
@@ -256,9 +255,6 @@ def main():
     parser.add_argument("--flagav", action="store_true", default=False,
                         help="If a single element in an averaging bin is flagged, "
                              "flag the averaged bin")
-    parser.add_argument("--caltables", action="store_true", default=False,
-                        help="Create calibration tables from gain solutions in "
-                             "the dataset (if present)")
     parser.add_argument("--quack", type=int, default=1, metavar='N',
                         help="Discard the first N dumps "
                              "(which are frequently incomplete)")
@@ -569,12 +565,6 @@ def main():
             ms_dict['OBSERVATION'] = ms_extra.populate_observation_dict(
                 start_time, end_time, telescope_name, dataset.observer, dataset.experiment_id)
 
-            # before resetting ms_dict, copy subset to caltable dictionary
-            if options.caltables:
-                caltable_dict = {}
-                caltable_dict['ANTENNA'] = ms_dict['ANTENNA']
-                caltable_dict['OBSERVATION'] = ms_dict['OBSERVATION']
-
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
 
@@ -767,151 +757,6 @@ def main():
             tar = tarfile.open(f'{ms_name}.tar', 'w')
             tar.add(ms_name, arcname=os.path.basename(ms_name))
             tar.close()
-
-        # --------------------------------------
-        # Now write calibration product tables if required
-        # Open first HDF5 file in the list to extract TelescopeState parameters from
-        #   (can't extract telstate params from contatenated katdal file as it
-        #    uses the hdf5 file directly)
-        first_dataset = katdal.open(args[0], ref_ant=options.ref_ant)
-        main_table = ms_extra.open_table(ms_name, verbose=options.verbose)
-
-        if options.caltables:
-            # copy extra subtable dictionary values necessary for caltable
-            caltable_dict['SPECTRAL_WINDOW'] = ms_dict['SPECTRAL_WINDOW']
-            caltable_dict['FIELD'] = ms_dict['FIELD']
-
-            solution_types = ['G', 'B', 'K']
-            ms_soltype_lookup = {'G': 'G Jones', 'B': 'B Jones', 'K': 'K Jones'}
-
-            print("\nWriting calibration solution tables to disk....")
-            if 'TelescopeState' not in first_dataset.file.keys():
-                print(" No TelescopeState in first dataset. Can't create solution tables.\n")
-            else:
-                # first get solution antenna ordering
-                #   newer files have the cal antlist as a sensor
-                if 'cal_antlist' in first_dataset.file['TelescopeState'].keys():
-                    a0 = first_dataset.file['TelescopeState/cal_antlist'][()]
-                    antlist = telstate_decode(a0[0][1])
-                #   older files have the cal antlist as an attribute
-                elif 'cal_antlist' in first_dataset.file['TelescopeState'].attrs.keys():
-                    antlist = np.safe_eval(first_dataset.file['TelescopeState'].attrs['cal_antlist'])
-                else:
-                    print(" No calibration antenna ordering in first dataset. "
-                          "Can't create solution tables.\n")
-                    continue
-                antlist_indices = list(range(len(antlist)))
-
-                # for each solution type in the file, create a table
-                for sol in solution_types:
-                    caltable_name = f'{basename}.{sol}'
-                    sol_name = f'cal_product_{sol}'
-
-                    if sol_name in first_dataset.file['TelescopeState'].keys():
-                        print(f' - creating {sol} solution table: {caltable_name}\n')
-
-                        # get solution values from the file
-                        solutions = first_dataset.file['TelescopeState'][sol_name][()]
-                        soltimes, solvals = [], []
-                        for t, s in solutions:
-                            soltimes.append(t)
-                            solvals.append(telstate_decode(s))
-                        solvals = np.array(solvals)
-
-                        # convert averaged UTC timestamps to MJD seconds.
-                        sol_mjd = np.array([katpoint.Timestamp(time_utc).to_mjd() * 24 * 60 * 60
-                                            for time_utc in soltimes])
-
-                        # determine solution characteristics
-                        if len(solvals.shape) == 4:
-                            ntimes, nchans, npols, nants = solvals.shape
-                        else:
-                            ntimes, npols, nants = solvals.shape
-                            nchans = 1
-                            solvals = solvals.reshape((ntimes, nchans, npols, nants))
-
-                        # create calibration solution measurement set
-                        caltable_desc = ms_extra.caltable_desc_float \
-                            if sol == 'K' else ms_extra.caltable_desc_complex
-                        caltable = ms_extra.open_table(caltable_name, tabledesc=caltable_desc)
-
-                        # add other keywords for main table
-                        if sol == 'K':
-                            caltable.putkeyword('ParType', 'Float')
-                        else:
-                            caltable.putkeyword('ParType', 'Complex')
-                        caltable.putkeyword('MSName', ms_name)
-                        caltable.putkeyword('VisCal', ms_soltype_lookup[sol])
-                        caltable.putkeyword('PolBasis', 'unknown')
-                        # add necessary units
-                        caltable.putcolkeywords('TIME', {'MEASINFO': {'Ref': 'UTC', 'type': 'epoch'},
-                                                         'QuantumUnits': ['s']})
-                        caltable.putcolkeywords('INTERVAL', {'QuantumUnits': ['s']})
-                        # specify that this is a calibration table
-                        caltable.putinfo({'readme': '', 'subType': ms_soltype_lookup[sol],
-                                          'type': 'Calibration'})
-
-                        # get the solution data to write to the main table
-                        solutions_to_write = solvals.transpose(0, 3, 1, 2).reshape((
-                            ntimes * nants, nchans, npols))
-
-                        # MS's store delays in nanoseconds
-                        if sol == 'K':
-                            solutions_to_write = 1e9 * solutions_to_write
-
-                        times_to_write = np.repeat(sol_mjd, nants)
-                        antennas_to_write = np.tile(antlist_indices, ntimes)
-                        # just mock up the scans -- this doesnt actually correspond to scans in the data
-                        scans_to_write = np.repeat(list(range(len(sol_mjd))), nants)
-                        # write the main table
-                        main_cal_dict = ms_extra.populate_caltable_main_dict(
-                            times_to_write, solutions_to_write, antennas_to_write, scans_to_write)
-                        ms_extra.write_rows(caltable, main_cal_dict, verbose=options.verbose)
-
-                        # create and write subtables
-                        subtables = ['OBSERVATION', 'ANTENNA', 'FIELD', 'SPECTRAL_WINDOW', 'HISTORY']
-                        subtable_key = [(os.path.join(caltable.name(), st)) for st in subtables]
-
-                        # Add subtable keywords and create subtables
-                        # ------------------------------------------------------------------------------
-                        # # this gives an error in casapy:
-                        # *** Error *** MSObservation(const Table &) - table is not a valid MSObservation
-                        # for subtable, subtable_location in zip(subtables, subtable_key)
-                        #    ms_extra.open_table(subtable_location, tabledesc=ms_extra.ms_desc[subtable])
-                        #    caltable.putkeyword(subtable, 'Table: {0}'.format(subtable_location))
-                        # # write the static info for the table
-                        # ms_extra.write_dict(caltable_dict, caltable.name(), verbose=options.verbose)
-                        # ------------------------------------------------------------------------------
-                        # instead try just copying the main table subtables
-                        #   this works to plot the data casapy, but the solutions still can't be
-                        #   applied in casapy...
-                        for subtable, subtable_location in zip(subtables, subtable_key):
-                            main_subtable = ms_extra.open_table(os.path.join(main_table.name(),
-                                                                             subtable))
-                            main_subtable.copy(subtable_location, deep=True)
-                            caltable.putkeyword(subtable, f'Table: {subtable_location}')
-                            if subtable == 'ANTENNA':
-                                caltable.putkeyword('NAME', antlist)
-                                caltable.putkeyword('STATION', antlist)
-                        if sol != 'B':
-                            spw_table = ms_extra.open_table(os.path.join(caltable.name(),
-                                                                         'SPECTRAL_WINDOW'))
-                            spw_table.removerows(spw_table.rownumbers())
-                            cen_index = len(out_freqs) // 2
-                            # the delay values in the cal pipeline are calculated relative to frequency 0
-                            ref_freq = 0.0 if sol == 'K' else None
-                            spw_dict = {'SPECTRAL_WINDOW':
-                                        ms_extra.populate_spectral_window_dict(np.atleast_1d(out_freqs[cen_index]),
-                                                                               np.atleast_1d(channel_freq_width),
-                                                                               ref_freq=ref_freq)}
-                            ms_extra.write_dict(spw_dict, caltable.name(), verbose=options.verbose)
-
-                        # done with this caltable
-                        caltable.flush()
-                        caltable.close()
-
-        main_table.close()
-        # done writing main table
 
 
 if __name__ == '__main__':

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -25,6 +25,7 @@ import multiprocessing.sharedctypes
 import os
 import queue
 import re
+import sys
 import tarfile
 import time
 import urllib.parse
@@ -564,6 +565,52 @@ def main():
                                                                           circular=options.circular)
             ms_dict['OBSERVATION'] = ms_extra.populate_observation_dict(
                 start_time, end_time, telescope_name, dataset.observer, dataset.experiment_id)
+
+            # Log conversion into HISTORY subtable
+
+            current_mjd_sec = katpoint.Timestamp().to_mjd() * 86400.0
+            # Capture the exact command line invocation
+            cli_cmd = list(sys.argv)
+
+            # Construct message lines matching CASA task history format
+            messages = [
+                "taskname=mvftoms",
+                f"version: {katdal.__version__}",
+            ]
+
+            # Record input dataset path(s)
+            if isinstance(open_args, (list, tuple)):
+                messages.append(f"dataset         = {repr(list(open_args))}")
+            else:
+                messages.append(f"dataset         = {repr(open_args)}")
+
+            # Append user-selected command line parameters
+            for opt, val in vars(options).items():
+                if val is not None:
+                    messages.append(f"{opt:15s} = {repr(val)}")
+
+            n_rows = len(messages)
+            times = [current_mjd_sec] * n_rows
+            applications = ["mvftoms"] * n_rows
+            origins = ["mvftoms"] * n_rows
+            cli_commands = [cli_cmd] * n_rows
+            app_params = [[""]] * n_rows
+            priorities = ["INFO"] * n_rows
+            object_ids = [0] * n_rows
+            observation_ids = [-1] * n_rows
+
+            # Populate HISTORY subtable
+            ms_dict['HISTORY'] = ms_extra.populate_history_dict(
+                times=times,
+                applications=applications,
+                origins=origins,
+                messages=messages,
+                cli_command=cli_commands,
+                app_params=app_params,
+                priorities=priorities,
+                object_ids=object_ids,
+                observation_ids=observation_ids,
+            )
 
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -576,6 +576,7 @@ def main():
             messages = [
                 "taskname=mvftoms",
                 f"version: {katdal.__version__}",
+                f"katpoint version: {katpoint.__version__}",
             ]
 
             # Record input dataset path(s)
@@ -601,17 +602,13 @@ def main():
 
             # Populate HISTORY subtable
             ms_dict['HISTORY'] = ms_extra.populate_history_dict(
-                times=times,
-                applications=applications,
-                origins=origins,
-                messages=messages,
-                cli_command=cli_commands,
-                app_params=app_params,
-                priorities=priorities,
-                object_ids=object_ids,
-                observation_ids=observation_ids,
+              times=times,
+              applications=applications,
+              origins=origins,
+              messages=messages,
+              cli_command=cli_commands
             )
-
+            
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
 

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -595,20 +595,16 @@ def main():
             applications = ["mvftoms"] * n_rows
             origins = ["mvftoms"] * n_rows
             cli_commands = [cli_cmd] * n_rows
-            app_params = [[""]] * n_rows
-            priorities = ["INFO"] * n_rows
-            object_ids = [0] * n_rows
-            observation_ids = [-1] * n_rows
 
             # Populate HISTORY subtable
             ms_dict['HISTORY'] = ms_extra.populate_history_dict(
-              times=times,
-              applications=applications,
-              origins=origins,
-              messages=messages,
-              cli_command=cli_commands
+                times=times,
+                applications=applications,
+                origins=origins,
+                messages=messages,
+                cli_command=cli_commands
             )
-            
+
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
 


### PR DESCRIPTION
This PR logs the conversion of MVF to MS commands into the HISTORY subtable. The logged entries record:

- The task name and `katdal` version

- The input dataset path(s)

- All non-default CLI options passed to `mvftoms`

- The full CLI invocation (`sys.argv`) in the `CLI_COMMAND `column

Each row carries an MJD timestamp with `APPLICATION='mvftoms'`, `ORIGIN='mvftoms'`, and `PRIORITY='INFO'`, matching the `CASA importasdm `HISTORY convention.