### PR TITLE
SPP1-180: Serial numbers for MKE feed packages

### DIFF
--- a/src/katdal/h5datav3.py
+++ b/src/katdal/h5datav3.py
@@ -77,6 +77,12 @@ WEIGHT_DESCRIPTIONS = ('visibility precision (inverse variance, i.e. 1 / sigma^2
 # Number of bits in ADC sample counter, used to timestamp correlator data in original SPEAD stream
 ADC_COUNTER_BITS = 48
 
+# Mapping from receiver band identity to SPFC SPF feed package index number
+MK_BAND_TO_SKA_MID_BAND = {
+    'l': 2,   # L-band -> SPF2
+    's': 3,   # S-band -> SPF3
+}
+
 # -------------------------------------------------------------------------------------------------
 # --- Utility functions
 # -------------------------------------------------------------------------------------------------
@@ -460,14 +466,17 @@ class H5DataV3(DataSet):
             logger.warning('Could not figure out receiver band - '
                            'please provide it via band parameter')
         # Populate antenna -> receiver mapping and figure out noise diode
+        spf_index = MK_BAND_TO_SKA_MID_BAND.get(band)
         for ant in cam_ants:
-            rx_sensor_options = (
+            spfc_sensor = (f'TelescopeState/{ant}_spfc_serialNumbers_{spf_index}',) if spf_index else ()
+            rx_sensor_options = spfc_sensor + (
                 # Since 2018-01-16 MKAT / ARx only has this version
                 f'TelescopeState/{ant}_rsc_rx{band}_serial_number',
                 # RTS since 2017-11-15
                 f'TelescopeState/{ant}_rx_serial_number',
                 # Original TelescopeModel version
-                f'Antennas/{ant}/rsc_rx{band}_serial_number')
+                f'Antennas/{ant}/rsc_rx{band}_serial_number',
+            )
             rx_serial = 0
             for rx_sensor in rx_sensor_options:
                 if rx_sensor in self.sensor:
@@ -475,6 +484,7 @@ class H5DataV3(DataSet):
                     break
             if band:
                 self.receivers[ant] = f'{band}.{rx_serial}'
+
             nd_sensor = f'TelescopeState/{ant}_dig_{band}_band_noise_diode'
             if nd_sensor in self.sensor:
                 # A sensor alias would be ideal for this but it only deals with suffixes ATM

--- a/src/katdal/ms_extra.py
+++ b/src/katdal/ms_extra.py
@@ -903,9 +903,7 @@ def populate_pointing_dict(num_antennas, observation_duration, start_time, phase
     return pointing_dict
 
 
-def populate_history_dict(times, applications, origins, messages,
-                          cli_command=None, app_params=None,
-                          priorities=None, object_ids=None, observation_ids=None):
+def populate_history_dict(times, applications, origins, messages, cli_command=None, app_params=None):
     """Construct a dictionary containing all standard columns for the HISTORY subtable.
 
     Parameters
@@ -922,12 +920,6 @@ def populate_history_dict(times, applications, origins, messages,
         CLI arguments vector per row
     app_params : sequence of list of str, optional
         Application parameters vector per row
-    priorities : sequence of str, optional
-        Priority strings (e.g., 'INFO')
-    object_ids : sequence of int, optional
-        Object IDs (default 0)
-    observation_ids : sequence of int, optional
-        Observation IDs (default -1)
 
     Returns
     -------
@@ -943,22 +935,16 @@ def populate_history_dict(times, applications, origins, messages,
         cli_command = [[""]] * n
     if app_params is None:
         app_params = [[""]] * n
-    if priorities is None:
-        priorities = ["INFO"] * n
-    if object_ids is None:
-        object_ids = [0] * n
-    if observation_ids is None:
-        observation_ids = [-1] * n
 
     history_dict = {}
-    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=object)
-    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=object)
-    history_dict['APPLICATION'] = np.asarray(applications, dtype=object)
-    history_dict['MESSAGE'] = np.asarray(messages, dtype=object)
-    history_dict['OBJECT_ID'] = np.asarray(object_ids, dtype=np.int32)
-    history_dict['OBSERVATION_ID'] = np.asarray(observation_ids, dtype=np.int32)
-    history_dict['ORIGIN'] = np.asarray(origins, dtype=object)
-    history_dict['PRIORITY'] = np.asarray(priorities, dtype=object)
+    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=str)
+    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=str)
+    history_dict['APPLICATION'] = np.asarray(applications, dtype=str)
+    history_dict['MESSAGE'] = np.asarray(messages, dtype=str)
+    history_dict['OBJECT_ID'] = np.zeros(n, dtype=np.int32)
+    history_dict['OBSERVATION_ID'] = np.full(n, -1, dtype=np.int32)
+    history_dict['ORIGIN'] = np.asarray(origins, dtype=str)
+    history_dict['PRIORITY'] = np.full(n, "INFO", dtype='U32')
     history_dict['TIME'] = np.asarray(times, dtype=np.float64)
 
     return history_dict

--- a/src/katdal/ms_extra.py
+++ b/src/katdal/ms_extra.py
@@ -903,6 +903,67 @@ def populate_pointing_dict(num_antennas, observation_duration, start_time, phase
     return pointing_dict
 
 
+def populate_history_dict(times, applications, origins, messages,
+                          cli_command=None, app_params=None,
+                          priorities=None, object_ids=None, observation_ids=None):
+    """Construct a dictionary containing all standard columns for the HISTORY subtable.
+
+    Parameters
+    ----------
+    times : sequence of float
+        Event times in MJD seconds
+    applications : sequence of str
+        Application names (e.g., 'mvftoms')
+    origins : sequence of str
+        Origin script/module names (e.g., 'mvftoms')
+    messages : sequence of str
+        Log and parameter history entries
+    cli_command : sequence of list of str, optional
+        CLI arguments vector per row
+    app_params : sequence of list of str, optional
+        Application parameters vector per row
+    priorities : sequence of str, optional
+        Priority strings (e.g., 'INFO')
+    object_ids : sequence of int, optional
+        Object IDs (default 0)
+    observation_ids : sequence of int, optional
+        Observation IDs (default -1)
+
+    Returns
+    -------
+    history_dict : dict
+        Dictionary mapping HISTORY column names to numpy arrays
+    """
+    n = len(times)
+    if not (len(applications) == len(origins) == len(messages) == n):
+        raise ValueError("All main input sequences must have the same length")
+
+    # Supply default column data if optional sequences are not provided
+    if cli_command is None:
+        cli_command = [[""]] * n
+    if app_params is None:
+        app_params = [[""]] * n
+    if priorities is None:
+        priorities = ["INFO"] * n
+    if object_ids is None:
+        object_ids = [0] * n
+    if observation_ids is None:
+        observation_ids = [-1] * n
+
+    history_dict = {}
+    history_dict['APP_PARAMS'] = np.asarray(app_params, dtype=object)
+    history_dict['CLI_COMMAND'] = np.asarray(cli_command, dtype=object)
+    history_dict['APPLICATION'] = np.asarray(applications, dtype=object)
+    history_dict['MESSAGE'] = np.asarray(messages, dtype=object)
+    history_dict['OBJECT_ID'] = np.asarray(object_ids, dtype=np.int32)
+    history_dict['OBSERVATION_ID'] = np.asarray(observation_ids, dtype=np.int32)
+    history_dict['ORIGIN'] = np.asarray(origins, dtype=object)
+    history_dict['PRIORITY'] = np.asarray(priorities, dtype=object)
+    history_dict['TIME'] = np.asarray(times, dtype=np.float64)
+
+    return history_dict
+
+
 def populate_ms_dict(uvw_coordinates, vis_data, timestamps, antenna1_index, antenna2_index,
                      integrate_length, center_frequencies, channel_bandwidths,
                      antenna_names, antenna_positions, antenna_diameter,

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -25,6 +25,7 @@ import multiprocessing.sharedctypes
 import os
 import queue
 import re
+import sys
 import tarfile
 import time
 import urllib.parse
@@ -564,6 +565,52 @@ def main():
                                                                           circular=options.circular)
             ms_dict['OBSERVATION'] = ms_extra.populate_observation_dict(
                 start_time, end_time, telescope_name, dataset.observer, dataset.experiment_id)
+
+            # Log conversion into HISTORY subtable
+
+            current_mjd_sec = katpoint.Timestamp().to_mjd() * 86400.0
+            # Capture the exact command line invocation
+            cli_cmd = list(sys.argv)
+
+            # Construct message lines matching CASA task history format
+            messages = [
+                "taskname=mvftoms",
+                f"version: {katdal.__version__}",
+            ]
+
+            # Record input dataset path(s)
+            if isinstance(open_args, (list, tuple)):
+                messages.append(f"dataset         = {repr(list(open_args))}")
+            else:
+                messages.append(f"dataset         = {repr(open_args)}")
+
+            # Append user-selected command line parameters
+            for opt, val in vars(options).items():
+                if val is not None:
+                    messages.append(f"{opt:15s} = {repr(val)}")
+
+            n_rows = len(messages)
+            times = [current_mjd_sec] * n_rows
+            applications = ["mvftoms"] * n_rows
+            origins = ["mvftoms"] * n_rows
+            cli_commands = [cli_cmd] * n_rows
+            app_params = [[""]] * n_rows
+            priorities = ["INFO"] * n_rows
+            object_ids = [0] * n_rows
+            observation_ids = [-1] * n_rows
+
+            # Populate HISTORY subtable
+            ms_dict['HISTORY'] = ms_extra.populate_history_dict(
+                times=times,
+                applications=applications,
+                origins=origins,
+                messages=messages,
+                cli_command=cli_commands,
+                app_params=app_params,
+                priorities=priorities,
+                object_ids=object_ids,
+                observation_ids=observation_ids,
+            )
 
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -576,6 +576,7 @@ def main():
             messages = [
                 "taskname=mvftoms",
                 f"version: {katdal.__version__}",
+                f"katpoint version: {katpoint.__version__}",
             ]
 
             # Record input dataset path(s)
@@ -601,17 +602,13 @@ def main():
 
             # Populate HISTORY subtable
             ms_dict['HISTORY'] = ms_extra.populate_history_dict(
-                times=times,
-                applications=applications,
-                origins=origins,
-                messages=messages,
-                cli_command=cli_commands,
-                app_params=app_params,
-                priorities=priorities,
-                object_ids=object_ids,
-                observation_ids=observation_ids,
+              times=times,
+              applications=applications,
+              origins=origins,
+              messages=messages,
+              cli_command=cli_commands
             )
-
+            
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
 

--- a/src/katdal/scripts/mvftoms.py
+++ b/src/katdal/scripts/mvftoms.py
@@ -595,20 +595,16 @@ def main():
             applications = ["mvftoms"] * n_rows
             origins = ["mvftoms"] * n_rows
             cli_commands = [cli_cmd] * n_rows
-            app_params = [[""]] * n_rows
-            priorities = ["INFO"] * n_rows
-            object_ids = [0] * n_rows
-            observation_ids = [-1] * n_rows
 
             # Populate HISTORY subtable
             ms_dict['HISTORY'] = ms_extra.populate_history_dict(
-              times=times,
-              applications=applications,
-              origins=origins,
-              messages=messages,
-              cli_command=cli_commands
+                times=times,
+                applications=applications,
+                origins=origins,
+                messages=messages,
+                cli_command=cli_commands
             )
-            
+
             print("Writing static meta data...")
             ms_extra.write_dict(ms_dict, ms_name, verbose=options.verbose)
 

--- a/src/katdal/visdatav4.py
+++ b/src/katdal/visdatav4.py
@@ -67,6 +67,12 @@ SENSOR_ALIASES = {
     'nd_coupler': 'dig_noise_diode',
 }
 
+# Mapping from receiver band identity to SPFC SPF feed package index number
+MK_BAND_TO_SKA_MID_BAND = {
+    'l': 2,   # L-band -> SPF2
+    's': 3,   # S-band -> SPF3
+}
+
 
 def _calc_azel(cache, name, ant):
     """Calculate virtual (az, el) sensors from actual ones in sensor cache."""
@@ -374,10 +380,20 @@ class VisibilityDataV4(DataSet):
 
         # Get the receiver band identity ('l', 's', 'u', 'x')
         band = attrs['sub_band']
+        spf_index = MK_BAND_TO_SKA_MID_BAND.get(band)
         # Populate antenna -> receiver mapping and figure out noise diode
         for ant in cam_ants:
-            # Try sanitised version of RX serial number first
-            rx_serial = attrs.get(f'{ant}_rsc_rx{band}_serial_number', 0)
+            spfc_attr = (f'{ant}_spfc_serialNumbers_{spf_index}',) if spf_index else ()
+            rx_attr_options = spfc_attr + (
+                # Try sanitised version of RX serial number first
+                f'{ant}_rsc_rx{band}_serial_number',
+                f'{ant}_rx_serial_number',
+            )
+            rx_serial = 0
+            for rx_attr in rx_attr_options:
+                if rx_attr in attrs:
+                    rx_serial = attrs[rx_attr]
+                    break
             self.receivers[ant] = f'{band}.{rx_serial}'
             nd_sensor = f'{ant}_dig_{band}_band_noise_diode'
             if nd_sensor in self.sensor:

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -304,3 +304,19 @@ class TestTelstateDataSource:
         source_name = f'{cbid}_{sn}'
         assert source_from_file.name == source_name
         assert rdb_filename in source_from_file.url
+
+    def test_spfc_receiver_serial_numbers(self):
+        self.telstate['sub_band'] = 'l'
+        self.telstate['sub_product'] = 'c856M4k'
+        self.telstate['obs_params'] = {}
+        self.telstate['sub_pool_resources'] = 'e117'
+        self.telstate['e117_observer'] = 'e117, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, 0.0, 0.0, 0.0'
+        self.telstate['e117_spfc_serialNumbers_2'] = 'SPF2:4A1014'
+        view, cbid, sn, _, _ = make_fake_data_source(self.telstate, self.store, (5, 16, 40))
+        self.telstate.add('obs_activity', 'track', ts=SYNC_TIME)
+        self.telstate.add('cbf_target', 'AZEL, 0, 0', ts=SYNC_TIME)
+        data_source = TelstateDataSource(view, cbid, sn, chunk_store=self.store)
+        from katdal.visdatav4 import VisibilityDataV4
+        dataset = VisibilityDataV4(data_source)
+        assert dataset.receivers['e117'] == 'l.SPF2:4A1014'
+

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -319,4 +319,3 @@ class TestTelstateDataSource:
         from katdal.visdatav4 import VisibilityDataV4
         dataset = VisibilityDataV4(data_source)
         assert dataset.receivers['e117'] == 'l.SPF2:4A1014'
-


### PR DESCRIPTION
This PR adds MKE SPFC feed package serial number support. 
Updates include:

1. Added `MK_BAND_TO_SKA_MID_BAND` mapping for L-band (2) and S-band (3).
2. Updated receiver serial number lookups to prioritize the MKE SPFC sensor format before falling back to legacy formats (`rsc_rx`, `rx_serial_number`, etc.).
3. Added unit test `test_spfc_receiver_serial_numbers` in `test_datasources.py.`